### PR TITLE
Fixed purging of connections after rediscovery

### DIFF
--- a/src/v1/routing-driver.js
+++ b/src/v1/routing-driver.js
@@ -145,7 +145,7 @@ class RoutingDriver extends Driver {
 
     // close old connections to servers not present in the new routing table
     const staleServers = currentRoutingTable.serversDiff(newRoutingTable);
-    staleServers.forEach(server => this._pool.purge);
+    staleServers.forEach(server => this._pool.purge(server));
 
     // make this driver instance aware of the new table
     this._routingTable = newRoutingTable;


### PR DESCRIPTION
After rediscovery newly obtained routing table is compared to the known routing table to find all servers that are "stale" - in the current table but not in the new one. Connections to such servers are supposed to be terminated.

However this did not happen because purging function was not invoked correctly. This commit fixes the issue.