### PR TITLE
Fix: checking if a parameter is integer in packer by using Integer.isInteger

### DIFF
--- a/src/v1/internal/packstream.js
+++ b/src/v1/internal/packstream.js
@@ -97,7 +97,7 @@ class Packer {
       return () => this.packFloat(x);
     } else if (typeof(x) == "string") {
       return () => this.packString(x, onError);
-    } else if (x instanceof Integer) {
+    } else if (Integer.isInteger(x)) {
       return () => this.packInteger( x );
     } else if (x instanceof Array) {
       return () => {


### PR DESCRIPTION
In the following scenario we have one module that uses a different version of `neo4j-driver` that the one that is installed in the project.
```
node_modules/
 - neo4j-driver@1.0.5
 - module_a/
  - neo4j-driver@1.0.4
```
This will result in loading 2 instances of `neo4j-driver` and 2 instances of the class `Integer`. 

Now lets say that `module_a` generates an `Integer` using it's version of the `Integer` class and then that integer is passed in a query (using the project's version of `neo4j-driver`). When the packer checks for integer it checks the class, but it check it's version of `Integer` which is different and fails to parse it as an integer, defaulting to parse it as an object (`{low, high}`).

![image](https://cloud.githubusercontent.com/assets/962643/21717547/60cc3cb0-d41a-11e6-9616-48c588065e3b.png)
As seen in the screenshot, in the packer, `x` is an `Integer` class, but not the same class that is checked against.

I think a good solution for this is to use the `Integer.isInteger` implementation to check for integers.