### PR TITLE
Add preferNativeInt for unpack operation

### DIFF
--- a/src/v1/integer.js
+++ b/src/v1/integer.js
@@ -719,6 +719,23 @@ Integer.fromValue = function(val) {
 };
 
 /**
+ * Returns a number or Integer for a given pair of low and high bits, preferring number when in scope.
+ * @access private
+ * @param {number} lowBits The low 32 bits
+ * @param {number} highBits The high 32 bits
+ * @returns {!Integer|number} The corresponding Integer value
+ * @expose
+ */
+Integer.asNative = function(lowBits, highBits) {
+  var val = new Integer(lowBits, highBits);
+  if (val.greaterThan(MIN_NATIVE) && val.lessThan(MAX_NATIVE)) {
+    return val.toNumber();
+  } else {
+    return val;
+  }
+};
+
+/**
  * @type {number}
  * @const
  * @inner
@@ -800,6 +817,24 @@ Integer.MAX_VALUE = Integer.fromBits(0xFFFFFFFF|0, 0x7FFFFFFF|0, false);
  * @expose
  */
 Integer.MIN_VALUE = Integer.fromBits(0, 0x80000000|0, false);
+
+/**
+ * Minimum safe native value.
+ * @type {!Integer}
+ * @const
+ * @inner
+ * @private
+ */
+var MIN_NATIVE = Integer.fromValue(Number.MIN_SAFE_INTEGER);
+
+/**
+ * Maximum safe native value.
+ * @type {!Integer}
+ * @const
+ * @inner
+ * @private
+ */
+var MAX_NATIVE = Integer.fromValue(Number.MAX_SAFE_INTEGER);
 
 /**
  * Cast value to Integer type.

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -161,7 +161,7 @@ class Connection {
    * @param channel - channel with a 'write' function and a 'onmessage'
    *                  callback property
    */
-  constructor (channel) {
+  constructor (channel, config) {
     /**
      * An ordered queue of observers, each exchange response (zero or more
      * RECORD messages followed by a SUCCESS message) we recieve will be routed
@@ -173,7 +173,7 @@ class Connection {
     this._dechunker = new chunking.Dechunker();
     this._chunker = new chunking.Chunker( channel );
     this._packer = new packstream.Packer( this._chunker );
-    this._unpacker = new packstream.Unpacker();
+    this._unpacker = new packstream.Unpacker( config );
     this._isHandlingFailure = false;
 
     // Set to true on fatal errors, to get this out of session pool.
@@ -428,7 +428,7 @@ function connect( url, config = {}) {
     trust : config.trust || (hasFeature("trust_on_first_use") ? "TRUST_ON_FIRST_USE" : "TRUST_SIGNED_CERTIFICATES"),
     trustedCertificates : config.trustedCertificates || [],
     knownHosts : config.knownHosts
-  }));
+  }), config);
 }
 
 export default {

--- a/src/v1/internal/packstream.js
+++ b/src/v1/internal/packstream.js
@@ -291,6 +291,13 @@ class Unpacker {
       return int(value);
     }
   }
+  unpackLargeInt(low, high) {
+    if( this._config.preferNativeInt ) {
+      return Integer.asNative(low, high);
+    } else {
+      return Integer.fromBits(low, high);
+    }
+  }
 
   unpack ( buffer ) {
     let marker = buffer.readUInt8();
@@ -315,7 +322,7 @@ class Unpacker {
     } else if (marker == INT_64) {
       let high = buffer.readInt32();
       let low  = buffer.readInt32();
-      return new Integer( low, high );
+      return this.unpackLargeInt( low, high );
     } else if (marker == STRING_8) {
       return utf8.decode( buffer, buffer.readUInt8());
     } else if (marker == STRING_16) {

--- a/test/internal/packstream.test.js
+++ b/test/internal/packstream.test.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 var alloc = require('../../lib/v1/internal/buf').alloc,
     packstream = require("../../lib/v1/internal/packstream.js"),
     integer = require("../../lib/v1/integer.js"),
@@ -32,16 +32,19 @@ describe('packstream', function() {
     for(n = -999; n <= 999; n += 1) {
       i = Integer.fromNumber(n);
       expect( packAndUnpack( i ).toString() ).toBe( i.toString() );
+      expect( packAndUnpack( i, undefined, {preferNativeInt: true} ) ).toBe( i.toNumber() );
     }
     // positive numbers
     for(n = 16; n <= 16 ; n += 1) {
       i = Integer.fromNumber(Math.pow(2, n));
       expect( packAndUnpack( i ).toString() ).toBe( i.toString() );
+      expect( packAndUnpack( i, undefined, {preferNativeInt: true} ) ).toBe( i.toNumber() );
     }
     // negative numbers
     for(n = 0; n <= 63 ; n += 1) {
       i = Integer.fromNumber(-Math.pow(2, n));
       expect( packAndUnpack( i ).toString() ).toBe( i.toString() );
+      expect( packAndUnpack( i, undefined, {preferNativeInt: true} ).toString() ).toEqual( i.toString() );
     }
   });
   it('should pack strings', function() {
@@ -51,7 +54,7 @@ describe('packstream', function() {
     expect( packAndUnpack(str, str.length + 8)).toBe(str);
   });
   it('should pack structures', function() {
-    expect( packAndUnpack( new Structure(1, ["Hello, world!!!"] ) ).fields[0] )  
+    expect( packAndUnpack( new Structure(1, ["Hello, world!!!"] ) ).fields[0] )
      .toBe( "Hello, world!!!" );
   });
   it('should pack lists', function() {
@@ -73,10 +76,10 @@ describe('packstream', function() {
   });
 });
 
-function packAndUnpack( val, bufferSize ) {
+function packAndUnpack( val, bufferSize, options ) {
   bufferSize = bufferSize || 128;
   var buffer = alloc(bufferSize);
   new Packer( buffer ).pack( val );
   buffer.reset();
-  return new Unpacker().unpack( buffer );
+  return new Unpacker(options).unpack( buffer );
 }

--- a/test/v1/types.test.js
+++ b/test/v1/types.test.js
@@ -34,6 +34,8 @@ describe('integer values', function() {
   it('should support integer -1 ', testVal( neo4j.int(-1) ) );
   it('should support integer larger than JS Numbers can model', testVal( neo4j.int("0x7fffffffffffffff") ) );
   it('should support integer smaller than JS Numbers can model', testVal( neo4j.int("0x8000000000000000") ) );
+
+  it('should support integer 1 casting to native ', testVal( neo4j.int(1), 1, {preferNativeInt: true} ) );
 });
 
 describe('boolean values', function() {
@@ -131,14 +133,14 @@ describe('path values', function() {
   });
 });
 
-function testVal( val ) {
+function testVal( val, expected, config ) {
   return function( done ) {
-    var driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"));
+    var driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"), config);
     var session = driver.session();
 
     session.run("RETURN {val} as v", {val: val})
       .then( function( result ) {
-        expect( result.records[0].get('v') ).toEqual( val );
+        expect( result.records[0].get('v') ).toEqual( expected || val );
         driver.close();
         done();
       }).catch(function(err) { console.log(err); });


### PR DESCRIPTION
This forces database results to be read as language-native number values unless they are out of range, which reduces the code overhead for applications that do not need to worry about the extended range.
