### PR TITLE
Added: Record.toObject() to transform a Record into an Object

### DIFF
--- a/src/v1/record.js
+++ b/src/v1/record.js
@@ -77,6 +77,20 @@ class Record {
   }
 
   /**
+   * Generates an object out of the current Record
+   *
+   * @returns {Object}
+   */
+  toObject() {
+    const object = {};
+    this.forEach((value, key) => {
+      object[key] = value
+    });
+
+    return object;
+  }
+
+  /**
    * Get a value from this record, either by index or by field key.
    *
    * @param {string|Number} key Field key, or the index of the field.

--- a/test/v1/record.test.js
+++ b/test/v1/record.test.js
@@ -41,6 +41,19 @@ describe('Record', function() {
     expect(record.has(1)).toEqual(false);
   });
 
+  it('should transform Record into Object', function() {
+    // Given
+    var record = new Record( ["name", "age", "nested"], ["Bob", 20.5, {test: true}] );
+
+    // When
+    var obj = record.toObject();
+
+    // Then
+    expect(obj.name).toEqual("Bob");
+    expect(obj.age).toEqual(20.5);
+    expect(obj.nested.test).toEqual(true);
+  });
+
   it('should give helpful error on no such key', function() {
     // Given
     var record = new Record( ["name"], ["Bob"] );


### PR DESCRIPTION
There are cases when you want to:

``` cypher
RETURN { a: 1, b: true, c: 'Hello World' } AS data 
```

and you don't want to 

``` javascript
const data =  {
   a: record.get('a'),
   b: record.get('b'),
   c: record.get('c')
};
```

so you can just

``` javascript
const data = record.toObject();
```
