### PR TITLE
Define readUInt32 on buffer

### DIFF
--- a/src/v1/internal/buf.js
+++ b/src/v1/internal/buf.js
@@ -202,6 +202,13 @@ class BaseBuffer
   /**
    * Read from state position.
    */
+  readUInt32 () {
+    return this.getUInt32( this._updatePos(4) );
+  }
+
+  /**
+   * Read from state position.
+   */
   readInt16 () {
     return this.getInt16( this._updatePos(2) );
   }

--- a/test/internal/packstream.test.js
+++ b/test/internal/packstream.test.js
@@ -47,6 +47,8 @@ describe('packstream', function() {
   it('should pack strings', function() {
     expect( packAndUnpack( "" ) ).toBe( "" );
     expect( packAndUnpack( "abcdefg123567" ) ).toBe( "abcdefg123567" );
+    var str = Array(65536 + 1).join('a'); // 2 ^ 16 + 1
+    expect( packAndUnpack(str, str.length + 8)).toBe(str);
   });
   it('should pack structures', function() {
     expect( packAndUnpack( new Structure(1, ["Hello, world!!!"] ) ).fields[0] )  


### PR DESCRIPTION
- Used by packstream for STRING_32, LIST_32 and MAP_32
  but not defined on buffer.
