### PR TITLE
improve closed connection handling

### DIFF
--- a/src/v1/internal/ch-node.js
+++ b/src/v1/internal/ch-node.js
@@ -266,6 +266,7 @@ class NodeChannel {
     this._open = true;
     this._error = null;
     this._handleConnectionError = this._handleConnectionError.bind(this);
+    this._handleConnectionTerminated = this._handleConnectionTerminated.bind(this);
 
     this._encrypted = opts.encrypted;
     this._conn = connect(opts, () => {
@@ -299,10 +300,8 @@ class NodeChannel {
   }
 
   _handleConnectionTerminated() {
-      this._error = new Error('Connection was closed by server');
-      if( this.onerror ) {
-        this.onerror(this._error);
-      }
+      this._open = false;
+      this._conn = undefined;
   }
 
   isEncrypted() {

--- a/src/v1/internal/pool.js
+++ b/src/v1/internal/pool.js
@@ -46,6 +46,8 @@ class Pool {
 
       if( this._validate(resource) ) {
         return resource;
+      } else {
+        this._destroy(resource);
       }
     }
 


### PR DESCRIPTION
Related to my previous PR (#137).
- Not sure why it seemed to work, but the `_handleConnectionTerminated` handler never really worked because it wasn't bound correctly and `'this.onerror` is always undefined. So I bound the function.
- Upon reflection, I don't think that the server closing a connection should be considered as an error, the connection is simply not open anymore for whatever reason. Once you try to open a new connection, you'll get a more accurate error message like the server not being reachable anymore for example or no error is there is a failover setup configured, ... So instead of throwing an error, I close the connection.
- The pool did not call the `_destroy` method on resources that are detected as invalid during acquisition, so they weren't being cleaned up correctly.
