### PR TITLE
Expose more types to allow for external comparisons.

### DIFF
--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -21,6 +21,10 @@ import {int, isInt} from './integer';
 import {driver} from './driver';
 import {Node, Relationship, UnboundRelationship, PathSegment, Path} from './graph-types'
 import {Neo4jError} from './error';
+import Result from './result';
+import ResultSummary from './result-summary';
+import {Record} from './record';
+
 export default {
   driver,
   int,
@@ -36,6 +40,9 @@ export default {
     Relationship,
     UnboundRelationship,
     PathSegment,
-    Path
+    Path,
+    Result,
+    ResultSummary,
+    Record
   }
 }

--- a/test/v1/driver.test.js
+++ b/test/v1/driver.test.js
@@ -47,4 +47,22 @@ describe('driver', function() {
     // When
     driver.session();
   });
+
+  var exposedTypes = [
+    'Node',
+    'Path',
+    'PathSegment',
+    'Record',
+    'Relationship',
+    'Result',
+    'ResultSummary',
+    'UnboundRelationship',
+  ];
+
+  exposedTypes.forEach(type => {
+    it(`should expose type ${type}`, function() {
+      expect(undefined === neo4j.types[type]).toBe(false);
+    });
+  });
+
 });


### PR DESCRIPTION
```
  var exposedTypes = [
    'Node',
    'Path',
    'PathSegment',
    'Record',
    'Relationship',
    'Result',
    'ResultSummary',
    'UnboundRelationship',
  ];

  exposedTypes.forEach(type => {
    it(`should expose type ${type}`, function() {
      expect(undefined === neo4j.types[type]).toBe(false);
    });
  });
```
