### PR TITLE
Cleanup around connections and sessions

### DIFF
--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -17,11 +17,11 @@
  * limitations under the License.
  */
 
-import Session from "./session";
-import Pool from "./internal/pool";
-import {connect} from "./internal/connector";
-import StreamObserver from "./internal/stream-observer";
-import {newError, SERVICE_UNAVAILABLE} from "./error";
+import Session from './session';
+import Pool from './internal/pool';
+import {connect} from './internal/connector';
+import StreamObserver from './internal/stream-observer';
+import {newError, SERVICE_UNAVAILABLE} from './error';
 
 const READ = 'READ', WRITE = 'WRITE';
 /**
@@ -119,33 +119,7 @@ class Driver {
         //we don't need to tell the driver about this error
       }
     });
-    return this._createSession(connectionPromise, this._releaseConnection(connectionPromise));
-  }
-
-  /**
-   * The returned function gets called on Session#close(), and is where we return the pooled 'connection' instance.
-   * We don't pool Session instances, to avoid users using the Session after they've called close.
-   * The `Session` object is just a thin wrapper around Connection anyway, so it makes little difference.
-   * @param {Promise} connectionPromise - promise resolved with the connection.
-   * @return {function(callback: function)} - function that releases the connection and then executes an optional callback.
-   * @protected
-   */
-  _releaseConnection(connectionPromise) {
-    return userDefinedCallback => {
-      connectionPromise.then(conn => {
-        // Queue up a 'reset', to ensure the next user gets a clean session to work with.
-        conn.reset();
-        conn.sync();
-
-        // Return connection to the pool
-        conn._release();
-      }).catch(ignoredError => {
-      });
-
-      if (userDefinedCallback) {
-        userDefinedCallback();
-      }
-    };
+    return this._createSession(connectionPromise);
   }
 
   static _validateSessionMode(rawMode) {
@@ -162,8 +136,8 @@ class Driver {
   }
 
   //Extension point
-  _createSession(connectionPromise, cb) {
-    return new Session(connectionPromise, cb);
+  _createSession(connectionPromise) {
+    return new Session(connectionPromise);
   }
 
   /**

--- a/src/v1/internal/connection-providers.js
+++ b/src/v1/internal/connection-providers.js
@@ -67,6 +67,7 @@ export class LoadBalancer extends ConnectionProvider {
 
   forget(address) {
     this._routingTable.forget(address);
+    this._connectionPool.purge(address);
   }
 
   forgetWriter(address) {
@@ -115,6 +116,7 @@ export class LoadBalancer extends ConnectionProvider {
       });
     }, Promise.resolve(null));
 
+    // todo: who removes the final router when all routers fail?
     return refreshedTablePromise.then(newRoutingTable => {
       if (newRoutingTable && !newRoutingTable.writers.isEmpty()) {
         this._updateRoutingTable(newRoutingTable);

--- a/src/v1/internal/connection-providers.js
+++ b/src/v1/internal/connection-providers.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {newError, SERVICE_UNAVAILABLE, SESSION_EXPIRED} from '../error';
+import {READ, WRITE} from '../driver';
+import Session from '../session';
+import RoundRobinArray from './round-robin-array';
+import RoutingTable from './routing-table';
+import Rediscovery from './rediscovery';
+
+class ConnectionProvider {
+
+  acquireConnection(mode) {
+    throw new Error('Abstract method');
+  }
+}
+
+export class DirectConnectionProvider extends ConnectionProvider {
+
+  constructor(address, connectionPool) {
+    super();
+    this._address = address;
+    this._connectionPool = connectionPool;
+  }
+
+  acquireConnection(mode) {
+    return Promise.resolve(this._connectionPool.acquire(this._address));
+  }
+}
+
+export class LoadBalancer extends ConnectionProvider {
+
+  constructor(address, connectionPool) {
+    super();
+    this._routingTable = new RoutingTable(new RoundRobinArray([address]));
+    this._rediscovery = new Rediscovery();
+    this._connectionPool = connectionPool;
+  }
+
+  acquireConnection(mode) {
+    return this._freshRoutingTable().then(routingTable => {
+      if (mode === READ) {
+        return this._acquireConnectionToServer(routingTable.readers, 'read');
+      } else if (mode === WRITE) {
+        return this._acquireConnectionToServer(routingTable.writers, 'write');
+      } else {
+        throw newError('Illegal mode ' + mode);
+      }
+    });
+  }
+
+  forget(address) {
+    this._routingTable.forget(address);
+  }
+
+  forgetWriter(address) {
+    this._routingTable.forgetWriter(address);
+  }
+
+  _acquireConnectionToServer(serversRoundRobinArray, serverName) {
+    const address = serversRoundRobinArray.next();
+    if (!address) {
+      return Promise.reject(newError('No ' + serverName + ' servers available', SESSION_EXPIRED));
+    }
+    return this._connectionPool.acquire(address);
+  }
+
+  _freshRoutingTable() {
+    const currentRoutingTable = this._routingTable;
+
+    if (!currentRoutingTable.isStale()) {
+      return Promise.resolve(currentRoutingTable);
+    }
+    return this._refreshRoutingTable(currentRoutingTable);
+  }
+
+  _refreshRoutingTable(currentRoutingTable) {
+    const knownRouters = currentRoutingTable.routers.toArray();
+
+    const refreshedTablePromise = knownRouters.reduce((refreshedTablePromise, currentRouter, currentIndex) => {
+      return refreshedTablePromise.then(newRoutingTable => {
+        if (newRoutingTable) {
+          if (!newRoutingTable.writers.isEmpty()) {
+            // valid routing table was fetched - just return it, try next router otherwise
+            return newRoutingTable;
+          }
+        } else {
+          // returned routing table was undefined, this means a connection error happened and we need to forget the
+          // previous router and try the next one
+          const previousRouter = knownRouters[currentIndex - 1];
+          if (previousRouter) {
+            currentRoutingTable.forgetRouter(previousRouter);
+          }
+        }
+
+        // try next router
+        const session = this._createSessionForRediscovery(currentRouter);
+        return this._rediscovery.lookupRoutingTableOnRouter(session, currentRouter);
+      });
+    }, Promise.resolve(null));
+
+    return refreshedTablePromise.then(newRoutingTable => {
+      if (newRoutingTable && !newRoutingTable.writers.isEmpty()) {
+        this._updateRoutingTable(newRoutingTable);
+        return newRoutingTable;
+      }
+      throw newError('Could not perform discovery. No routing servers available.', SERVICE_UNAVAILABLE);
+    });
+  }
+
+  _createSessionForRediscovery(routerAddress) {
+    const connection = this._connectionPool.acquire(routerAddress);
+    const connectionPromise = Promise.resolve(connection);
+    return new Session(connectionPromise);
+  }
+
+  _updateRoutingTable(newRoutingTable) {
+    const currentRoutingTable = this._routingTable;
+
+    // close old connections to servers not present in the new routing table
+    const staleServers = currentRoutingTable.serversDiff(newRoutingTable);
+    staleServers.forEach(server => this._connectionPool.purge(server));
+
+    // make this driver instance aware of the new table
+    this._routingTable = newRoutingTable;
+  }
+}

--- a/src/v1/routing-driver.js
+++ b/src/v1/routing-driver.js
@@ -18,11 +18,9 @@
  */
 
 import Session from './session';
-import {Driver, READ, WRITE} from './driver';
+import {Driver} from './driver';
 import {newError, SERVICE_UNAVAILABLE, SESSION_EXPIRED} from './error';
-import RoundRobinArray from './internal/round-robin-array';
-import RoutingTable from './internal/routing-table';
-import Rediscovery from './internal/rediscovery';
+import {LoadBalancer} from './internal/connection-providers';
 
 /**
  * A driver that supports routing in a core-edge cluster.
@@ -31,8 +29,10 @@ class RoutingDriver extends Driver {
 
   constructor(url, userAgent, token = {}, config = {}) {
     super(url, userAgent, token, RoutingDriver._validateConfig(config));
-    this._routingTable = new RoutingTable(new RoundRobinArray([url]));
-    this._rediscovery = new Rediscovery();
+  }
+
+  _createConnectionProvider(address, connectionPool) {
+    return new LoadBalancer(address, connectionPool);
   }
 
   _createSession(connectionPromise) {
@@ -50,10 +50,10 @@ class RoutingDriver extends Driver {
         let url = 'UNKNOWN';
         if (conn) {
           url = conn.url;
-          this._routingTable.forgetWriter(conn.url);
+          this._connectionProvider.forgetWriter(conn.url);
         } else {
           connectionPromise.then((conn) => {
-            this._routingTable.forgetWriter(conn.url);
+            this._connectionProvider.forgetWriter(conn.url);
           }).catch(() => {/*ignore*/});
         }
         return newError('No longer possible to write to server at ' + url, SESSION_EXPIRED);
@@ -63,92 +63,9 @@ class RoutingDriver extends Driver {
     });
   }
 
-  _acquireConnection(mode) {
-    return this._freshRoutingTable().then(routingTable => {
-      if (mode === READ) {
-        return this._acquireConnectionToServer(routingTable.readers, "read");
-      } else if (mode === WRITE) {
-        return this._acquireConnectionToServer(routingTable.writers, "write");
-      } else {
-        throw newError('Illegal session mode ' + mode);
-      }
-    });
-  }
-
-  _acquireConnectionToServer(serversRoundRobinArray, serverName) {
-    const address = serversRoundRobinArray.next();
-    if (!address) {
-      return Promise.reject(newError('No ' + serverName + ' servers available', SESSION_EXPIRED));
-    }
-    return this._pool.acquire(address);
-  }
-
-  _freshRoutingTable() {
-    const currentRoutingTable = this._routingTable;
-
-    if (!currentRoutingTable.isStale()) {
-      return Promise.resolve(currentRoutingTable);
-    }
-    return this._refreshRoutingTable(currentRoutingTable);
-  }
-
-  _refreshRoutingTable(currentRoutingTable) {
-    const knownRouters = currentRoutingTable.routers.toArray();
-
-    const refreshedTablePromise = knownRouters.reduce((refreshedTablePromise, currentRouter, currentIndex) => {
-      return refreshedTablePromise.then(newRoutingTable => {
-        if (newRoutingTable) {
-          if (!newRoutingTable.writers.isEmpty()) {
-            // valid routing table was fetched - just return it, try next router otherwise
-            return newRoutingTable;
-          }
-        } else {
-          // returned routing table was undefined, this means a connection error happened and we need to forget the
-          // previous router and try the next one
-          const previousRouter = knownRouters[currentIndex - 1];
-          if (previousRouter) {
-            currentRoutingTable.forgetRouter(previousRouter);
-          }
-        }
-
-        // try next router
-        const session = this._createSessionForRediscovery(currentRouter);
-        return this._rediscovery.lookupRoutingTableOnRouter(session, currentRouter);
-      })
-    }, Promise.resolve(null));
-
-    return refreshedTablePromise.then(newRoutingTable => {
-      if (newRoutingTable && !newRoutingTable.writers.isEmpty()) {
-        this._updateRoutingTable(newRoutingTable);
-        return newRoutingTable
-      }
-      throw newError('Could not perform discovery. No routing servers available.', SERVICE_UNAVAILABLE);
-    });
-  }
-
-  _createSessionForRediscovery(routerAddress) {
-    const connection = this._pool.acquire(routerAddress);
-    const connectionPromise = Promise.resolve(connection);
-    // error transformer here is a no-op unlike the one in a regular session, this is so because errors are
-    // handled in the rediscovery promise chain and we do not need to do this in the error transformer
-    const errorTransformer = error => error;
-    return new RoutingSession(connectionPromise, errorTransformer);
-  }
-
   _forget(url) {
-    this._routingTable.forget(url);
+    this._connectionProvider.forget(url);
     this._pool.purge(url);
-  }
-
-  _updateRoutingTable(newRoutingTable) {
-    const currentRoutingTable = this._routingTable;
-
-    // close old connections to servers not present in the new routing table
-    const staleServers = currentRoutingTable.serversDiff(newRoutingTable);
-    staleServers.forEach(server => this._pool.purge(server));
-
-    // make this driver instance aware of the new table
-    this._routingTable = newRoutingTable;
   }
 
   static _validateConfig(config) {

--- a/src/v1/routing-driver.js
+++ b/src/v1/routing-driver.js
@@ -39,10 +39,10 @@ class RoutingDriver extends Driver {
     return new RoutingSession(connectionPromise, (error, conn) => {
       if (error.code === SERVICE_UNAVAILABLE || error.code === SESSION_EXPIRED) {
         if (conn) {
-          this._forget(conn.url)
+          this._connectionProvider.forget(conn.url);
         } else {
           connectionPromise.then((conn) => {
-            this._forget(conn.url);
+            this._connectionProvider.forget(conn.url);
           }).catch(() => {/*ignore*/});
         }
         return error;
@@ -61,11 +61,6 @@ class RoutingDriver extends Driver {
         return error;
       }
     });
-  }
-
-  _forget(url) {
-    this._connectionProvider.forget(url);
-    this._pool.purge(url);
   }
 
   static _validateConfig(config) {

--- a/src/v1/routing-driver.js
+++ b/src/v1/routing-driver.js
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import Session from "./session";
-import {Driver, READ, WRITE} from "./driver";
-import {newError, SERVICE_UNAVAILABLE, SESSION_EXPIRED} from "./error";
-import RoundRobinArray from "./internal/round-robin-array";
-import RoutingTable from "./internal/routing-table";
-import Rediscovery from "./internal/rediscovery";
+import Session from './session';
+import {Driver, READ, WRITE} from './driver';
+import {newError, SERVICE_UNAVAILABLE, SESSION_EXPIRED} from './error';
+import RoundRobinArray from './internal/round-robin-array';
+import RoutingTable from './internal/routing-table';
+import Rediscovery from './internal/rediscovery';
 
 /**
  * A driver that supports routing in a core-edge cluster.
@@ -35,8 +35,8 @@ class RoutingDriver extends Driver {
     this._rediscovery = new Rediscovery();
   }
 
-  _createSession(connectionPromise, cb) {
-    return new RoutingSession(connectionPromise, cb, (error, conn) => {
+  _createSession(connectionPromise) {
+    return new RoutingSession(connectionPromise, (error, conn) => {
       if (error.code === SERVICE_UNAVAILABLE || error.code === SESSION_EXPIRED) {
         if (conn) {
           this._forget(conn.url)
@@ -132,7 +132,7 @@ class RoutingDriver extends Driver {
     // error transformer here is a no-op unlike the one in a regular session, this is so because errors are
     // handled in the rediscovery promise chain and we do not need to do this in the error transformer
     const errorTransformer = error => error;
-    return new RoutingSession(connectionPromise, this._releaseConnection(connectionPromise), errorTransformer);
+    return new RoutingSession(connectionPromise, errorTransformer);
   }
 
   _forget(url) {
@@ -160,8 +160,8 @@ class RoutingDriver extends Driver {
 }
 
 class RoutingSession extends Session {
-  constructor(connectionPromise, onClose, onFailedConnection) {
-    super(connectionPromise, onClose);
+  constructor(connectionPromise, onFailedConnection) {
+    super(connectionPromise);
     this._onFailedConnection = onFailedConnection;
   }
 

--- a/test/internal/connection-providers.test.js
+++ b/test/internal/connection-providers.test.js
@@ -1,0 +1,580 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {READ, WRITE} from '../../src/v1/driver';
+import Integer, {int} from '../../src/v1/integer';
+import {SERVICE_UNAVAILABLE} from '../../src/v1/error';
+import RoutingTable from '../../src/v1/internal/routing-table';
+import RoundRobinArray from '../../src/v1/internal/round-robin-array';
+import {DirectConnectionProvider, LoadBalancer} from '../../src/v1/internal/connection-providers';
+import Pool from '../../src/v1/internal/pool';
+
+describe('DirectConnectionProvider', () => {
+
+  it('acquires connection from the pool', done => {
+    const pool = newPool();
+    const connectionProvider = new DirectConnectionProvider('localhost:123', pool);
+
+    connectionProvider.acquireConnection(READ).then(connection => {
+      expect(connection).toBeDefined();
+      expect(connection.address).toEqual('localhost:123');
+      expect(connection.release).toBeDefined();
+      expect(pool.has('localhost:123')).toBeTruthy();
+
+      done();
+    });
+  });
+
+});
+
+describe('LoadBalancer', () => {
+
+  it('can forget address', () => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-2'],
+      ['server-2', 'server-4']
+    );
+
+    loadBalancer.forget('server-2');
+
+    expectRoutingTable(loadBalancer,
+      ['server-1', 'server-2'],
+      ['server-3'],
+      ['server-4']
+    );
+  });
+
+  it('can not forget unknown address', () => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6']
+    );
+
+    loadBalancer.forget('server-42');
+
+    expectRoutingTable(loadBalancer,
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6']
+    );
+  });
+
+  it('can forget writer address', () => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-2'],
+      ['server-2', 'server-4']
+    );
+
+    loadBalancer.forgetWriter('server-2');
+
+    expectRoutingTable(loadBalancer,
+      ['server-1', 'server-2'],
+      ['server-3', 'server-2'],
+      ['server-4']
+    );
+  });
+
+  it('can not forget unknown writer address', () => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6']
+    );
+
+    loadBalancer.forgetWriter('server-42');
+
+    expectRoutingTable(loadBalancer,
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6']
+    );
+  });
+
+  it('initializes routing table with the given router', () => {
+    const loadBalancer = new LoadBalancer('server-ABC', newPool());
+
+    expectRoutingTable(loadBalancer,
+      ['server-ABC'],
+      [],
+      []
+    );
+  });
+
+  it('acquires read connection with up-to-date routing table', done => {
+    const pool = newPool();
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool
+    );
+
+    loadBalancer.acquireConnection(READ).then(connection => {
+      expect(connection.address).toEqual('server-3');
+      expect(pool.has('server-3')).toBeTruthy();
+
+      loadBalancer.acquireConnection(READ).then(connection => {
+        expect(connection.address).toEqual('server-4');
+        expect(pool.has('server-4')).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
+  it('acquires write connection with up-to-date routing table', done => {
+    const pool = newPool();
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool
+    );
+
+    loadBalancer.acquireConnection(WRITE).then(connection => {
+      expect(connection.address).toEqual('server-5');
+      expect(pool.has('server-5')).toBeTruthy();
+
+      loadBalancer.acquireConnection(WRITE).then(connection => {
+        expect(connection.address).toEqual('server-6');
+        expect(pool.has('server-6')).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
+  it('throws for illegal access mode', done => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6']
+    );
+
+    loadBalancer.acquireConnection('WRONG').catch(error => {
+      expect(error.message).toEqual('Illegal mode WRONG');
+      done();
+    });
+  });
+
+  it('refreshes stale routing table to get read connection', done => {
+    const pool = newPool();
+    const updatedRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      ['server-E', 'server-F']
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool,
+      int(0), // expired routing table
+      {'server-1': updatedRoutingTable}
+    );
+
+    loadBalancer.acquireConnection(READ).then(connection => {
+      expect(connection.address).toEqual('server-C');
+      expect(pool.has('server-C')).toBeTruthy();
+
+      loadBalancer.acquireConnection(READ).then(connection => {
+        expect(connection.address).toEqual('server-D');
+        expect(pool.has('server-D')).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
+  it('refreshes stale routing table to get write connection', done => {
+    const pool = newPool();
+    const updatedRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      ['server-E', 'server-F']
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool,
+      int(0), // expired routing table
+      {'server-1': updatedRoutingTable}
+    );
+
+    loadBalancer.acquireConnection(WRITE).then(connection => {
+      expect(connection.address).toEqual('server-E');
+      expect(pool.has('server-E')).toBeTruthy();
+
+      loadBalancer.acquireConnection(WRITE).then(connection => {
+        expect(connection.address).toEqual('server-F');
+        expect(pool.has('server-F')).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
+  it('refreshes stale routing table to get read connection when one router fails', done => {
+    const pool = newPool();
+    const updatedRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      ['server-E', 'server-F']
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool,
+      int(0), // expired routing table
+      {
+        'server-1': null, // did not return any routing table
+        'server-2': updatedRoutingTable,
+      }
+    );
+
+    loadBalancer.acquireConnection(READ).then(connection => {
+      expect(connection.address).toEqual('server-C');
+      expect(pool.has('server-C')).toBeTruthy();
+
+      loadBalancer.acquireConnection(READ).then(connection => {
+        expect(connection.address).toEqual('server-D');
+        expect(pool.has('server-D')).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
+  it('refreshes stale routing table to get write connection', done => {
+    const pool = newPool();
+    const updatedRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      ['server-E', 'server-F']
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool,
+      int(0), // expired routing table
+      {
+        'server-1': null, // did not return any routing table
+        'server-2': updatedRoutingTable,
+      }
+    );
+
+    loadBalancer.acquireConnection(WRITE).then(connection => {
+      expect(connection.address).toEqual('server-E');
+      expect(pool.has('server-E')).toBeTruthy();
+
+      loadBalancer.acquireConnection(WRITE).then(connection => {
+        expect(connection.address).toEqual('server-F');
+        expect(pool.has('server-F')).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
+  it('refreshes stale routing table to get read connection when one router returns illegal response', done => {
+    const pool = newPool();
+    const newIllegalRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      [] // no writers - table is illegal and should be skipped
+    );
+    const newLegalRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      ['server-E', 'server-F']
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool,
+      int(0), // expired routing table
+      {
+        'server-1': newIllegalRoutingTable,
+        'server-2': newLegalRoutingTable,
+      }
+    );
+
+    loadBalancer.acquireConnection(READ).then(connection => {
+      expect(connection.address).toEqual('server-C');
+      expect(pool.has('server-C')).toBeTruthy();
+
+      loadBalancer.acquireConnection(READ).then(connection => {
+        expect(connection.address).toEqual('server-D');
+        expect(pool.has('server-D')).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
+  it('refreshes stale routing table to get write connection when one router returns illegal response', done => {
+    const pool = newPool();
+    const newIllegalRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      [] // no writers - table is illegal and should be skipped
+    );
+    const newLegalRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      ['server-E', 'server-F']
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool,
+      int(0), // expired routing table
+      {
+        'server-1': newIllegalRoutingTable,
+        'server-2': newLegalRoutingTable,
+      }
+    );
+
+    loadBalancer.acquireConnection(WRITE).then(connection => {
+      expect(connection.address).toEqual('server-E');
+      expect(pool.has('server-E')).toBeTruthy();
+
+      loadBalancer.acquireConnection(WRITE).then(connection => {
+        expect(connection.address).toEqual('server-F');
+        expect(pool.has('server-F')).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
+  it('throws when all routers return nothing while getting read connection', done => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      newPool(),
+      int(0), // expired routing table
+      {
+        'server-1': null, // did not return any routing table
+        'server-2': null  // did not return any routing table
+      }
+    );
+
+    loadBalancer.acquireConnection(READ).catch(error => {
+      expect(error.code).toEqual(SERVICE_UNAVAILABLE);
+      done();
+    });
+  });
+
+  it('throws when all routers return nothing while getting write connection', done => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      newPool(),
+      int(0), // expired routing table
+      {
+        'server-1': null, // did not return any routing table
+        'server-2': null  // did not return any routing table
+      }
+    );
+
+    loadBalancer.acquireConnection(WRITE).catch(error => {
+      expect(error.code).toEqual(SERVICE_UNAVAILABLE);
+      done();
+    });
+  });
+
+  it('throws when all routers return illegal routing tables while getting read connection', done => {
+    const newIllegalRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      [] // no writers - table is illegal and should be skipped
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      newPool(),
+      int(0), // expired routing table
+      {
+        'server-1': newIllegalRoutingTable,
+        'server-2': newIllegalRoutingTable
+      }
+    );
+
+    loadBalancer.acquireConnection(READ).catch(error => {
+      expect(error.code).toEqual(SERVICE_UNAVAILABLE);
+      done();
+    });
+  });
+
+  it('throws when all routers return illegal routing tables while getting write connection', done => {
+    const newIllegalRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      [] // no writers - table is illegal and should be skipped
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      newPool(),
+      int(0), // expired routing table
+      {
+        'server-1': newIllegalRoutingTable,
+        'server-2': newIllegalRoutingTable
+      }
+    );
+
+    loadBalancer.acquireConnection(WRITE).catch(error => {
+      expect(error.code).toEqual(SERVICE_UNAVAILABLE);
+      done();
+    });
+  });
+
+  it('throws when stale routing table without routers while getting read connection', done => {
+    const loadBalancer = newLoadBalancer(
+      [], // no routers
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      newPool(),
+      int(0) // expired routing table
+    );
+
+    loadBalancer.acquireConnection(READ).catch(error => {
+      expect(error.code).toEqual(SERVICE_UNAVAILABLE);
+      done();
+    });
+  });
+
+  it('throws when stale routing table without routers while getting write connection', done => {
+    const loadBalancer = newLoadBalancer(
+      [], // no routers
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      newPool(),
+      int(0) // expired routing table
+    );
+
+    loadBalancer.acquireConnection(WRITE).catch(error => {
+      expect(error.code).toEqual(SERVICE_UNAVAILABLE);
+      done();
+    });
+  });
+
+  it('updates routing table after refresh', done => {
+    const pool = newPool();
+    const updatedRoutingTable = newRoutingTable(
+      ['server-A', 'server-B'],
+      ['server-C', 'server-D'],
+      ['server-E', 'server-F']
+    );
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool,
+      int(0), // expired routing table
+      {
+        'server-1': updatedRoutingTable
+      }
+    );
+
+    loadBalancer.acquireConnection(READ).then(() => {
+      expectRoutingTable(loadBalancer,
+        ['server-A', 'server-B'],
+        ['server-C', 'server-D'],
+        ['server-E', 'server-F']
+      );
+      expectPoolToNotContain(pool, ['server-1', 'server-2', 'server-3', 'server-4', 'server-5', 'server-6']);
+      done();
+    });
+  });
+
+});
+
+function newLoadBalancer(routers, readers, writers, pool = null, expirationTime = Integer.MAX_VALUE, routerToRoutingTable = {}) {
+  const loadBalancer = new LoadBalancer(null, pool || newPool());
+  loadBalancer._routingTable = new RoutingTable(
+    new RoundRobinArray(routers),
+    new RoundRobinArray(readers),
+    new RoundRobinArray(writers),
+    expirationTime
+  );
+  loadBalancer._rediscovery = new FakeRediscovery(routerToRoutingTable);
+  return loadBalancer;
+}
+
+function newRoutingTable(routers, readers, writers, expirationTime = Integer.MAX_VALUE) {
+  return new RoutingTable(
+    new RoundRobinArray(routers),
+    new RoundRobinArray(readers),
+    new RoundRobinArray(writers),
+    expirationTime
+  );
+}
+
+function newPool() {
+  return new Pool(FakeConnection.create);
+}
+
+function expectRoutingTable(loadBalancer, routers, readers, writers) {
+  expect(loadBalancer._routingTable.routers.toArray()).toEqual(routers);
+  expect(loadBalancer._routingTable.readers.toArray()).toEqual(readers);
+  expect(loadBalancer._routingTable.writers.toArray()).toEqual(writers);
+}
+
+function expectPoolToNotContain(pool, addresses) {
+  addresses.forEach(address => {
+    expect(pool.has(address)).toBeFalsy();
+  });
+}
+
+class FakeConnection {
+
+  constructor(address, release) {
+    this.address = address;
+    this.release = release;
+  }
+
+  static create(address, release) {
+    return new FakeConnection(address, release);
+  }
+}
+
+class FakeRediscovery {
+
+  constructor(routerToRoutingTable) {
+    this._routerToRoutingTable = routerToRoutingTable;
+  }
+
+  lookupRoutingTableOnRouter(ignored, router) {
+    return this._routerToRoutingTable[router];
+  }
+}

--- a/test/internal/connection-providers.test.js
+++ b/test/internal/connection-providers.test.js
@@ -539,6 +539,46 @@ describe('LoadBalancer', () => {
     });
   });
 
+  it('forgets all routers when they fail while acquiring read connection', done => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2', 'server-3'],
+      ['server-4', 'server-5'],
+      ['server-6', 'server-7'],
+      newPool(),
+      int(0) // expired routing table
+    );
+
+    loadBalancer.acquireConnection(READ).catch(error => {
+      expect(error.code).toEqual(SERVICE_UNAVAILABLE);
+      expectRoutingTable(loadBalancer,
+        [],
+        ['server-4', 'server-5'],
+        ['server-6', 'server-7']
+      );
+      done();
+    });
+  });
+
+  it('forgets all routers when they fail while acquiring write connection', done => {
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2', 'server-3'],
+      ['server-4', 'server-5'],
+      ['server-6', 'server-7'],
+      newPool(),
+      int(0) // expired routing table
+    );
+
+    loadBalancer.acquireConnection(WRITE).catch(error => {
+      expect(error.code).toEqual(SERVICE_UNAVAILABLE);
+      expectRoutingTable(loadBalancer,
+        [],
+        ['server-4', 'server-5'],
+        ['server-6', 'server-7']
+      );
+      done();
+    });
+  });
+
 });
 
 function newLoadBalancer(routers, readers, writers, pool = null, expirationTime = Integer.MAX_VALUE, routerToRoutingTable = {}) {


### PR DESCRIPTION
Simplified connection release when closing session and pulled routing table handling out of the routing driver to a separate class - `LoadBalancer`.

Fixes #205 