### PR TITLE
Better error handling for unpackable types

### DIFF
--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -156,6 +156,7 @@ let _mappers = {
  * @access private
  */
 class Connection {
+
   /**
    * @constructor
    * @param channel - channel with a 'write' function and a 'onmessage'
@@ -319,28 +320,30 @@ class Connection {
   /** Queue an INIT-message to be sent to the database */
   initialize( clientName, token, observer ) {
     this._queueObserver(observer);
-    this._packer.packStruct( INIT, [clientName, token] );
+    this._packer.packStruct( INIT, [this._packable(clientName), this._packable(token)],
+      (err) => this._handleFatalError(err) );
     this._chunker.messageBoundary();
   }
 
   /** Queue a RUN-message to be sent to the database */
   run( statement, params, observer ) {
     this._queueObserver(observer);
-    this._packer.packStruct( RUN, [statement, params] );
+    this._packer.packStruct( RUN, [this._packable(statement), this._packable(params)],
+      (err) => this._handleFatalError(err)  );
     this._chunker.messageBoundary();
   }
 
   /** Queue a PULL_ALL-message to be sent to the database */
   pullAll( observer ) {
     this._queueObserver(observer);
-    this._packer.packStruct( PULL_ALL );
+    this._packer.packStruct( PULL_ALL, [], (err) => this._handleFatalError(err) );
     this._chunker.messageBoundary();
   }
 
   /** Queue a DISCARD_ALL-message to be sent to the database */
   discardAll( observer ) {
     this._queueObserver(observer);
-    this._packer.packStruct( DISCARD_ALL );
+    this._packer.packStruct( DISCARD_ALL, [], (err) => this._handleFatalError(err) );
     this._chunker.messageBoundary();
   }
 
@@ -359,14 +362,14 @@ class Connection {
       }
     };
     this._queueObserver(wrappedObs);
-    this._packer.packStruct( RESET );
+    this._packer.packStruct( RESET, [], (err) => this._handleFatalError(err) );
     this._chunker.messageBoundary();
   }
 
   /** Queue a ACK_FAILURE-message to be sent to the database */
   _ackFailure( observer ) {
     this._queueObserver(observer);
-    this._packer.packStruct( ACK_FAILURE );
+    this._packer.packStruct( ACK_FAILURE, [], (err) => this._handleFatalError(err) );
     this._chunker.messageBoundary();
   }
 
@@ -407,6 +410,10 @@ class Connection {
    */
   close(cb) {
     this._ch.close(cb);
+  }
+
+  _packable(value) {
+      return this._packer.packable(value, (err) => this._handleFatalError(err));
   }
 }
 

--- a/test/internal/packstream.test.js
+++ b/test/internal/packstream.test.js
@@ -26,6 +26,8 @@ var alloc = require('../../lib/v1/internal/buf').alloc,
     Integer = integer.Integer;
 
 describe('packstream', function() {
+
+
   it('should pack integers', function() {
     var n, i;
     // test small numbers
@@ -76,7 +78,7 @@ describe('packstream', function() {
 function packAndUnpack( val, bufferSize ) {
   bufferSize = bufferSize || 128;
   var buffer = alloc(bufferSize);
-  new Packer( buffer ).pack( val );
+  new Packer( buffer ).packable( val )();
   buffer.reset();
   return new Unpacker().unpack( buffer );
 }

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -292,6 +292,20 @@ describe('session', function () {
     }, 1500);
   });
 
+  it('should fail nicely on unpackable values ', function (done) {
+    // Given
+    var unpackable = function(){throw Error()};
+
+    var statement = "RETURN {param}";
+    var params = {param: unpackable};
+    // When & Then
+    session
+      .run(statement, params)
+      .catch(function (ignore) {
+        done();
+      })
+  });
+
 });
 
 


### PR DESCRIPTION
Whenever we encounter an unknown type we throw an exception midstream,
when we have already started writing data back to the channel. Instead of
starting to write to the channel write away we create an function that we
are certain will be packable, and fail early if we cannot pack.

Fixes #91
