### PR TITLE
Fix/know hosts fingerprint duplication error

### DIFF
--- a/src/v1/internal/ch-node.js
+++ b/src/v1/internal/ch-node.js
@@ -45,7 +45,7 @@ function loadFingerprint( serverId, knownHostsPath, cb ) {
   require('readline').createInterface({
     input: fs.createReadStream(knownHostsPath)
   }).on('line', (line)  => {
-    if( line.startsWith( serverId )) {
+    if( !found && line.startsWith( serverId )) {
       found = true;
       cb( line.split(" ")[1] );
     }

--- a/src/v1/internal/ch-node.js
+++ b/src/v1/internal/ch-node.js
@@ -56,8 +56,26 @@ function loadFingerprint( serverId, knownHostsPath, cb ) {
   });
 }
 
+const _lockFingerprintFromAppending = {};
 function storeFingerprint( serverId, knownHostsPath, fingerprint ) {
+  // we check if the serverId has been appended
+  if(!!_lockFingerprintFromAppending[serverId]){
+    // if it has, we ignore it
+    return;
+  }
+
+  // we make the line as appended
+  // ( 1 is more efficient to store than true because true is an oddball )
+  _lockFingerprintFromAppending[serverId] = 1;
+
+  // we append to file
   fs.appendFile(knownHostsPath, serverId + " " + fingerprint + EOL, "utf8" );
+
+  // since the error occurs in the span of one tick
+  // after one tick we clean up to not interfere with anything else
+  setImmediate(() => {
+    delete _lockFingerprintFromAppending[serverId];
+  });
 }
 
 const TrustStrategy = {

--- a/test/internal/tls.test.js
+++ b/test/internal/tls.test.js
@@ -139,6 +139,36 @@ describe('trust-on-first-use', function() {
     });
   });
 
+  it('should not duplicate fingerprint entries', function(done) {
+    // Assuming we only run this test on NodeJS with TOFU support
+    if( !hasFeature("trust_on_first_use") ) {
+      done();
+      return;
+    }
+
+    // Given
+    var knownHostsPath = "build/known_hosts";
+    if( fs.existsSync(knownHostsPath) ) {
+      fs.unlinkSync(knownHostsPath);
+    }
+    fs.writeFileSync(knownHostsPath, '');
+
+    driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"), {
+      encrypted: true,
+      trust: "TRUST_ON_FIRST_USE",
+      knownHosts: knownHostsPath
+    });
+
+    // When
+    driver.session();
+    driver.session();
+
+    setTimeout(function() {
+      expect( fs.readFileSync(knownHostsPath, 'utf8').split('\n').length ).toBe( 1 );
+      done();
+    }, 1000);
+  });
+
   it('should should give helpful error if database cert does not match stored certificate', function(done) {
     // Assuming we only run this test on NodeJS with TOFU support
     if( !hasFeature("trust_on_first_use") ) {


### PR DESCRIPTION
Fixes issue #107 & #108 
Fix: `loadFingerprint` callback only called once
Fix: `storeFingerprint` does not duplicate information in the `known_hosts` file
Add: test cases
