### PR TITLE
Update dependency on phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jasmine-reporters": "^2.0.7",
     "merge-stream": "^1.0.0",
     "minimist": "^1.2.0",
-    "phantomjs2-ext": "^0.1.0",
+    "phantomjs-prebuilt": "^2.1.7 ",
     "run-sequence": "^1.1.4",
     "through2": "~2.0.0",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
The old module that pulled in phantomjs in the builds was old and wasn't working on
all platforms. This one seems like it is better supported.
