### PR TITLE
Ability to observe socket errors on driver object

### DIFF
--- a/src/v1/internal/ch-websocket.js
+++ b/src/v1/internal/ch-websocket.js
@@ -55,9 +55,9 @@ class WebSocketChannel {
       } 
     };
 
-    this._ws.onerror = () => {
+    this._ws.onerror = (err) => {
       if( self.onerror ) {
-        self.onerror();
+        self.onerror(err);
       }
     }
   }

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -207,7 +207,12 @@ class Connection {
       }
     };
 
-    this._ch.onerror = () => self._isBroken = true;
+    this._ch.onerror = (error) => {
+      self._isBroken = true;
+      if(this._currentObserver.onError) {
+        this._currentObserver.onError(error);
+      }
+    }
 
     this._dechunker.onmessage = (buf) => {
       self._handleMessage( self._unpacker.unpack( buf ) );
@@ -266,9 +271,9 @@ class Connection {
         break;
       case IGNORED:
         try {
-          if (this._errorMsg)
+          if (this._errorMsg && this._currentObserver.onError)
             this._currentObserver.onError(this._errorMsg);
-          else
+          else if(this._currentObserver.onError)
             this._currentObserver.onError(msg);
         } finally {
           this._currentObserver = this._pendingObservers.shift();


### PR DESCRIPTION
To catch broken socket errors etc.

Usage:

``` javascript
var driver = neo4j.v1.driver("bolt://localhost:7687", bolt.auth.basic(username, password))
driver.onError = function (e){ console.log('Got it: ', e) }
```
