### PR TITLE
example code doesn't work without v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ bower install neo4j-driver
 ```
 
 ```javascript
-var neo4j = require('neo4j-driver');
+var neo4j = require('neo4j-driver').v1;
 ```
 
 ## Include in web browser
@@ -28,7 +28,7 @@ We build a special browser version of the driver, which supports connecting to N
 This will make a global `neo4j` object available, where you can access the `v1` API at `neo4j.v1`:
 
 ```javascript
-var driver = neo4j.v1.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"));
+var driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"));
 ```
 
 ## Usage examples
@@ -44,10 +44,10 @@ var session = driver.session();
 
 // Run a Cypher statement, reading the result in a streaming manner as records arrive:
 session
-  .run("MATCH (alice {name : {nameParam} }) RETURN alice.age", { nameParam:'Alice' })
+  .run("MERGE (alice:Person {name : {nameParam} }) RETURN alice.name", { nameParam:'Alice' })
   .subscribe({
     onNext: function(record) {
-      console.log(record);
+     console.log(record._fields);
     },
     onCompleted: function() {
       // Completed!
@@ -61,12 +61,11 @@ session
 // or
 // the Promise way, where the complete result is collected before we act on it:
 session
-  .run("MATCH (alice {name : {nameParam} }) RETURN alice.age", { nameParam:'Alice' })
+  .run("MERGE (james:Person {name : {nameParam} }) RETURN james.name", { nameParam:'James' })
   .then(function(result){
     result.records.forEach(function(record) {
-      console.log(record);
+      console.log(record._fields);
     });
-
     // Completed!
     session.close();
   })
@@ -74,30 +73,40 @@ session
     console.log(error);
   });
 
-  //run statement in a transaction
-  var tx = session.beginTransaction();
-  tx.run("CREATE (alice {name : {nameParam} })", { nameParam:'Alice' });
-  tx.run("MATCH (alice {name : {nameParam} }) RETURN alice.age", { nameParam:'Alice' });
-  //decide if the transaction should be committed or rolled back
-  var success = ...
-  ...
-  if (success) {
-    tx.commit()
-      .subscribe({
-        onCompleted: function() {
-          // Completed!
-          session.close();
-         },
-         onError: function(error) {
-           console.log(error);
-          }
-        });
-   } else {
-     //transaction is rolled black nothing is created in the database
-     tx.rollback();
-   }
+//run statement in a transaction
+var tx = session.beginTransaction();
+tx.run("MERGE (bob:Person {name : {nameParam} }) RETURN bob.name", { nameParam:'Bob' })
+  .subscribe({
+    onNext: function(record) {
+      console.log(record._fields);
+      },
+    onCompleted: function() {
+      // Completed!
+      session.close();
+    },
+    onError: function(error) {
+      console.log(error);
+    }
+  });
+  
+//decide if the transaction should be committed or rolled back
+var success = false;
 
-
+if (success) {
+  tx.commit()
+    .subscribe({
+      onCompleted: function() {
+        // Completed!
+      },
+      onError: function(error) {
+        console.log(error);
+        }
+      });
+  } else {
+  //transaction is rolled black and nothing is created in the database
+  console.log('rolled back');
+  tx.rollback();
+}
 ```
 
 ## Building


### PR DESCRIPTION
Having two different ways to create a driver instance is confusing. `examples/node.js` does not use v1, but the only way I could get it to work was with v1. 
