### PR TITLE
Fix for failing windows test

### DIFF
--- a/test/internal/tls.test.js
+++ b/test/internal/tls.test.js
@@ -79,7 +79,7 @@ describe('trust-signed-certificates', function() {
     driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "neo4j"), {
       encrypted: true,
       trust: "TRUST_SIGNED_CERTIFICATES",
-      trustedCertificates: ["build/neo4j/certificates/neo4j.cert", "test/resources/random.certificate"]
+      trustedCertificates: ["build/neo4j/certificates/neo4j.cert", "build/neo4j/certificates/neo4j.cert"]
     });
 
     // When


### PR DESCRIPTION
Test was relying on certificates being loaded one-at-a-time which is not true on windows.
Since the test only asserts we get the input to the undelying channel correct we simple send a list
of identical certifactes instead.
