### PR TITLE
Fix/known hosts fingerprint duplication error/upstream 1.0

### DIFF
--- a/src/v1/internal/ch-node.js
+++ b/src/v1/internal/ch-node.js
@@ -56,11 +56,29 @@ function loadFingerprint( serverId, knownHostsPath, cb ) {
   });
 }
 
-function storeFingerprint(serverId, knownHostsPath, fingerprint) {
+const _lockFingerprintFromAppending = {};
+function storeFingerprint( serverId, knownHostsPath, fingerprint ) {
+  // we check if the serverId has been appended
+  if(!!_lockFingerprintFromAppending[serverId]){
+    // if it has, we ignore it
+    return;
+  }
+
+  // we make the line as appended
+  // ( 1 is more efficient to store than true because true is an oddball )
+  _lockFingerprintFromAppending[serverId] = 1;
+
+  // we append to file
   fs.appendFile(knownHostsPath, serverId + " " + fingerprint + EOL, "utf8", (err) => {
     if (err) {
       console.log(err);
     }
+  });
+
+  // since the error occurs in the span of one tick
+  // after one tick we clean up to not interfere with anything else
+  setImmediate(() => {
+    delete _lockFingerprintFromAppending[serverId];
   });
 }
 

--- a/src/v1/internal/ch-node.js
+++ b/src/v1/internal/ch-node.js
@@ -45,7 +45,7 @@ function loadFingerprint( serverId, knownHostsPath, cb ) {
   require('readline').createInterface({
     input: fs.createReadStream(knownHostsPath)
   }).on('line', (line)  => {
-    if( line.startsWith( serverId )) {
+    if( !found && line.startsWith( serverId )) {
       found = true;
       cb( line.split(" ")[1] );
     }

--- a/test/internal/tls.test.js
+++ b/test/internal/tls.test.js
@@ -167,7 +167,30 @@ describe('trust-on-first-use', function() {
     driver.session();
 
     setTimeout(function() {
-      expect( fs.readFileSync(knownHostsPath, 'utf8').trim().split('\n').length ).toBe( 1 );
+      var lines = {};
+      fs.readFileSync(knownHostsPath, 'utf8')
+          .split('\n')
+          .filter(function(line) {
+            return !! (line.trim());
+          })
+          .forEach(function(line) {
+            if (!lines[line]) {
+              lines[line] = 0;
+            }
+            lines[line]++;
+          });
+
+      var duplicatedLines = Object
+          .keys(lines)
+          .map(function(line) {
+              return lines[line];
+          })
+          .filter(function(count) {
+              return count > 1;
+          })
+          .length;
+
+      expect( duplicatedLines ).toBe( 0 );
       done();
     }, 1000);
   });

--- a/test/internal/tls.test.js
+++ b/test/internal/tls.test.js
@@ -139,6 +139,36 @@ describe('trust-on-first-use', function() {
     });
   });
 
+  it('should not duplicate fingerprint entries', function(done) {
+    // Assuming we only run this test on NodeJS with TOFU support
+    if( !hasFeature("trust_on_first_use") ) {
+      done();
+      return;
+    }
+
+    // Given
+    var knownHostsPath = "build/known_hosts";
+    if( fs.existsSync(knownHostsPath) ) {
+      fs.unlinkSync(knownHostsPath);
+    }
+    fs.writeFileSync(knownHostsPath, '');
+
+    driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"), {
+      encrypted: true,
+      trust: "TRUST_ON_FIRST_USE",
+      knownHosts: knownHostsPath
+    });
+
+    // When
+    driver.session();
+    driver.session();
+
+    setTimeout(function() {
+      expect( fs.readFileSync(knownHostsPath, 'utf8').split('\n').length ).toBe( 1 );
+      done();
+    }, 1000);
+  });
+
   it('should should give helpful error if database cert does not match stored certificate', function(done) {
     // Assuming we only run this test on NodeJS with TOFU support
     if( !hasFeature("trust_on_first_use") ) {

--- a/test/internal/tls.test.js
+++ b/test/internal/tls.test.js
@@ -90,25 +90,28 @@ describe('trust-on-first-use', function() {
       fs.unlinkSync(knownHostsPath);
     }
 
-    fs.writeFileSync(
-      knownHostsPath,
-      'localhost:7687 abcd\n' +
-      'localhost:7687 abcd'
-    );
-
     driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"), {
       encrypted: true,
       trust: "TRUST_ON_FIRST_USE",
       knownHosts: knownHostsPath
     });
 
+    driver.session(); // write into the knownHost file
+
+    // duplicate the same serverId twice
+    setTimeout(function() {
+      var text = fs.readFileSync(knownHostsPath, 'utf8');
+      fs.writeFileSync(knownHostsPath, text + text);
+    }, 1000);
+
     // When
-    driver.session().run("RETURN true AS a").then( function(data) {
-      // Then we get to here.
-      // And then the known_hosts file should have correct contents
-      expect( data.records[0].get('a') ).toBe( true );
-      done();
-    });
+    setTimeout(function() {
+      driver.session().run("RETURN true AS a").then( function(data) {
+        // Then we get to here.
+        expect( data.records[0].get('a') ).toBe( true );
+        done();
+      });
+    }, 2000);
   });
 
   it('should accept previously un-seen hosts', function(done) {
@@ -164,7 +167,7 @@ describe('trust-on-first-use', function() {
     driver.session();
 
     setTimeout(function() {
-      expect( fs.readFileSync(knownHostsPath, 'utf8').split('\n').length ).toBe( 1 );
+      expect( fs.readFileSync(knownHostsPath, 'utf8').trim().split('\n').length ).toBe( 1 );
       done();
     }, 1000);
   });


### PR DESCRIPTION
Fixes issue #107 & #108 
Fix: `loadFingerprint` callback only called once
Fix: `storeFingerprint` does not duplicate information in the `known_hosts` file
Add: test cases
