### PR TITLE
Ignore null bookmarks in transaction

### DIFF
--- a/src/v1/session.js
+++ b/src/v1/session.js
@@ -86,7 +86,7 @@ class Session {
    *
    * While a transaction is open the session cannot be used to run statements outside the transaction.
    *
-   * @param {string} bookmark - a reference to a previous transaction. DEPRECATED: This function is deprecated in
+   * @param {string} bookmark - a reference to a previous transaction. DEPRECATED: This parameter is deprecated in
    * favour of {@link Driver#session(string)} that accepts an initial bookmark. Session will ensure that all nested
    * transactions are chained with bookmarks to guarantee causal consistency.
    * @returns {Transaction} - New Transaction
@@ -94,9 +94,7 @@ class Session {
   beginTransaction(bookmark) {
     if (bookmark) {
       assertString(bookmark, 'Bookmark');
-    }
-    if (typeof bookmark !== 'undefined') {
-      this._lastBookmark = bookmark;
+      this._updateBookmark(bookmark);
     }
 
     if (this._hasTx) {

--- a/test/resources/boltkit/write_read_tx_with_bookmark_override.script
+++ b/test/resources/boltkit/write_read_tx_with_bookmark_override.script
@@ -14,7 +14,7 @@ C: RUN "COMMIT" {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "BEGIN" {{{bookmarkOverride}}}
+C: RUN "BEGIN" {"bookmark": "BookmarkOverride"}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}


### PR DESCRIPTION
This PR makes `Session#beginTransaction(bookmark)` ignore `null` bookmark argument. Previously only `undefined` value was ignored and `null` was allowed to give ability to "break" the causal consistency chain. This makes it easier to reason about non-defined parameters. If "breaking" of the consistency chain is required then separate session should be used. Values `null` & `undefined` will result in session using it's known last bookmark for the next transaction.