### PR TITLE
Rollback transaction after run failure

### DIFF
--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -99,7 +99,13 @@ class Transaction {
   }
 
   _onError() {
-    this._onClose();
+    // rollback explicitly if tx.run failed, rollback
+    if (this._state == _states.ACTIVE) {
+        this.rollback();
+    } else {
+        // else just do the cleanup
+        this._onClose();
+    }
     this._state = _states.FAILED;
   }
 }


### PR DESCRIPTION
Transaction can't continue after the very first run failure. This commit makes sure we send rollback to the server when such failure is detected.