### PR TITLE
sync after reset on session.close

### DIFF
--- a/lib/v1/driver.js
+++ b/lib/v1/driver.js
@@ -158,10 +158,9 @@ var Driver = (function () {
         // wrapper around Connection anyway, so it makes little difference.
 
         // Queue up a 'reset', to ensure the next user gets a clean
-        // session to work with. No need to flush, this will get sent
-        // along with whatever the next thing the user wants to do with
-        // this session ends up being, so we save the network round trip.
+        // session to work with.
         conn.reset();
+        conn.sync();
 
         // Return connection to the pool
         conn._release();

--- a/lib/v1/internal/connector.js
+++ b/lib/v1/internal/connector.js
@@ -403,7 +403,19 @@ var Connection = (function () {
   }, {
     key: "reset",
     value: function reset(observer) {
-      this._queueObserver(observer);
+      this._isHandlingFailure = true;
+      var self = this;
+      var wrappedObs = {
+        onNext: observer ? observer.onNext : NO_OP,
+        onError: observer ? observer.onError : NO_OP,
+        onCompleted: function onCompleted() {
+          self._isHandlingFailure = false;
+          if (observer) {
+            observer.onCompleted();
+          }
+        }
+      };
+      this._queueObserver(wrappedObs);
       this._packer.packStruct(RESET);
       this._chunker.messageBoundary();
     }

--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -118,10 +118,9 @@ class Driver {
       // wrapper around Connection anyway, so it makes little difference.
 
       // Queue up a 'reset', to ensure the next user gets a clean
-      // session to work with. No need to flush, this will get sent
-      // along with whatever the next thing the user wants to do with
-      // this session ends up being, so we save the network round trip.
+      // session to work with.
       conn.reset();
+      conn.sync();
 
       // Return connection to the pool
       conn._release();

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -185,6 +185,8 @@ class Connection {
     this._unpacker.structMappers[UNBOUND_RELATIONSHIP] = _mappers.unboundRel;
     this._unpacker.structMappers[PATH] = _mappers.path;
 
+
+
     let self = this;
     // TODO: Using `onmessage` and `onerror` came from the WebSocket API,
     // it reads poorly and has several annoying drawbacks. Swap to having
@@ -341,7 +343,19 @@ class Connection {
 
   /** Queue a RESET-message to be sent to the database */
   reset( observer ) {
-    this._queueObserver(observer);
+    this._isHandlingFailure = true;
+    let self = this;
+    let wrappedObs = {
+      onNext: observer ? observer.onNext : NO_OP,
+      onError: observer ? observer.onError : NO_OP,
+      onCompleted: () => {
+        self._isHandlingFailure = false;
+        if (observer) {
+          observer.onCompleted();
+        }
+      }
+    };
+    this._queueObserver(wrappedObs);
     this._packer.packStruct( RESET );
     this._chunker.messageBoundary();
   }

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -21,25 +21,25 @@ var neo4j = require("../../lib/v1");
 var StatementType = require("../../lib/v1/result-summary").statementType;
 var Session = require("../../lib/v1/session");
 
-describe('session', function() {
+describe('session', function () {
 
   var driver, session;
 
-  beforeEach(function(done) {
+  beforeEach(function (done) {
     driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"));
     session = driver.session();
 
     session.run("MATCH (n) DETACH DELETE n").then(done);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     driver.close();
   });
 
-  it('close should be idempotent ', function(){
+  it('close should be idempotent ', function () {
     // Given
     var counter = 0;
-    var _session = new Session(null, function(){
+    var _session = new Session(null, function () {
       counter++;
     });
     _session.close();
@@ -48,33 +48,33 @@ describe('session', function() {
     expect(counter).toBe(1);
   });
 
-  it('should expose basic run/subscribe ', function(done) {
+  it('should expose basic run/subscribe ', function (done) {
     // Given
 
     // When & Then
     var records = [];
-    session.run( "RETURN 1.0 AS a").subscribe( {
-      onNext : function( record ) {
-        records.push( record );
+    session.run("RETURN 1.0 AS a").subscribe({
+      onNext: function (record) {
+        records.push(record);
       },
-      onCompleted : function( ) {
-        expect( records.length ).toBe( 1 );
-        expect( records[0].get('a') ).toBe( 1 );
+      onCompleted: function () {
+        expect(records.length).toBe(1);
+        expect(records[0].get('a')).toBe(1);
         done();
       }
     });
   });
 
-  it('should keep context in subscribe methods ', function(done) {
+  it('should keep context in subscribe methods ', function (done) {
     // Given
-    function myObserver(){
+    function myObserver() {
       this.local = 'hello';
       var privateLocal = 'hello';
-      this.onNext = function() {
+      this.onNext = function () {
         expect(privateLocal).toBe('hello');
         expect(this.local).toBe('hello');
       };
-      this.onCompleted = function() {
+      this.onCompleted = function () {
         expect(privateLocal).toBe('hello');
         expect(this.local).toBe('hello');
         done();
@@ -82,148 +82,148 @@ describe('session', function() {
     }
 
     // When & Then
-    session.run( "RETURN 1.0 AS a").subscribe(new myObserver());
+    session.run("RETURN 1.0 AS a").subscribe(new myObserver());
   });
 
-  it('should call observers onError on error ', function(done) {
+  it('should call observers onError on error ', function (done) {
 
     // When & Then
-    session.run( "RETURN 1 AS").subscribe( {
-      onError: function(error) {
+    session.run("RETURN 1 AS").subscribe({
+      onError: function (error) {
         expect(error.fields.length).toBe(1);
         done();
       }
     });
   });
 
-  it('should accept a statement object ', function(done) {
+  it('should accept a statement object ', function (done) {
     // Given
     var statement = {text: "RETURN 1 = {param} AS a", parameters: {param: 1}};
 
     // When & Then
     var records = [];
-    session.run( statement ).subscribe( {
-      onNext : function( record ) {
-        records.push( record );
+    session.run(statement).subscribe({
+      onNext: function (record) {
+        records.push(record);
       },
-      onCompleted : function( ) {
-        expect( records.length ).toBe( 1 );
-        expect( records[0].get('a') ).toBe( true );
+      onCompleted: function () {
+        expect(records.length).toBe(1);
+        expect(records[0].get('a')).toBe(true);
         done();
       }
     });
   });
 
-  it('should expose run/then/then/then ', function(done) {
+  it('should expose run/then/then/then ', function (done) {
     // When & Then
-    session.run( "RETURN 1.0 AS a")
-    .then(
-      function(result) {
-        expect(result.records.length).toBe( 1 );
-        expect(result.records[0].get('a')).toBe( 1 );
-        return result
+    session.run("RETURN 1.0 AS a")
+      .then(
+        function (result) {
+          expect(result.records.length).toBe(1);
+          expect(result.records[0].get('a')).toBe(1);
+          return result
+        }
+      ).then(
+      function (result) {
+        expect(result.records.length).toBe(1);
+        expect(result.records[0].get('a')).toBe(1);
       }
-    ).then(
-      function(result) {
-        expect(result.records.length).toBe( 1 );
-        expect(result.records[0].get('a')).toBe( 1 );
-      }
-    ).then( done );
+    ).then(done);
   });
 
-  it('should expose basic run/catch ', function(done) {
+  it('should expose basic run/catch ', function (done) {
     // When & Then
-    session.run( "RETURN 1 AS").catch(
-      function(error) {
-        expect( error.fields.length).toBe(1);
+    session.run("RETURN 1 AS").catch(
+      function (error) {
+        expect(error.fields.length).toBe(1);
         done();
       }
     )
   });
 
-  it('should expose summarize method for basic metadata ', function(done) {
+  it('should expose summarize method for basic metadata ', function (done) {
     // Given
     var statement = "CREATE (n:Label {prop:{prop}}) RETURN n";
     var params = {prop: "string"};
     // When & Then
-    session.run( statement, params )
-          .then(function(result) {
-      var sum = result.summary;
-      expect(sum.statement.text).toBe( statement );
-      expect(sum.statement.parameters).toBe( params );
-      expect(sum.updateStatistics.containsUpdates()).toBe(true);
-      expect(sum.updateStatistics.nodesCreated()).toBe(1);
-      expect(sum.statementType).toBe(StatementType.READ_WRITE);
-      done();
-    });
-  });
-
-  it('should expose empty parameter map on call with no parameters', function(done) {
-    // Given
-    var statement = "CREATE (n:Label {prop:'string'}) RETURN n";
-    // When & Then
-    session.run(statement)
-      .then(function(result) {
+    session.run(statement, params)
+      .then(function (result) {
         var sum = result.summary;
-        expect(sum.statement.parameters).toEqual( {} );
+        expect(sum.statement.text).toBe(statement);
+        expect(sum.statement.parameters).toBe(params);
+        expect(sum.updateStatistics.containsUpdates()).toBe(true);
+        expect(sum.updateStatistics.nodesCreated()).toBe(1);
+        expect(sum.statementType).toBe(StatementType.READ_WRITE);
         done();
       });
   });
 
-  it('should expose plan ', function(done) {
+  it('should expose empty parameter map on call with no parameters', function (done) {
+    // Given
+    var statement = "CREATE (n:Label {prop:'string'}) RETURN n";
+    // When & Then
+    session.run(statement)
+      .then(function (result) {
+        var sum = result.summary;
+        expect(sum.statement.parameters).toEqual({});
+        done();
+      });
+  });
+
+  it('should expose plan ', function (done) {
     // Given
     var statement = "EXPLAIN CREATE (n:Label {prop:{prop}}) RETURN n";
     var params = {prop: "string"};
     // When & Then
     session
-          .run( statement, params )
-          .then(function(result) {
-      var sum = result.summary;
-      expect(sum.hasPlan()).toBe(true);
-      expect(sum.hasProfile()).toBe(false);
-      expect(sum.plan.operatorType).toBe('ProduceResults');
-      expect(sum.plan.arguments.runtime).toBe('INTERPRETED');
-      expect(sum.plan.identifiers[0]).toBe('n');
-      expect(sum.plan.children[0].operatorType).toBe('CreateNode');
-      done();
-    });
+      .run(statement, params)
+      .then(function (result) {
+        var sum = result.summary;
+        expect(sum.hasPlan()).toBe(true);
+        expect(sum.hasProfile()).toBe(false);
+        expect(sum.plan.operatorType).toBe('ProduceResults');
+        expect(sum.plan.arguments.runtime).toBe('INTERPRETED');
+        expect(sum.plan.identifiers[0]).toBe('n');
+        expect(sum.plan.children[0].operatorType).toBe('CreateNode');
+        done();
+      });
   });
 
-  it('should expose profile ', function(done) {
+  it('should expose profile ', function (done) {
     // Given
     var statement = "PROFILE MATCH (n:Label {prop:{prop}}) RETURN n";
     var params = {prop: "string"};
     // When & Then
     session
-          .run( statement, params )
-          .then(function(result) {
-      var sum = result.summary;
-      expect(sum.hasPlan()).toBe(true); //When there's a profile, there's a plan
-      expect(sum.hasProfile()).toBe(true);
-      expect(sum.profile.operatorType).toBe('ProduceResults');
-      expect(sum.profile.arguments.runtime).toBe('INTERPRETED');
-      expect(sum.profile.identifiers[0]).toBe('n');
-      expect(sum.profile.children[0].operatorType).toBe('Filter');
-      expect(sum.profile.rows).toBe(0);
-      //expect(sum.profile.dbHits).toBeGreaterThan(0);
-      done();
-    });
+      .run(statement, params)
+      .then(function (result) {
+        var sum = result.summary;
+        expect(sum.hasPlan()).toBe(true); //When there's a profile, there's a plan
+        expect(sum.hasProfile()).toBe(true);
+        expect(sum.profile.operatorType).toBe('ProduceResults');
+        expect(sum.profile.arguments.runtime).toBe('INTERPRETED');
+        expect(sum.profile.identifiers[0]).toBe('n');
+        expect(sum.profile.children[0].operatorType).toBe('Filter');
+        expect(sum.profile.rows).toBe(0);
+        //expect(sum.profile.dbHits).toBeGreaterThan(0);
+        done();
+      });
   });
 
-  it('should expose cypher notifications ', function(done) {
+  it('should expose cypher notifications ', function (done) {
     // Given
     var statement = "EXPLAIN MATCH (n), (m) RETURN n, m";
     // When & Then
     session
-          .run( statement )
-          .then(function(result) {
-      var sum = result.summary;
-      expect(sum.notifications.length).toBeGreaterThan(0);
-      expect(sum.notifications[0].code).toBe("Neo.ClientNotification.Statement.CartesianProductWarning");
-      expect(sum.notifications[0].title).toBe("This query builds a cartesian product between disconnected patterns.");
-      expect(sum.notifications[0].position.column).toBeGreaterThan(0);
-      done();
-    });
+      .run(statement)
+      .then(function (result) {
+        var sum = result.summary;
+        expect(sum.notifications.length).toBeGreaterThan(0);
+        expect(sum.notifications[0].code).toBe("Neo.ClientNotification.Statement.CartesianProductWarning");
+        expect(sum.notifications[0].title).toBe("This query builds a cartesian product between disconnected patterns.");
+        expect(sum.notifications[0].position.column).toBeGreaterThan(0);
+        done();
+      });
   });
 
   it('should fail when using the session when having an open transaction', function (done) {
@@ -235,8 +235,8 @@ describe('session', function() {
     session.run("RETURN 42")
       .catch(function (error) {
         expect(error.message).toBe("Statements cannot be run directly on a "
-         + "session with an open transaction; either run from within the "
-         + "transaction or use a different session." );
+          + "session with an open transaction; either run from within the "
+          + "transaction or use a different session.");
         done();
       })
   });
@@ -270,8 +270,28 @@ describe('session', function() {
               }
             }
           )
+
       });
   });
+
+  it('should be able to close a long running query ', function (done) {
+    //given a long running query
+    session.run("unwind range(1,1000000) as x create (n {prop:x}) delete n");
+
+    //wait some time than close the session and run
+    //a new query
+    setTimeout(function () {
+      session.close();
+      var anotherSession = driver.session();
+      setTimeout(function () {
+        anotherSession.run("RETURN 1.0 as a")
+          .then(function (ignore) {
+            done();
+          });
+      }, 1000);
+    }, 1500);
+  });
+
 });
 
 


### PR DESCRIPTION
In order to preserve roundtrips we didn't call `sync` after `reset` in
`session.close`. However this means that if `session.close` is invoked
in order to close a long-running query nothing will happen until you send
the next query.
