### PR TITLE
Expose server info in result summary from sessions and transactions

### DIFF
--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -193,6 +193,7 @@ class Connection {
      * to the next pending observer.
      */
     this.url = url;
+    this.server = {address: url};
     this._pendingObservers = [];
     this._currentObserver = undefined;
     this._ch = channel;
@@ -453,6 +454,10 @@ class Connection {
   _packable(value) {
       return this._packer.packable(value, (err) => this._handleFatalError(err));
   }
+
+  setServerVersion(version) {
+    this.server.version = version;
+  }
 }
 
 /**
@@ -464,6 +469,10 @@ class Connection {
  */
 function connect( url, config = {}) {
   let Ch = config.channel || Channel;
+  const host = parseHost(url);
+  const port = parsePort(url) || 7687;
+  const completeUrl = host + ':' + port;
+
   return new Connection( new Ch({
     host: parseHost(url),
     port: parsePort(url) || 7687,
@@ -473,7 +482,7 @@ function connect( url, config = {}) {
     trust : config.trust || (hasFeature("trust_all_certificates") ? "TRUST_ALL_CERTIFICATES" : "TRUST_CUSTOM_CA_SIGNED_CERTIFICATES"),
     trustedCertificates : config.trustedCertificates || [],
     knownHosts : config.knownHosts
-  }), url);
+  }), completeUrl);
 }
 
 export {

--- a/src/v1/result-summary.js
+++ b/src/v1/result-summary.js
@@ -40,6 +40,7 @@ class ResultSummary {
     this.plan = metadata.plan || metadata.profile ? new Plan(metadata.plan || metadata.profile) : false;
     this.profile = metadata.profile ? new ProfiledPlan(metadata.profile) : false;
     this.notifications = this._buildNotifications(metadata.notifications);
+    this.server = new ServerInfo(metadata.server);
     this.resultConsumedAfter = metadata.result_consumed_after;
     this.resultAvailableAfter = metadata.result_available_after;
   }
@@ -250,6 +251,24 @@ class Notification {
       offset: pos.offset.toInt(),
       line: pos.line.toInt(),
       column: pos.column.toInt()
+    }
+  }
+}
+
+/**
+  * Class for exposing server info from a result.
+  * @access public
+  */
+class ServerInfo {
+  /**
+   * Create a ServerInfo instance
+   * @constructor
+   * @param {Object} serverMeta - Object with serverMeta data
+   */
+  constructor(serverMeta) {
+    if (serverMeta) {
+      this.address = serverMeta.address;
+      this.version = serverMeta.version;
     }
   }
 }

--- a/src/v1/session.js
+++ b/src/v1/session.js
@@ -136,7 +136,8 @@ class _RunObserver extends StreamObserver {
   }
 
   meta() {
-    return this._meta;
+    const serverMeta = {server: this._conn.server};
+    return Object.assign({}, this._meta, serverMeta);
   }
 }
 

--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -134,6 +134,11 @@ class _TransactionStreamObserver extends StreamObserver {
       this._tx._onBookmark(bookmark);
     }
   }
+
+  serverMeta() {
+    const serverMeta = {server: this._conn.server};
+    return serverMeta;
+  }
 }
 
 /** internal state machine of the transaction*/
@@ -155,7 +160,7 @@ let _states = {
         conn.sync();
       }).catch(observer.onError);
 
-      return new Result( observer, statement, parameters );
+      return new Result( observer, statement, parameters, () => observer.serverMeta() );
     }
   },
 

--- a/test/resources/boltkit/read_server_with_version.script
+++ b/test/resources/boltkit/read_server_with_version.script
@@ -1,7 +1,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: INIT "neo4j-javascript/[object Object]" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
+C: INIT "neo4j-javascript/0.0.0-dev" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
 S: SUCCESS {"server": "TheReadServerV1"}
 C: RUN "MATCH (n) RETURN n.name" {}
    PULL_ALL

--- a/test/resources/boltkit/read_server_with_version.script
+++ b/test/resources/boltkit/read_server_with_version.script
@@ -1,0 +1,12 @@
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: INIT "neo4j-javascript/[object Object]" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
+S: SUCCESS {"server": "TheReadServerV1"}
+C: RUN "MATCH (n) RETURN n.name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   RECORD ["Tina"]
+   SUCCESS {}

--- a/test/resources/boltkit/write_server_with_version.script
+++ b/test/resources/boltkit/write_server_with_version.script
@@ -1,0 +1,9 @@
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: INIT "neo4j-javascript/[object Object]" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
+S: SUCCESS {"server": "TheWriteServerV1"}
+C: RUN "CREATE (n {name:'Bob'})" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}

--- a/test/resources/boltkit/write_server_with_version.script
+++ b/test/resources/boltkit/write_server_with_version.script
@@ -1,7 +1,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: INIT "neo4j-javascript/[object Object]" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
+C: INIT "neo4j-javascript/0.0.0-dev" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
 S: SUCCESS {"server": "TheWriteServerV1"}
 C: RUN "CREATE (n {name:'Bob'})" {}
    PULL_ALL

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -164,6 +164,29 @@ describe('session', function () {
       });
   });
 
+  it('should expose server info on successful query', function (done) {
+    //lazy way of checking the version number
+    //if server has been set we know it is at least
+    //3.1 (todo actually parse the version string)
+    if (!server) {
+      done();
+      return;
+    }
+
+    // Given
+    var statement = 'RETURN 1';
+
+    // When & Then
+    session.run(statement)
+      .then(function (result) {
+        var sum = result.summary;
+        expect(sum.server).toBeDefined();
+        expect(sum.server.address).toEqual('localhost:7687');
+        expect(sum.server.version).toBeDefined();
+        done();
+      });
+  });
+
   it('should expose execution time information when using 3.1 and onwards', function (done) {
 
     //lazy way of checking the version number

--- a/test/v1/transaction.test.js
+++ b/test/v1/transaction.test.js
@@ -296,8 +296,33 @@ describe('transaction', function() {
           });
   });
 
+  it('should expose server info on successful query', function (done) {
+    //lazy way of checking the version number
+    //if server has been set we know it is at least
+    //3.1 (todo actually parse the version string)
+    if (!server) {
+      done();
+      return;
+    }
+    // Given
+    var statement = 'RETURN 1';
+
+    // When & Then
+    var tx = session.beginTransaction();
+    tx.run(statement)
+      .then(function (result) {
+        var sum = result.summary;
+        expect(sum.server).toBeDefined();
+        expect(sum.server.address).toEqual('localhost:7687');
+        expect(sum.server.version).toBeDefined();
+      });
+    tx.commit().then(function() {
+      done();
+    })
+  });
+
   function expectSyntaxError(error) {
-    const code = error.fields[0].code;
-    expect(code).toBe('Neo.ClientError.Statement.SyntaxError');
+      const code = error.fields[0].code;
+      expect(code).toBe('Neo.ClientError.Statement.SyntaxError');
   }
 });


### PR DESCRIPTION
Exposed as a map in `result.summary.server`:

```
{
  address: 'localhost:7687',
  version: 'Neo4j/3.1.0'
}
```