### PR TITLE
Fix for mangled records

### DIFF
--- a/src/v1/internal/utf8.js
+++ b/src/v1/internal/utf8.js
@@ -37,18 +37,19 @@ try {
       return new buf.NodeBuffer( new node.Buffer(str, "UTF-8") );
     },
     "decode" : function( buffer, length ) {
+      let start = buffer.position,
+          end = start + length;
+      buffer.position = end;
+
       if( buffer instanceof buf.NodeBuffer ) {
-        let start = buffer.position,
-            end = start + length;
-        buffer.position = end;
         return buffer._buffer.toString( 'utf8', start, end );
       } 
       else if( buffer instanceof buf.CombinedBuffer ) {
-        let out = streamDecodeCombinedBuffer(buffer._buffers, length,
+        let out = streamDecodeCombinedBuffer(buffer._buffers, end,
           (partBuffer) => {
             return decoder.write(partBuffer._buffer);
           },
-          () => { return decoder.end(); }
+          () => { return decoder.end().slice(start, end); }
         );
         return out;
       } 

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -249,4 +249,24 @@ describe('session', function() {
     // Then
     expect(session.beginTransaction).toThrow();
   });
+  it('should return lots of data', function (done) {
+    session.run("UNWIND range(1,1000) AS x CREATE (t:testNode {name: 'testNameString'})")
+    .then(function () {
+      session.run("MATCH (n) RETURN n.name")
+        .subscribe({
+          onNext: function (record) {
+            var node = record.get('n');
+            expect(node.name).toEqual("testNameString");
+          },
+          onCompleted: function () {
+            // Completed!
+            session.close();
+            done()
+          },
+          onError: function (error) {
+            console.log(error);
+          }
+        })
+      });
+  });
 });


### PR DESCRIPTION
Decoding utf-8 string for combined buffers didn't skip first 4
characters that were in header, so it ended 4 characters short.
