### PR TITLE
Unpack failure messages to Neo4jErrors

### DIFF
--- a/src/v1/internal/buf.js
+++ b/src/v1/internal/buf.js
@@ -22,7 +22,6 @@
   *(via Buffer API).
   */
 
-import {newError} from './../error';
 let _node = require("buffer");
 /**
   * Common base with default implementation for most buffer methods.
@@ -551,7 +550,7 @@ class NodeBuffer extends BaseBuffer {
         val.position + bytesToCopy );
       val.position += bytesToCopy;
     } else {
-      throw newError("Copying not yet implemented.");
+      super.putBytes(position, val);
     }
   };
 

--- a/src/v1/internal/get-servers-util.js
+++ b/src/v1/internal/get-servers-util.js
@@ -31,7 +31,7 @@ export default class GetServersUtil {
       session.close();
       return result.records;
     }).catch(error => {
-      if (this._isProcedureNotFoundError(error)) {
+      if (error.code === PROCEDURE_NOT_FOUND_CODE) {
         // throw when getServers procedure not found because this is clearly a configuration issue
         throw newError('Server ' + routerAddress + ' could not perform routing. ' +
           'Make sure you are connecting to a causal cluster', SERVICE_UNAVAILABLE);
@@ -91,17 +91,5 @@ export default class GetServersUtil {
         'Unable to parse servers entry from router ' + routerAddress + ' from record:\n' + JSON.stringify(record),
         PROTOCOL_ERROR);
     }
-  }
-
-  _isProcedureNotFoundError(error) {
-    let errorCode = error.code;
-    if (!errorCode) {
-      try {
-        errorCode = error.fields[0].code;
-      } catch (e) {
-        errorCode = 'UNKNOWN';
-      }
-    }
-    return errorCode === PROCEDURE_NOT_FOUND_CODE;
   }
 }

--- a/test/internal/connector.test.js
+++ b/test/internal/connector.test.js
@@ -16,43 +16,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var DummyChannel = require('../../lib/v1/internal/ch-dummy.js');
-var connect = require("../../lib/v1/internal/connector.js").connect;
 
-describe('connector', function() {
+import * as DummyChannel from "../../src/v1/internal/ch-dummy";
+import {connect} from "../../src/v1/internal/connector";
 
-  it('should read/write basic messages', function(done) {
+describe('connector', () => {
+
+  it('should read/write basic messages', done => {
     // Given
-    var conn = connect("bolt://localhost")
+    const conn = connect("bolt://localhost");
 
     // When
-    conn.initialize( "mydriver/0.0.0", {scheme: "basic", principal: "neo4j", credentials: "neo4j"},  {
-      onCompleted: function( msg ) {
-        expect( msg ).not.toBeNull();
+    conn.initialize("mydriver/0.0.0", {scheme: "basic", principal: "neo4j", credentials: "neo4j"}, {
+      onCompleted: msg => {
+        expect(msg).not.toBeNull();
         conn.close();
         done();
       },
-      onError: function(err) {
-        console.log(err);
-      }
+      onError: console.log
     });
     conn.sync();
 
   });
-  it('should retrieve stream', function(done) {
+
+  it('should retrieve stream', done => {
     // Given
-    var conn = connect("bolt://localhost")
+    const conn = connect("bolt://localhost");
 
     // When
-    var records = [];
-    conn.initialize( "mydriver/0.0.0", {scheme: "basic", principal: "neo4j", credentials: "neo4j"} );
-    conn.run( "RETURN 1.0", {} );
-    conn.pullAll( {
-      onNext: function( record ) {
-        records.push( record );
+    const records = [];
+    conn.initialize("mydriver/0.0.0", {scheme: "basic", principal: "neo4j", credentials: "neo4j"});
+    conn.run("RETURN 1.0", {});
+    conn.pullAll({
+      onNext: record => {
+        records.push(record);
       },
-      onCompleted: function( tail ) {
-        expect( records[0][0] ).toBe( 1 );
+      onCompleted: () => {
+        expect(records[0][0]).toBe(1);
         conn.close();
         done();
       }
@@ -60,31 +60,30 @@ describe('connector', function() {
     conn.sync();
   });
 
-  it('should use DummyChannel to read what gets written', function(done) {
+  it('should use DummyChannel to read what gets written', done => {
     // Given
-    var observer = DummyChannel.observer;
-    var conn = connect("bolt://localhost", {channel:DummyChannel.channel});
+    const observer = DummyChannel.observer;
+    const conn = connect("bolt://localhost", {channel: DummyChannel.channel});
 
     // When
-    var records = [];
-    conn.initialize( "mydriver/0.0.0", {scheme: "basic", principal: "neo4j", credentials: "neo4j"} );
-    conn.run( "RETURN 1", {} );
+    conn.initialize("mydriver/0.0.0", {scheme: "basic", principal: "neo4j", credentials: "neo4j"});
+    conn.run("RETURN 1", {});
     conn.sync();
-    expect( observer.instance.toHex() ).toBe( '60 60 b0 17 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 41 b2 01 8e 6d 79 64 72 69 76 65 72 2f 30 2e 30 2e 30 a3 86 73 63 68 65 6d 65 85 62 61 73 69 63 89 70 72 69 6e 63 69 70 61 6c 85 6e 65 6f 34 6a 8b 63 72 65 64 65 6e 74 69 61 6c 73 85 6e 65 6f 34 6a 00 00 00 0c b2 10 88 52 45 54 55 52 4e 20 31 a0 00 00 ' );
+    expect(observer.instance.toHex()).toBe('60 60 b0 17 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 41 b2 01 8e 6d 79 64 72 69 76 65 72 2f 30 2e 30 2e 30 a3 86 73 63 68 65 6d 65 85 62 61 73 69 63 89 70 72 69 6e 63 69 70 61 6c 85 6e 65 6f 34 6a 8b 63 72 65 64 65 6e 74 69 61 6c 73 85 6e 65 6f 34 6a 00 00 00 0c b2 10 88 52 45 54 55 52 4e 20 31 a0 00 00 ');
     done();
   });
 
-  it('should provide error message when connecting to http-port', function(done) {
+  it('should provide error message when connecting to http-port', done => {
     // Given
-    var conn = connect("bolt://localhost:7474", {encrypted:false});
+    const conn = connect("bolt://localhost:7474", {encrypted: false});
 
     // When
-    conn.initialize( "mydriver/0.0.0", {scheme: "basic", principal: "neo4j", credentials: "neo4j"},  {
-      onCompleted: function( msg ) {
+    conn.initialize("mydriver/0.0.0", {scheme: "basic", principal: "neo4j", credentials: "neo4j"}, {
+      onCompleted: msg => {
       },
-      onError: function(err) {
+      onError: err => {
         //only node gets the pretty error message
-        if( require('../../lib/v1/internal/ch-node.js').available ) {
+        if (require('../../lib/v1/internal/ch-node.js').available) {
           expect(err.message).toBe("Server responded HTTP. Make sure you are not trying to connect to the http endpoint " +
             "(HTTP defaults to port 7474 whereas BOLT defaults to port 7687)");
         }

--- a/test/v1/driver.test.js
+++ b/test/v1/driver.test.js
@@ -79,7 +79,7 @@ describe('driver', function() {
     // Expect
     driver.onError = function (err) {
       //the error message is different whether in browser or node
-      expect(err.fields[0].code).toEqual('Neo.ClientError.Security.Unauthorized');
+      expect(err.code).toEqual('Neo.ClientError.Security.Unauthorized');
       done();
     };
 

--- a/test/v1/examples.test.js
+++ b/test/v1/examples.test.js
@@ -306,7 +306,7 @@ describe('examples', function() {
     // end::handle-cypher-error[]
 
     testResultPromise.then(function(loggedError){
-      expect(loggedError.fields[0].code).toBe( "Neo.ClientError.Statement.SyntaxError" );
+      expect(loggedError.code).toBe( 'Neo.ClientError.Statement.SyntaxError' );
       done();
     });
   });

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -94,9 +94,9 @@ describe('session', function () {
   it('should call observers onError on error ', function (done) {
 
     // When & Then
-    session.run("RETURN 1 AS").subscribe({
+    session.run('RETURN 1 AS').subscribe({
       onError: function (error) {
-        expect(error.fields.length).toBe(1);
+        expect(error.code).toEqual('Neo.ClientError.Statement.SyntaxError');
         done();
       }
     });
@@ -139,9 +139,9 @@ describe('session', function () {
 
   it('should expose basic run/catch ', function (done) {
     // When & Then
-    session.run("RETURN 1 AS").catch(
+    session.run('RETURN 1 AS').catch(
       function (error) {
-        expect(error.fields.length).toBe(1);
+        expect(error.code).toEqual('Neo.ClientError.Statement.SyntaxError');
         done();
       }
     )

--- a/test/v1/tck/steps/authsteps.js
+++ b/test/v1/tck/steps/authsteps.js
@@ -64,8 +64,8 @@ module.exports = function () {
   });
 
   this.Then(/^a `Protocol Error` is raised$/, function () {
-    var message = this.err.fields[0].message;
-    var code = this.err.fields[0].code;
+    var message = this.err.message;
+    var code = this.err.code;
 
     var expectedStartOfMessage = 'The client is unauthorized due to authentication failure.';
     var expectedCode = 'Neo.ClientError.Security.Unauthorized';

--- a/test/v1/tck/steps/erroreportingsteps.js
+++ b/test/v1/tck/steps/erroreportingsteps.js
@@ -58,7 +58,7 @@ module.exports = function () {
 
   this.When(/^I run a non valid cypher statement$/, function (callback) {
     var self = this;
-    this.session.run("CRETE (:n)").then(function(result) {callback()}).catch(function(err) {self.error = err.fields[0]; callback()})
+    this.session.run("CRETE (:n)").then(function(result) {callback()}).catch(function(err) {self.error = err; callback()})
   });
 
   this.When(/^I set up a driver to an incorrect port$/, function (callback) {

--- a/test/v1/transaction.test.js
+++ b/test/v1/transaction.test.js
@@ -77,9 +77,9 @@ describe('transaction', () => {
 
   it('should handle failures with subscribe', done => {
     const tx = session.beginTransaction();
-    tx.run("THIS IS NOT CYPHER")
+    tx.run('THIS IS NOT CYPHER')
       .catch(error => {
-        expect(error.fields.length).toBe(1);
+        expect(error.code).toEqual('Neo.ClientError.Statement.SyntaxError');
         driver.close();
         done();
       });
@@ -87,10 +87,10 @@ describe('transaction', () => {
 
   it('should handle failures with catch', done => {
     const tx = session.beginTransaction();
-    tx.run("THIS IS NOT CYPHER")
+    tx.run('THIS IS NOT CYPHER')
       .subscribe({
         onError: error => {
-          expect(error.fields.length).toBe(1);
+          expect(error.code).toEqual('Neo.ClientError.Statement.SyntaxError');
           driver.close();
           done();
         }
@@ -297,7 +297,7 @@ describe('transaction', () => {
     const invalidBookmark = 'hi, this is an invalid bookmark';
     const tx = session.beginTransaction(invalidBookmark);
     tx.run('RETURN 1').catch(error => {
-      expect(error.fields[0].code).toBe('Neo.ClientError.Transaction.InvalidBookmark');
+      expect(error.code).toBe('Neo.ClientError.Transaction.InvalidBookmark');
       done();
     });
   });
@@ -317,7 +317,7 @@ describe('transaction', () => {
         const unreachableBookmark = session.lastBookmark() + "0";
         const tx2 = session.beginTransaction(unreachableBookmark);
         tx2.run('CREATE ()').catch(error => {
-          const message = error.fields[0].message;
+          const message = error.message;
           const expectedPrefix = message.indexOf('Database not up to the requested version') === 0;
           expect(expectedPrefix).toBeTruthy();
           done();
@@ -445,8 +445,7 @@ describe('transaction', () => {
   });
 
   function expectSyntaxError(error) {
-    const code = error.fields[0].code;
-    expect(code).toBe('Neo.ClientError.Statement.SyntaxError');
+    expect(error.code).toBe('Neo.ClientError.Statement.SyntaxError');
   }
 
   function expectValidLastBookmark(session) {


### PR DESCRIPTION
Previously raw FAILURE message was passed to `onError`-like callbacks and thrown as is. This means thrown error contained packstream related fields and actually was a packstream structure. Example:

```
Structure {
  signature: 127,
  fields: [
    {
      code: 'Neo.ClientError.Schema.ConstraintValidationFailed',
      message: 'Node 0 already exists with label A and property "a"=[42]'
    }
  ]
}
```

This commit makes sure we unpack/convert FAILURE messages to `Neo4jError`s and pass those further to callbacks.

Fixes #201 