### PR TITLE
Allow initial bookmark in session

### DIFF
--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -108,12 +108,14 @@ class Driver {
    * it is returned to the pool, the session will be reset to a clean state and
    * made available for others to use.
    *
-   * @param {String} mode of session - optional
+   * @param {string} [mode=WRITE] the access mode of this session, allowed values are {@link READ} and {@link WRITE}.
+   * @param {string} [bookmark=null] the initial reference to some previous transaction. Value is optional and
+   * absence indicates that that the bookmark does not exist or is unknown.
    * @return {Session} new session.
    */
-  session(mode) {
+  session(mode, bookmark) {
     const sessionMode = Driver._validateSessionMode(mode);
-    return this._createSession(sessionMode, this._connectionProvider);
+    return this._createSession(sessionMode, this._connectionProvider, bookmark);
   }
 
   static _validateSessionMode(rawMode) {
@@ -130,8 +132,8 @@ class Driver {
   }
 
   //Extension point
-  _createSession(mode, connectionProvider) {
-    return new Session(mode, connectionProvider);
+  _createSession(mode, connectionProvider, bookmark) {
+    return new Session(mode, connectionProvider, bookmark);
   }
 
   _driverOnErrorCallback(error) {

--- a/src/v1/internal/connection-holder.js
+++ b/src/v1/internal/connection-holder.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {newError} from '../error';
+
+/**
+ * Utility to lazily initialize connections and return them back to the pool when unused.
+ */
+export default class ConnectionHolder {
+
+  /**
+   * @constructor
+   * @param {string} mode - the access mode for new connection holder.
+   * @param {ConnectionProvider} connectionProvider - the connection provider to acquire connections from.
+   */
+  constructor(mode, connectionProvider) {
+    this._mode = mode;
+    this._connectionProvider = connectionProvider;
+    this._referenceCount = 0;
+    this._connectionPromise = Promise.resolve(null);
+  }
+
+  /**
+   * Make this holder initialize new connection if none exists already.
+   * @return {undefined}
+   */
+  initializeConnection() {
+    if (this._referenceCount === 0) {
+      this._connectionPromise = this._connectionProvider.acquireConnection(this._mode);
+    }
+    this._referenceCount++;
+  }
+
+  /**
+   * Get the current connection promise.
+   * @return {Promise<Connection>} promise resolved with the current connection.
+   */
+  getConnection() {
+    return this._connectionPromise;
+  }
+
+  /**
+   * Notify this holder that single party does not require current connection any more.
+   * @return {Promise<Connection>} promise resolved with the current connection.
+   */
+  releaseConnection() {
+    if (this._referenceCount === 0) {
+      return this._connectionPromise;
+    }
+
+    this._referenceCount--;
+    if (this._referenceCount === 0) {
+      // release a connection without muting ACK_FAILURE, this is the last action on this connection
+      return this._releaseConnection(true);
+    }
+    return this._connectionPromise;
+  }
+
+  /**
+   * Closes this holder and releases current connection (if any) despite any existing users.
+   * @return {Promise<Connection>} promise resolved when current connection is released to the pool.
+   */
+  close() {
+    if (this._referenceCount === 0) {
+      return this._connectionPromise;
+    }
+    this._referenceCount = 0;
+    // release a connection and mute ACK_FAILURE, this might be called concurrently with other
+    // operations and thus should ignore failure handling
+    return this._releaseConnection(false);
+  }
+
+  /**
+   * Return the current pooled connection instance to the connection pool.
+   * We don't pool Session instances, to avoid users using the Session after they've called close.
+   * The `Session` object is just a thin wrapper around Connection anyway, so it makes little difference.
+   * @return {Promise} - promise resolved then connection is returned to the pool.
+   * @private
+   */
+  _releaseConnection(sync) {
+    this._connectionPromise = this._connectionPromise.then(connection => {
+      if (connection) {
+        if(sync) {
+          connection.reset();
+        } else {
+          connection.resetAsync();
+        }
+        connection.sync();
+        connection._release();
+      }
+    }).catch(ignoredError => {
+    });
+
+    return this._connectionPromise;
+  }
+}
+
+class EmptyConnectionHolder extends ConnectionHolder {
+
+  initializeConnection() {
+    // nothing to initialize
+  }
+
+  getConnection() {
+    return Promise.reject(newError('This connection holder does not serve connections'));
+  }
+
+  releaseConnection() {
+    return Promise.resolve();
+  }
+
+  close() {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Connection holder that does not manage any connections.
+ * @type {ConnectionHolder}
+ */
+export const EMPTY_CONNECTION_HOLDER = new EmptyConnectionHolder();

--- a/src/v1/internal/connection-providers.js
+++ b/src/v1/internal/connection-providers.js
@@ -33,7 +33,9 @@ class ConnectionProvider {
   _withAdditionalOnErrorCallback(connectionPromise, driverOnErrorCallback) {
     // install error handler from the driver on the connection promise; this callback is installed separately
     // so that it does not handle errors, instead it is just an additional error reporting facility.
-    connectionPromise.catch(error => driverOnErrorCallback(error));
+    connectionPromise.catch(error => {
+      driverOnErrorCallback(error)
+    });
     // return the original connection promise
     return connectionPromise;
   }
@@ -49,7 +51,8 @@ export class DirectConnectionProvider extends ConnectionProvider {
   }
 
   acquireConnection(mode) {
-    const connectionPromise = Promise.resolve(this._connectionPool.acquire(this._address));
+    const connection = this._connectionPool.acquire(this._address);
+    const connectionPromise = Promise.resolve(connection);
     return this._withAdditionalOnErrorCallback(connectionPromise, this._driverOnErrorCallback);
   }
 }

--- a/src/v1/internal/connection-providers.js
+++ b/src/v1/internal/connection-providers.js
@@ -29,32 +29,43 @@ class ConnectionProvider {
   acquireConnection(mode) {
     throw new Error('Abstract method');
   }
+
+  _withAdditionalOnErrorCallback(connectionPromise, driverOnErrorCallback) {
+    // install error handler from the driver on the connection promise; this callback is installed separately
+    // so that it does not handle errors, instead it is just an additional error reporting facility.
+    connectionPromise.catch(error => driverOnErrorCallback(error));
+    // return the original connection promise
+    return connectionPromise;
+  }
 }
 
 export class DirectConnectionProvider extends ConnectionProvider {
 
-  constructor(address, connectionPool) {
+  constructor(address, connectionPool, driverOnErrorCallback) {
     super();
     this._address = address;
     this._connectionPool = connectionPool;
+    this._driverOnErrorCallback = driverOnErrorCallback;
   }
 
   acquireConnection(mode) {
-    return Promise.resolve(this._connectionPool.acquire(this._address));
+    const connectionPromise = Promise.resolve(this._connectionPool.acquire(this._address));
+    return this._withAdditionalOnErrorCallback(connectionPromise, this._driverOnErrorCallback);
   }
 }
 
 export class LoadBalancer extends ConnectionProvider {
 
-  constructor(address, connectionPool) {
+  constructor(address, connectionPool, driverOnErrorCallback) {
     super();
     this._routingTable = new RoutingTable(new RoundRobinArray([address]));
     this._rediscovery = new Rediscovery();
     this._connectionPool = connectionPool;
+    this._driverOnErrorCallback = driverOnErrorCallback;
   }
 
   acquireConnection(mode) {
-    return this._freshRoutingTable().then(routingTable => {
+    const connectionPromise = this._freshRoutingTable().then(routingTable => {
       if (mode === READ) {
         return this._acquireConnectionToServer(routingTable.readers, 'read');
       } else if (mode === WRITE) {
@@ -63,6 +74,7 @@ export class LoadBalancer extends ConnectionProvider {
         throw newError('Illegal mode ' + mode);
       }
     });
+    return this._withAdditionalOnErrorCallback(connectionPromise, this._driverOnErrorCallback);
   }
 
   forget(address) {
@@ -132,7 +144,8 @@ export class LoadBalancer extends ConnectionProvider {
   _createSessionForRediscovery(routerAddress) {
     const connection = this._connectionPool.acquire(routerAddress);
     const connectionPromise = Promise.resolve(connection);
-    return new Session(connectionPromise);
+    const connectionProvider = new SingleConnectionProvider(connectionPromise);
+    return new Session(READ, connectionProvider);
   }
 
   _updateRoutingTable(newRoutingTable) {
@@ -151,5 +164,19 @@ export class LoadBalancer extends ConnectionProvider {
     if (address) {
       routingTable.forgetRouter(address);
     }
+  }
+}
+
+export class SingleConnectionProvider extends ConnectionProvider {
+
+  constructor(connectionPromise) {
+    super();
+    this._connectionPromise = connectionPromise;
+  }
+
+  acquireConnection(mode) {
+    const connectionPromise = this._connectionPromise;
+    this._connectionPromise = null;
+    return connectionPromise;
   }
 }

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -96,7 +96,6 @@ function log(actor, msg) {
   }
 }
 
-
 function NO_OP(){}
 
 let NO_OP_OBSERVER = {
@@ -384,9 +383,9 @@ class Connection {
     this._chunker.messageBoundary();
   }
 
-  /** Queue a RESET-message to be sent to the database */
-  reset( observer ) {
-    log("C", "RESET");
+  /** Queue a RESET-message to be sent to the database. Mutes failure handling. */
+  resetAsync( observer ) {
+    log("C", "RESET_ASYNC");
     this._isHandlingFailure = true;
     let self = this;
     let wrappedObs = {
@@ -401,6 +400,14 @@ class Connection {
     };
     this._queueObserver(wrappedObs);
     this._packer.packStruct( RESET, [], (err) => this._handleFatalError(err) );
+    this._chunker.messageBoundary();
+  }
+
+  /** Queue a RESET-message to be sent to the database */
+  reset(observer) {
+    log('C', 'RESET');
+    this._queueObserver(observer);
+    this._packer.packStruct(RESET, [], (err) => this._handleFatalError(err));
     this._chunker.messageBoundary();
   }
 

--- a/src/v1/internal/get-servers-util.js
+++ b/src/v1/internal/get-servers-util.js
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-import RoundRobinArray from "./round-robin-array";
-import {newError, PROTOCOL_ERROR, SERVICE_UNAVAILABLE} from "../error";
-import Integer, {int} from "../integer";
+import RoundRobinArray from './round-robin-array';
+import {newError, PROTOCOL_ERROR, SERVICE_UNAVAILABLE} from '../error';
+import Integer, {int} from '../integer';
 
 const PROCEDURE_CALL = 'CALL dbms.cluster.routing.getServers';
 const PROCEDURE_NOT_FOUND_CODE = 'Neo.ClientError.Procedure.ProcedureNotFound';

--- a/src/v1/routing-driver.js
+++ b/src/v1/routing-driver.js
@@ -35,8 +35,8 @@ class RoutingDriver extends Driver {
     return new LoadBalancer(address, connectionPool, driverOnErrorCallback);
   }
 
-  _createSession(mode, connectionProvider) {
-    return new RoutingSession(mode, connectionProvider, (error, conn) => {
+  _createSession(mode, connectionProvider, bookmark) {
+    return new RoutingSession(mode, connectionProvider, bookmark, (error, conn) => {
       if (error.code === SERVICE_UNAVAILABLE || error.code === SESSION_EXPIRED) {
         // connection is undefined if error happened before connection was acquired
         if (conn) {
@@ -66,8 +66,8 @@ class RoutingDriver extends Driver {
 }
 
 class RoutingSession extends Session {
-  constructor(mode, connectionProvider, onFailedConnection) {
-    super(mode, connectionProvider);
+  constructor(mode, connectionProvider, bookmark, onFailedConnection) {
+    super(mode, connectionProvider, bookmark);
     this._onFailedConnection = onFailedConnection;
   }
 

--- a/src/v1/session.js
+++ b/src/v1/session.js
@@ -31,10 +31,12 @@ import {assertString} from './internal/util';
 class Session {
   /**
    * @constructor
-   * @param {Promise.<Connection>} connectionPromise - Promise of a connection to use
+   * todo: doc params
    */
-  constructor(connectionPromise) {
-    this._connectionPromise = connectionPromise;
+  constructor(mode, connectionProvider) {
+    this._mode = mode;
+    this._connectionProvider = connectionProvider;
+    this._connectionPromise = this._connectionProvider.acquireConnection(this._mode);
     this._open = true;
     this._hasTx = false;
   }

--- a/test/internal/connection-holder.test.js
+++ b/test/internal/connection-holder.test.js
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ConnectionHolder, {EMPTY_CONNECTION_HOLDER} from '../../src/v1/internal/connection-holder';
+import {SingleConnectionProvider} from '../../src/v1/internal/connection-providers';
+import {READ} from '../../src/v1/driver';
+import FakeConnection from './fake-connection';
+
+describe('EmptyConnectionHolder', () => {
+
+  it('should return rejected promise instead of connection', done => {
+    EMPTY_CONNECTION_HOLDER.getConnection().catch(() => {
+      done();
+    });
+  });
+
+  it('should return resolved promise on release', done => {
+    EMPTY_CONNECTION_HOLDER.releaseConnection().then(() => {
+      done();
+    });
+  });
+
+  it('should return resolved promise on close', done => {
+    EMPTY_CONNECTION_HOLDER.close().then(() => {
+      done();
+    });
+  });
+
+});
+
+describe('ConnectionHolder', () => {
+
+  it('should acquire new connection during initialization', () => {
+    const connectionProvider = new RecordingConnectionProvider([new FakeConnection()]);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.initializeConnection();
+
+    expect(connectionProvider.acquireConnectionInvoked).toBe(1);
+  });
+
+  it('should return acquired during initialization connection', done => {
+    const connection = new FakeConnection();
+    const connectionProvider = newSingleConnectionProvider(connection);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.initializeConnection();
+
+    connectionHolder.getConnection().then(connection => {
+      expect(connection).toBe(connection);
+      done();
+    });
+  });
+
+  it('should release connection with single user', done => {
+    const connection = new FakeConnection();
+    const connectionProvider = newSingleConnectionProvider(connection);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.initializeConnection();
+
+    connectionHolder.releaseConnection().then(() => {
+      expect(connection.isReleasedOnce()).toBeTruthy();
+      done();
+    });
+  });
+
+  it('should not release connection with multiple users', done => {
+    const connection = new FakeConnection();
+    const connectionProvider = newSingleConnectionProvider(connection);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.initializeConnection();
+    connectionHolder.initializeConnection();
+    connectionHolder.initializeConnection();
+
+    connectionHolder.releaseConnection().then(() => {
+      expect(connection.isNeverReleased()).toBeTruthy();
+      done();
+    });
+  });
+
+  it('should release connection with multiple users when all users release', done => {
+    const connection = new FakeConnection();
+    const connectionProvider = newSingleConnectionProvider(connection);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.initializeConnection();
+    connectionHolder.initializeConnection();
+    connectionHolder.initializeConnection();
+
+    connectionHolder.releaseConnection().then(() => {
+      connectionHolder.releaseConnection().then(() => {
+        connectionHolder.releaseConnection().then(() => {
+          expect(connection.isReleasedOnce()).toBeTruthy();
+          done();
+        });
+      });
+    });
+  });
+
+  it('should do nothing when closed and not initialized', done => {
+    const connection = new FakeConnection();
+    const connectionProvider = newSingleConnectionProvider(connection);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.close().then(() => {
+      expect(connection.isNeverReleased()).toBeTruthy();
+      done();
+    });
+  });
+
+  it('should close even when users exist', done => {
+    const connection = new FakeConnection();
+    const connectionProvider = newSingleConnectionProvider(connection);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.initializeConnection();
+    connectionHolder.initializeConnection();
+
+    connectionHolder.close().then(() => {
+      expect(connection.isReleasedOnceOnSessionClose()).toBeTruthy();
+      done();
+    });
+  });
+
+  it('should initialize new connection after releasing current one', done => {
+    const connection1 = new FakeConnection();
+    const connection2 = new FakeConnection();
+    const connectionProvider = new RecordingConnectionProvider([connection1, connection2]);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.initializeConnection();
+
+    connectionHolder.releaseConnection().then(() => {
+      expect(connection1.isReleasedOnce()).toBeTruthy();
+
+      connectionHolder.initializeConnection();
+      connectionHolder.releaseConnection().then(() => {
+        expect(connection2.isReleasedOnce()).toBeTruthy();
+        done();
+      });
+    });
+  });
+
+  it('should initialize new connection after being closed', done => {
+    const connection1 = new FakeConnection();
+    const connection2 = new FakeConnection();
+    const connectionProvider = new RecordingConnectionProvider([connection1, connection2]);
+    const connectionHolder = new ConnectionHolder(READ, connectionProvider);
+
+    connectionHolder.initializeConnection();
+
+    connectionHolder.close().then(() => {
+      expect(connection1.isReleasedOnceOnSessionClose()).toBeTruthy();
+
+      connectionHolder.initializeConnection();
+      connectionHolder.close().then(() => {
+        expect(connection2.isReleasedOnceOnSessionClose()).toBeTruthy();
+        done();
+      });
+    });
+  });
+});
+
+class RecordingConnectionProvider extends SingleConnectionProvider {
+
+  constructor(connections) {
+    super(Promise.resolve());
+    this.connectionPromises = connections.map(conn => Promise.resolve(conn));
+    this.acquireConnectionInvoked = 0;
+  }
+
+  acquireConnection(mode) {
+    return this.connectionPromises[this.acquireConnectionInvoked++];
+  }
+}
+
+function newSingleConnectionProvider(connection) {
+  return new SingleConnectionProvider(Promise.resolve(connection));
+}

--- a/test/internal/connection-providers.test.js
+++ b/test/internal/connection-providers.test.js
@@ -25,11 +25,14 @@ import RoundRobinArray from '../../src/v1/internal/round-robin-array';
 import {DirectConnectionProvider, LoadBalancer} from '../../src/v1/internal/connection-providers';
 import Pool from '../../src/v1/internal/pool';
 
+const NO_OP_DRIVER_CALLBACK = () => {
+};
+
 describe('DirectConnectionProvider', () => {
 
   it('acquires connection from the pool', done => {
     const pool = newPool();
-    const connectionProvider = new DirectConnectionProvider('localhost:123', pool);
+    const connectionProvider = newDirectConnectionProvider('localhost:123', pool);
 
     connectionProvider.acquireConnection(READ).then(connection => {
       expect(connection).toBeDefined();
@@ -132,7 +135,7 @@ describe('LoadBalancer', () => {
   });
 
   it('initializes routing table with the given router', () => {
-    const loadBalancer = new LoadBalancer('server-ABC', newPool());
+    const loadBalancer = new LoadBalancer('server-ABC', newPool(), NO_OP_DRIVER_CALLBACK);
 
     expectRoutingTable(loadBalancer,
       ['server-ABC'],
@@ -581,8 +584,12 @@ describe('LoadBalancer', () => {
 
 });
 
+function newDirectConnectionProvider(address, pool) {
+  return new DirectConnectionProvider(address, pool, NO_OP_DRIVER_CALLBACK);
+}
+
 function newLoadBalancer(routers, readers, writers, pool = null, expirationTime = Integer.MAX_VALUE, routerToRoutingTable = {}) {
-  const loadBalancer = new LoadBalancer(null, pool || newPool());
+  const loadBalancer = new LoadBalancer(null, pool || newPool(), NO_OP_DRIVER_CALLBACK);
   loadBalancer._routingTable = new RoutingTable(
     new RoundRobinArray(routers),
     new RoundRobinArray(readers),

--- a/test/internal/fake-connection.js
+++ b/test/internal/fake-connection.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class is like a mock of {@link Connection} that tracks invocations count.
+ * It tries to maintain same "interface" as {@link Connection}.
+ * It could be replaced with a proper mock by a library like testdouble.
+ * At the time of writing such libraries require {@link Proxy} support but browser tests execute in
+ * PhantomJS which does not support proxies.
+ */
+export default class FakeConnection {
+
+  constructor() {
+    this.resetInvoked = 0;
+    this.resetAsyncInvoked = 0;
+    this.syncInvoked = 0;
+    this.releaseInvoked = 0;
+  }
+
+  run() {
+  }
+
+  discardAll() {
+  }
+
+  reset() {
+    this.resetInvoked++;
+  }
+
+  resetAsync() {
+    this.resetAsyncInvoked++;
+  }
+
+  sync() {
+    this.syncInvoked++;
+  }
+
+  _release() {
+    this.releaseInvoked++;
+  }
+
+  isReleasedOnceOnSessionClose() {
+    return this.isReleasedOnSessionCloseTimes(1);
+  }
+
+  isReleasedOnSessionCloseTimes(times) {
+    return this.resetAsyncInvoked === times &&
+      this.resetInvoked === 0 &&
+      this.syncInvoked === times &&
+      this.releaseInvoked === times;
+  }
+
+  isNeverReleased() {
+    return this.isReleasedTimes(0);
+  }
+
+  isReleasedOnce() {
+    return this.isReleasedTimes(1);
+  }
+
+  isReleasedTimes(times) {
+    return this.resetAsyncInvoked === 0 &&
+      this.resetInvoked === times &&
+      this.syncInvoked === times &&
+      this.releaseInvoked === times;
+  }
+};

--- a/test/internal/tls.test.js
+++ b/test/internal/tls.test.js
@@ -269,7 +269,9 @@ describe('trust-on-first-use', function() {
       knownHosts: knownHostsPath
     });
 
-    driver.session(); // write into the knownHost file
+    // create session and transaction to force creation of new connection and writing into the knownHost file
+    const session = driver.session();
+    expect(session.beginTransaction()).toBeDefined();
 
     // duplicate the same serverId twice
     setTimeout(function() {

--- a/test/resources/boltkit/acquire_endpoints_with_one_of_each.script
+++ b/test/resources/boltkit/acquire_endpoints_with_one_of_each.script
@@ -1,0 +1,9 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"], "role": "ROUTE"}]]
+   SUCCESS {}

--- a/test/resources/boltkit/read_tx_with_bookmarks.script
+++ b/test/resources/boltkit/read_tx_with_bookmarks.script
@@ -1,0 +1,18 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "BEGIN" {"bookmark": "OldBookmark"}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   SUCCESS {"bookmark": "NewBookmark"}
+C: RUN "COMMIT" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}

--- a/test/resources/boltkit/write_read_tx_with_bookmark_override.script.mst
+++ b/test/resources/boltkit/write_read_tx_with_bookmark_override.script.mst
@@ -1,0 +1,30 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "BEGIN" {"bookmark": "BookmarkA"}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "CREATE (n {name:'Bob'})" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {"bookmark": "BookmarkB"}
+C: RUN "COMMIT" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "BEGIN" {{{bookmarkOverride}}}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Bob"]
+   SUCCESS {"bookmark": "BookmarkC"}
+C: RUN "COMMIT" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+

--- a/test/resources/boltkit/write_read_tx_with_bookmarks.script
+++ b/test/resources/boltkit/write_read_tx_with_bookmarks.script
@@ -1,0 +1,30 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "BEGIN" {"bookmark": "BookmarkA"}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "CREATE (n {name:'Bob'})" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {"bookmark": "BookmarkB"}
+C: RUN "COMMIT" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "BEGIN" {"bookmark": "BookmarkB"}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Bob"]
+   SUCCESS {"bookmark": "BookmarkC"}
+C: RUN "COMMIT" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+

--- a/test/resources/boltkit/write_tx_with_bookmarks.script
+++ b/test/resources/boltkit/write_tx_with_bookmarks.script
@@ -1,0 +1,16 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "BEGIN" {"bookmark": "OldBookmark"}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "CREATE (n {name:'Bob'})" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {"bookmark": "NewBookmark"}
+C: RUN "COMMIT" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}

--- a/test/v1/driver.test.js
+++ b/test/v1/driver.test.js
@@ -53,7 +53,7 @@ describe('driver', function() {
     };
 
     // When
-    driver.session();
+    startNewTransaction(driver);
   });
 
   it('should handle wrong scheme', () => {
@@ -84,7 +84,7 @@ describe('driver', function() {
     };
 
     // When
-    driver.session();
+    startNewTransaction(driver);
   });
 
   it('should indicate success early on correct credentials', function(done) {
@@ -97,7 +97,7 @@ describe('driver', function() {
     };
 
     // When
-    driver.session();
+    startNewTransaction(driver);
   });
 
   it('should be possible to pass a realm with basic auth tokens', function(done) {
@@ -110,7 +110,7 @@ describe('driver', function() {
     };
 
     // When
-    driver.session();
+    startNewTransaction(driver);
   });
 
   it('should be possible to create custom auth tokens', function(done) {
@@ -123,7 +123,7 @@ describe('driver', function() {
     };
 
     // When
-    driver.session();
+    startNewTransaction(driver);
   });
 
   it('should be possible to create custom auth tokens with additional parameters', function(done) {
@@ -136,7 +136,7 @@ describe('driver', function() {
     };
 
     // When
-    driver.session();
+    startNewTransaction(driver);
   });
 
   it('should fail nicely when connecting with routing to standalone server', done => {
@@ -151,7 +151,7 @@ describe('driver', function() {
     };
 
     // When
-    driver.session();
+    startNewTransaction(driver);
   });
 
   it('should have correct user agent', () => {
@@ -191,5 +191,14 @@ describe('driver', function() {
       expect(undefined === neo4j.types[type]).toBe(false);
     });
   });
+
+  /**
+   * Starts new transaction to force new network connection.
+   * @param {Driver} driver - the driver to use.
+   */
+  function startNewTransaction(driver) {
+    const session = driver.session();
+    expect(session.beginTransaction()).toBeDefined();
+  }
 
 });

--- a/test/v1/routing.driver.boltkit.it.js
+++ b/test/v1/routing.driver.boltkit.it.js
@@ -939,11 +939,10 @@ describe('routing driver', () => {
             for (let i = 0; i < acquiredConnections.length; i++) {
               expect(acquiredConnections[i]).toBe(releasedConnections[i]);
             }
-
             done();
           });
         });
-      });
+      }).catch(console.log);
     });
   });
 

--- a/test/v1/tck/steps/erroreportingsteps.js
+++ b/test/v1/tck/steps/erroreportingsteps.js
@@ -65,7 +65,7 @@ module.exports = function () {
     var self = this;
     var driver = neo4j.driver("bolt://localhost:7777", neo4j.auth.basic("neo4j", "neo4j"));
     driver.onError = function (error) { self.error = error; callback()};
-    driver.session();
+    driver.session().beginTransaction();
     setTimeout(callback, 1000);
   });
 


### PR DESCRIPTION
Based on https://github.com/neo4j/neo4j-javascript-driver/pull/215. Only last commit is new.

Commit adds second parameter `bookmark` to the existing `Driver#session(accessMode)` API function to allow creation of a session with the specified initial bookmark. This means that first transaction in the created session will ensure that the server, it is connected to, is at least up to the database version denoted by the bookmark.

Bookmark is a session related concept and this commit adds symmetry with regards to `Session#lastBookmark()` method.