### PR TITLE
Fix: Structure error has bad .toString()

### DIFF
--- a/src/v1/internal/packstream.js
+++ b/src/v1/internal/packstream.js
@@ -65,9 +65,9 @@ class Structure {
     let fieldStr = "";
     for (var i = 0; i < this.fields.length; i++) {
       if(i > 0) { fieldStr+=", " }
-      fieldStr += this.fields[i];
+      fieldStr += JSON.stringify(this.fields[i]);
     }
-    return "Structure(" + this.signature + ", [" + this.fields + "])"
+    return "Structure(" + this.signature + ", [" + fieldStr + "])"
   }
 }
 


### PR DESCRIPTION
Fixes issue where Structure.toString() outputs: `Structure(127, [[object Object]])`
Now it should properly stringify the error:  `Structure(127, [{"code":"Neo.ClientError.Statement.ArithmeticError","message":"/ by zero"}])`