### PR TITLE
Parameter map in summary never undefined

### DIFF
--- a/src/v1/result-summary.js
+++ b/src/v1/result-summary.js
@@ -89,7 +89,7 @@ class ProfiledPlan {
   /**
    * Create a ProfiledPlan instance
    * @constructor
-   * @param {Object} plan - Object with plan data
+   * @param {Object} profile - Object with profile data
    */
   constructor(profile) {
     this.operatorType = profile.operatorType;
@@ -235,10 +235,10 @@ class Notification {
     this.title = notification.title;
     this.description = notification.description;
     this.severity = notification.severity;
-    this.position = this._constructPosition(notification.position);
+    this.position = Notification._constructPosition(notification.position);
   }
 
-  _constructPosition(pos) {
+  static _constructPosition(pos) {
     if(!pos) {
       return {};
     }
@@ -255,7 +255,7 @@ const statementType = {
   READ_WRITE: 'rw',
   WRITE_ONLY: 'w',
   SCHEMA_WRITE: 's'
-}
+};
 
 export default {
   ResultSummary,

--- a/src/v1/result.js
+++ b/src/v1/result.js
@@ -32,12 +32,14 @@ class Result {
    * Inject the observer to be used.
    * @constructor
    * @param {StreamObserver} streamObserver
+   * @param {mixed} statement - Cypher statement to execute
+   * @param {Object} parameters - Map with parameters to use in statement
    */
   constructor(streamObserver, statement, parameters) {
     this._streamObserver = streamObserver;
     this._p = null;
     this._statement = statement;
-    this._parameters = parameters;
+    this._parameters = parameters || {};
   }
 
   /**
@@ -66,7 +68,8 @@ class Result {
    * Waits for all results and calls the passed in function
    * with the results.
    * Cannot be used with the subscribe function.
-   * @param {function(results: Object)} cb - Function to be called when all results are collected.
+   * @param {function(error: Object)} onFulfilled - Function to be called when finished.
+   * @param {function(error: Object)} onRejected - Function to be called upon errors.
    * @return {Promise} promise.
    */
   then(onFulfilled, onRejected) {
@@ -78,7 +81,7 @@ class Result {
   /**
    * Catch errors when using promises.
    * Cannot be used with the subscribe function.
-   * @param {function(error: Object)} cb - Function to be called upon errors.
+   * @param {function(error: Object)} onRejected - Function to be called upon errors.
    * @return {Promise} promise.
    */
   catch(onRejected) {

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -75,7 +75,6 @@ describe('session', function() {
   it('should call observers onError on error ', function(done) {
 
     // When & Then
-    var records = [];
     session.run( "RETURN 1 AS").subscribe( {
       onError: function(error) {
         expect(error.fields.length).toBe(1);
@@ -131,7 +130,7 @@ describe('session', function() {
   it('should expose summarize method for basic metadata ', function(done) {
     // Given
     var statement = "CREATE (n:Label {prop:{prop}}) RETURN n";
-    var params = {prop: "string"}
+    var params = {prop: "string"};
     // When & Then
     session.run( statement, params )
           .then(function(result) {
@@ -145,10 +144,22 @@ describe('session', function() {
     });
   });
 
+  it('should expose empty parameter map on call with no parameters', function(done) {
+    // Given
+    var statement = "CREATE (n:Label {prop:'string'}) RETURN n";
+    // When & Then
+    session.run(statement)
+      .then(function(result) {
+        var sum = result.summary;
+        expect(sum.statement.parameters).toEqual( {} );
+        done();
+      });
+  });
+
   it('should expose plan ', function(done) {
     // Given
     var statement = "EXPLAIN CREATE (n:Label {prop:{prop}}) RETURN n";
-    var params = {prop: "string"}
+    var params = {prop: "string"};
     // When & Then
     session
           .run( statement, params )
@@ -167,7 +178,7 @@ describe('session', function() {
   it('should expose profile ', function(done) {
     // Given
     var statement = "PROFILE MATCH (n:Label {prop:{prop}}) RETURN n";
-    var params = {prop: "string"}
+    var params = {prop: "string"};
     // When & Then
     session
           .run( statement, params )


### PR DESCRIPTION
To be compilant with the other drivers `summary.parameters` should return `{}`
instead of `undefined` when statement has been run with no paramaters.
