### PR TITLE
Rename: updateStatistics->counters.

### DIFF
--- a/src/v1/result-summary.js
+++ b/src/v1/result-summary.js
@@ -33,12 +33,14 @@ class ResultSummary {
   constructor(statement, parameters, metadata) {
     this.statement = {text: statement, parameters};
     this.statementType = metadata.type;
-    this.updateStatistics = new StatementStatistics(metadata.stats || {});
+    let counters = new StatementStatistics(metadata.stats || {});
+    this.counters = counters;
+    //for backwards compatibility, remove in future version
+    this.updateStatistics = counters;
     this.plan = metadata.plan || metadata.profile ? new Plan(metadata.plan || metadata.profile) : false;
     this.profile = metadata.profile ? new ProfiledPlan(metadata.profile) : false;
     this.notifications = this._buildNotifications(metadata.notifications);
   }
-
   _buildNotifications(notifications) {
     if(!notifications) {
       return [];

--- a/test/v1/examples.test.js
+++ b/test/v1/examples.test.js
@@ -88,7 +88,7 @@ describe('examples', function() {
     var s = driver.session();
     s.run( "CREATE (p:Person { name: {name} })", {name: "The One"} )
       .then( function(result) {
-        var theOnesCreated = result.summary.updateStatistics.nodesCreated();
+        var theOnesCreated = result.summary.counters.nodesCreated();
         console.log(theOnesCreated);
         s.close();
         driver.close();
@@ -106,7 +106,7 @@ describe('examples', function() {
       .run( "CREATE (person:Person {name: {name}})", {name: "Arthur"} )
     // end::statement[]
       .then( function(result) {
-        var theOnesCreated = result.summary.updateStatistics.nodesCreated();
+        var theOnesCreated = result.summary.counters.nodesCreated();
         console.log("There were " + theOnesCreated + " the ones created.")
       })
       .then(function() {
@@ -122,7 +122,7 @@ describe('examples', function() {
       .run( "CREATE (p:Person { name: 'Arthur' })" )
     // end::statement-without-parameters[]
       .then( function(result) {
-        var theOnesCreated = result.summary.updateStatistics.nodesCreated();
+        var theOnesCreated = result.summary.counters.nodesCreated();
         console.log("There were " + theOnesCreated + " the ones created.");
       });
 

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -151,8 +151,8 @@ describe('session', function () {
         var sum = result.summary;
         expect(sum.statement.text).toBe(statement);
         expect(sum.statement.parameters).toBe(params);
-        expect(sum.updateStatistics.containsUpdates()).toBe(true);
-        expect(sum.updateStatistics.nodesCreated()).toBe(1);
+        expect(sum.counters.containsUpdates()).toBe(true);
+        expect(sum.counters.nodesCreated()).toBe(1);
         expect(sum.statementType).toBe(StatementType.READ_WRITE);
         done();
       });

--- a/test/v1/tck/steps/resultapisteps.js
+++ b/test/v1/tck/steps/resultapisteps.js
@@ -56,11 +56,11 @@ module.exports = function () {
   });
 
   this.Then(/^requesting `Counters` from `Result Summary` should give$/, function (table) {
-    var updateStatistics = this.summary.updateStatistics
+    var counters = this.summary.counters;
     for ( var i = 0 ; i < table.hashes().length; i++) {
       var statistic = table.hashes()[i].counter;
       var expected = util.literalValueToTestValueNormalIntegers(table.hashes()[i].result);
-      var given = getStatistic(statistic, updateStatistics)
+      var given = getStatistic(statistic, counters)
       if (!util.compareValues(given, expected)) {
         throw Error("Statistics for: " + statistic + " does not match. Expected: '" + expected + "' Given: '" + given + "'");
       }
@@ -195,42 +195,42 @@ this.Then(/^the `Result Summary` `Notifications` has one notification with$/, fu
     throw Error("No statement type mapping of: " + type)
   }
 
-  function getStatistic(statementString, updateStatistics) {
+  function getStatistic(statementString, counters) {
     if (statementString == 'nodes created') {
-      return updateStatistics.nodesCreated();
+      return counters.nodesCreated();
     }
     if (statementString == 'nodes deleted') {
-      return updateStatistics.nodesDeleted();
+      return counters.nodesDeleted();
     }
     if (statementString == 'relationships created') {
-      return updateStatistics.relationshipsCreated();
+      return counters.relationshipsCreated();
     }
     if (statementString == 'relationships deleted') {
-      return updateStatistics.relationshipsDeleted();
+      return counters.relationshipsDeleted();
     }
     if (statementString == 'properties set') {
-      return updateStatistics.propertiesSet();
+      return counters.propertiesSet();
     }
     if (statementString == 'labels added') {
-      return updateStatistics.labelsAdded();
+      return counters.labelsAdded();
     }
     if (statementString == 'labels removed') {
-      return updateStatistics.labelsRemoved();
+      return counters.labelsRemoved();
     }
     if (statementString == 'indexes added') {
-      return updateStatistics.indexesAdded();
+      return counters.indexesAdded();
     }
     if (statementString == 'indexes removed') {
-      return updateStatistics.indexesRemoved();
+      return counters.indexesRemoved();
     }
     if (statementString == 'constraints added') {
-      return updateStatistics.constraintsAdded();
+      return counters.constraintsAdded();
     }
     if (statementString == 'constraints removed') {
-      return updateStatistics.constraintsRemoved();
+      return counters.constraintsRemoved();
     }
     if (statementString == 'contains updates') {
-      return updateStatistics.containsUpdates();
+      return counters.containsUpdates();
     }
     throw Error("No statistics mapping of: " + statementString)
   }


### PR DESCRIPTION
In order to be consistent between driversm `updateStatistics` is now called
counters in line with the other drivers. Using `updateStatistics` will still work but is deprecated and
will be removed in future versions.
