### PR TITLE
Slighly more robust tofu detection

### DIFF
--- a/src/v1/internal/features.js
+++ b/src/v1/internal/features.js
@@ -26,8 +26,8 @@ const FEATURES = {
       // This is insane. We are verifying that we have a version of getPeerCertificate
       // that supports reading the whole certificate, eg this commit:
       // https://github.com/nodejs/node/commit/345c40b6
-      let desc = require('tls').TLSSocket.prototype.getPeerCertificate.toString();
-      return desc.startsWith("function getPeerCertificate(detailed)");
+      let desc = require('tls').TLSSocket.prototype.getPeerCertificate;
+      return desc.length() >= 1;
     } catch( e ) {
       return false;
     }


### PR DESCRIPTION
The checking of if platform supports trust-on-first-use is broken on node 6.
We need a more robust way of detecting this, but until then this will have to do.
