### PR TITLE
Add transaction with retries API

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -164,23 +164,17 @@ gulp.task('test', function(cb){
 
 gulp.task('test-nodejs', ['install-driver-into-sandbox'], function () {
   return gulp.src('test/**/*.test.js')
-        .pipe(jasmine({
-            // reporter: new reporters.JUnitXmlReporter({
-            //   savePath: "build/nodejs-test-reports",
-            //   consolidateAll: false
-            // }),
-            includeStackTrace: true
-        }));
+    .pipe(jasmine({
+      includeStackTrace: true,
+      verbose: true
+    }));
 });
 
 gulp.task('test-boltkit', ['nodejs'], function () {
   return gulp.src('test/**/*.boltkit.it.js')
     .pipe(jasmine({
-      // reporter: new reporters.JUnitXmlReporter({
-      //   savePath: "build/nodejs-test-reports",
-      //   consolidateAll: false
-      // }),
-      includeStackTrace: true
+      includeStackTrace: true,
+      verbose: true
     }));
 });
 

--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -115,7 +115,7 @@ class Driver {
    */
   session(mode, bookmark) {
     const sessionMode = Driver._validateSessionMode(mode);
-    return this._createSession(sessionMode, this._connectionProvider, bookmark);
+    return this._createSession(sessionMode, this._connectionProvider, bookmark, this._config);
   }
 
   static _validateSessionMode(rawMode) {
@@ -132,8 +132,8 @@ class Driver {
   }
 
   //Extension point
-  _createSession(mode, connectionProvider, bookmark) {
-    return new Session(mode, connectionProvider, bookmark);
+  _createSession(mode, connectionProvider, bookmark, config) {
+    return new Session(mode, connectionProvider, bookmark, config);
   }
 
   _driverOnErrorCallback(error) {

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -100,6 +100,16 @@ let USER_AGENT = "neo4j-javascript/" + VERSION;
  *       // port, and this is then used to verify the host certificate does not change.
  *       // This setting has no effect unless TRUST_ON_FIRST_USE is enabled.
  *       knownHosts:"~/.neo4j/known_hosts",
+ *
+ *       // The max number of connections that are allowed idle in the pool at any time.
+ *       // Connection will be destroyed if this threshold is exceeded.
+ *       connectionPoolSize: 50,
+ *
+ *       // Specify the maximum time in milliseconds transactions are allowed to retry via
+ *       // {@link Session#readTransaction()} and {@link Session#writeTransaction()} functions. These functions
+ *       // will retry the given unit of work on `ServiceUnavailable`, `SessionExpired` and transient errors with
+ *       // exponential backoff using initial delay of 1 second. Default value is 30000 which is 30 seconds.
+ *       maxTransactionRetryTime: 30000,
  *     }
  *
  * @param {string} url The URL for the Neo4j database, for instance "bolt://localhost"

--- a/src/v1/internal/transaction-executor.js
+++ b/src/v1/internal/transaction-executor.js
@@ -27,10 +27,10 @@ const DEFAULT_RETRY_DELAY_JITTER_FACTOR = 0.2;
 export default class TransactionExecutor {
 
   constructor(maxRetryTimeMs, initialRetryDelayMs, multiplier, jitterFactor) {
-    this._maxRetryTimeMs = maxRetryTimeMs || DEFAULT_MAX_RETRY_TIME_MS;
-    this._initialRetryDelayMs = initialRetryDelayMs || DEFAULT_INITIAL_RETRY_DELAY_MS;
-    this._multiplier = multiplier || DEFAULT_RETRY_DELAY_MULTIPLIER;
-    this._jitterFactor = jitterFactor || DEFAULT_RETRY_DELAY_JITTER_FACTOR;
+    this._maxRetryTimeMs = _valueOrDefault(maxRetryTimeMs, DEFAULT_MAX_RETRY_TIME_MS);
+    this._initialRetryDelayMs = _valueOrDefault(initialRetryDelayMs, DEFAULT_INITIAL_RETRY_DELAY_MS);
+    this._multiplier = _valueOrDefault(multiplier, DEFAULT_RETRY_DELAY_MULTIPLIER);
+    this._jitterFactor = _valueOrDefault(jitterFactor, DEFAULT_RETRY_DELAY_JITTER_FACTOR);
 
     this._inFlightTimeoutIds = [];
 
@@ -140,3 +140,10 @@ export default class TransactionExecutor {
     }
   }
 };
+
+function _valueOrDefault(value, defaultValue) {
+  if (value || value === 0) {
+    return value;
+  }
+  return defaultValue;
+}

--- a/src/v1/internal/transaction-executor.js
+++ b/src/v1/internal/transaction-executor.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {newError, SERVICE_UNAVAILABLE, SESSION_EXPIRED} from '../error';
+
+const DEFAULT_MAX_RETRY_TIME_MS = 30 * 1000; // 30 seconds
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 1000; // 1 seconds
+const DEFAULT_RETRY_DELAY_MULTIPLIER = 2.0;
+const DEFAULT_RETRY_DELAY_JITTER_FACTOR = 0.2;
+
+export default class TransactionExecutor {
+
+  constructor(maxRetryTimeMs, initialRetryDelayMs, multiplier, jitterFactor) {
+    this._maxRetryTimeMs = maxRetryTimeMs || DEFAULT_MAX_RETRY_TIME_MS;
+    this._initialRetryDelayMs = initialRetryDelayMs || DEFAULT_INITIAL_RETRY_DELAY_MS;
+    this._multiplier = multiplier || DEFAULT_RETRY_DELAY_MULTIPLIER;
+    this._jitterFactor = jitterFactor || DEFAULT_RETRY_DELAY_JITTER_FACTOR;
+
+    this._inFlightTimeoutIds = [];
+
+    this._verifyAfterConstruction();
+  }
+
+  execute(transactionCreator, transactionWork) {
+    return new Promise((resolve, reject) => {
+      this._executeTransactionInsidePromise(transactionCreator, transactionWork, resolve, reject);
+    }).catch(error => {
+      const retryStartTimeMs = Date.now();
+      const retryDelayMs = this._initialRetryDelayMs;
+      return this._retryTransactionPromise(transactionCreator, transactionWork, error, retryStartTimeMs, retryDelayMs);
+    });
+  }
+
+  close() {
+    // cancel all existing timeouts to prevent further retries
+    this._inFlightTimeoutIds.forEach(timeoutId => clearTimeout(timeoutId));
+    this._inFlightTimeoutIds = [];
+  }
+
+  _retryTransactionPromise(transactionCreator, transactionWork, error, retryStartTime, retryDelayMs) {
+    const elapsedTimeMs = Date.now() - retryStartTime;
+
+    if (elapsedTimeMs > this._maxRetryTimeMs || !TransactionExecutor._canRetryOn(error)) {
+      return Promise.reject(error);
+    }
+
+    return new Promise((resolve, reject) => {
+      const nextRetryTime = this._computeDelayWithJitter(retryDelayMs);
+      const timeoutId = setTimeout(() => {
+        // filter out this timeoutId when time has come and function is being executed
+        this._inFlightTimeoutIds = this._inFlightTimeoutIds.filter(id => id !== timeoutId);
+        this._executeTransactionInsidePromise(transactionCreator, transactionWork, resolve, reject);
+      }, nextRetryTime);
+      // add newly created timeoutId to the list of all in-flight timeouts
+      this._inFlightTimeoutIds.push(timeoutId);
+    }).catch(error => {
+      const nextRetryDelayMs = retryDelayMs * this._multiplier;
+      return this._retryTransactionPromise(transactionCreator, transactionWork, error, retryStartTime, nextRetryDelayMs);
+    });
+  }
+
+  _executeTransactionInsidePromise(transactionCreator, transactionWork, resolve, reject) {
+    try {
+      const tx = transactionCreator();
+      const transactionWorkResult = transactionWork(tx);
+
+      // user defined callback is supposed to return a promise, but it might not; so to protect against an
+      // incorrect API usage we wrap the returned value with a resolved promise; this is effectively a
+      // validation step without type checks
+      const resultPromise = Promise.resolve(transactionWorkResult);
+
+      resultPromise.then(result => {
+        // transaction work returned resolved promise, try to commit the transaction
+        tx.commit().then(() => {
+          // transaction was committed, return result to the user
+          resolve(result);
+        }).catch(error => {
+          // transaction failed to commit, propagate the failure
+          reject(error);
+        });
+      }).catch(error => {
+        // transaction work returned rejected promise, propagate the failure
+        reject(error);
+      });
+
+    } catch (error) {
+      reject(error);
+    }
+  }
+
+  _computeDelayWithJitter(delayMs) {
+    const jitter = (delayMs * this._jitterFactor);
+    const min = delayMs - jitter;
+    const max = delayMs + jitter;
+    return Math.random() * (max - min) + min;
+  }
+
+  static _canRetryOn(error) {
+    return error && error.code &&
+      (error.code === SERVICE_UNAVAILABLE ||
+      error.code === SESSION_EXPIRED ||
+      error.code.indexOf('TransientError') >= 0);
+  }
+
+  _verifyAfterConstruction() {
+    if (this._maxRetryTimeMs < 0) {
+      throw newError('Max retry time should be >= 0: ' + this._maxRetryTimeMs);
+    }
+    if (this._initialRetryDelayMs < 0) {
+      throw newError('Initial retry delay should >= 0: ' + this._initialRetryDelayMs);
+    }
+    if (this._multiplier < 1.0) {
+      throw newError('Multiplier should be >= 1.0: ' + this._multiplier);
+    }
+    if (this._jitterFactor < 0 || this._jitterFactor > 1) {
+      throw newError('Jitter factor should be in [0.0, 1.0]: ' + this._jitterFactor);
+    }
+  }
+};

--- a/src/v1/routing-driver.js
+++ b/src/v1/routing-driver.js
@@ -35,8 +35,8 @@ class RoutingDriver extends Driver {
     return new LoadBalancer(address, connectionPool, driverOnErrorCallback);
   }
 
-  _createSession(mode, connectionProvider, bookmark) {
-    return new RoutingSession(mode, connectionProvider, bookmark, (error, conn) => {
+  _createSession(mode, connectionProvider, bookmark, config) {
+    return new RoutingSession(mode, connectionProvider, bookmark, config, (error, conn) => {
       if (error.code === SERVICE_UNAVAILABLE || error.code === SESSION_EXPIRED) {
         // connection is undefined if error happened before connection was acquired
         if (conn) {
@@ -66,8 +66,8 @@ class RoutingDriver extends Driver {
 }
 
 class RoutingSession extends Session {
-  constructor(mode, connectionProvider, bookmark, onFailedConnection) {
-    super(mode, connectionProvider, bookmark);
+  constructor(mode, connectionProvider, bookmark, config, onFailedConnection) {
+    super(mode, connectionProvider, bookmark, config);
     this._onFailedConnection = onFailedConnection;
   }
 

--- a/src/v1/session.js
+++ b/src/v1/session.js
@@ -119,14 +119,45 @@ class Session {
       this._onRunFailure(), this._lastBookmark, this._updateBookmark.bind(this));
   }
 
+  /**
+   * Return the bookmark received following the last completed {@link Transaction}.
+   *
+   * @return a reference to a previous transac'tion
+   */
   lastBookmark() {
     return this._lastBookmark;
   }
 
+  /**
+   * Execute given unit of work in a {@link Driver#READ} transaction.
+   *
+   * Transaction will automatically be committed unless the given function throws or returns a rejected promise.
+   * Some failures of the given function or the commit itself will be retried with exponential backoff with initial
+   * delay of 1 second and maximum retry time of 30 seconds. Maximum retry time is configurable via driver config's
+   * {@link #maxTransactionRetryTime} property in milliseconds.
+   *
+   * @param {function(Transaction)} transactionWork - callback that executes operations against
+   * a given {@link Transaction}.
+   * @return {Promise} resolved promise as returned by the given function or rejected promise when given
+   * function or commit fails.
+   */
   readTransaction(transactionWork) {
     return this._runTransaction(READ, transactionWork);
   }
 
+  /**
+   * Execute given unit of work in a {@link Driver#WRITE} transaction.
+   *
+   * Transaction will automatically be committed unless the given function throws or returns a rejected promise.
+   * Some failures of the given function or the commit itself will be retried with exponential backoff with initial
+   * delay of 1 second and maximum retry time of 30 seconds. Maximum retry time is configurable via driver config's
+   * {@link #maxTransactionRetryTime} property in milliseconds.
+   *
+   * @param {function(Transaction)} transactionWork - callback that executes operations against
+   * a given {@link Transaction}.
+   * @return {Promise} resolved promise as returned by the given function or rejected promise when given
+   * function or commit fails.
+   */
   writeTransaction(transactionWork) {
     return this._runTransaction(WRITE, transactionWork);
   }

--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -165,11 +165,11 @@ let _states = {
   //The transaction is running with no explicit success or failure marked
   ACTIVE: {
     commit: (connectionHolder, observer) => {
-      return {result: _runDiscardAll("COMMIT", connectionHolder, observer),
+      return {result: _runPullAll("COMMIT", connectionHolder, observer),
         state: _states.SUCCEEDED}
     },
     rollback: (connectionHolder, observer) => {
-      return {result: _runDiscardAll("ROLLBACK", connectionHolder, observer), state: _states.ROLLED_BACK};
+      return {result: _runPullAll("ROLLBACK", connectionHolder, observer), state: _states.ROLLED_BACK};
     },
     run: (connectionHolder, observer, statement, parameters) => {
       connectionHolder.getConnection().then(conn => {
@@ -250,7 +250,7 @@ let _states = {
   }
 };
 
-function _runDiscardAll(msg, connectionHolder, observer) {
+function _runPullAll(msg, connectionHolder, observer) {
   connectionHolder.getConnection().then(
     conn => {
       observer.resolveConnection(conn);

--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -61,7 +61,7 @@ class Transaction {
    * or with the statement and parameters as separate arguments.
    * @param {mixed} statement - Cypher statement to execute
    * @param {Object} parameters - Map with parameters to use in statement
-   * @return {Result} - New Result
+   * @return {Result} New Result
    */
   run(statement, parameters) {
     if(typeof statement === 'object' && statement.text) {
@@ -78,7 +78,7 @@ class Transaction {
    *
    * After committing the transaction can no longer be used.
    *
-   * @returns {Result} - New Result
+   * @returns {Result} New Result
    */
   commit() {
     let committed = this._state.commit(this._connectionHolder, new _TransactionStreamObserver(this));
@@ -93,7 +93,7 @@ class Transaction {
    *
    * After rolling back, the transaction can no longer be used.
    *
-   * @returns {Result} - New Result
+   * @returns {Result} New Result
    */
   rollback() {
     let committed = this._state.rollback(this._connectionHolder, new _TransactionStreamObserver(this));
@@ -103,8 +103,16 @@ class Transaction {
     return committed.result;
   }
 
+  /**
+   * Check if this transaction is active, which means commit and rollback did not happen.
+   * @return {boolean} <code>true</code> when not committed and not rolled back, <code>false</code> otherwise.
+   */
+  isOpen() {
+    return this._state == _states.ACTIVE;
+  }
+
   _onError() {
-    if (this._state == _states.ACTIVE) {
+    if (this.isOpen()) {
       // attempt to rollback, useful when Transaction#run() failed
       return this.rollback().catch(ignoredError => {
         // ignore all errors because it is best effort and transaction might already be rolled back

--- a/test/internal/timers-util.js
+++ b/test/internal/timers-util.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class SetTimeoutMock {
+
+  constructor() {
+    this._clearState();
+  }
+
+  install() {
+    this._originalSetTimeout = global.setTimeout;
+    global.setTimeout = (code, delay) => {
+      if (!this._paused) {
+        code();
+        this.invocationDelays.push(delay);
+      }
+      return this._timeoutIdCounter++;
+    };
+
+    this._originalClearTimeout = global.clearTimeout;
+    global.clearTimeout = id => {
+      this.clearedTimeouts.push(id);
+    };
+
+    return this;
+  }
+
+  pause() {
+    this._paused = true;
+  }
+
+  uninstall() {
+    global.setTimeout = this._originalSetTimeout;
+    global.clearTimeout = this._originalClearTimeout;
+    this._clearState();
+  }
+
+  setTimeoutOriginal(code, delay) {
+    return this._originalSetTimeout.call(null, code, delay);
+  }
+
+  _clearState() {
+    this._originalSetTimeout = null;
+    this._originalClearTimeout = null;
+    this._paused = false;
+    this._timeoutIdCounter = 0;
+
+    this.invocationDelays = [];
+    this.clearedTimeouts = [];
+  }
+}
+
+export const setTimeoutMock = new SetTimeoutMock();
+
+export function hijackNextDateNowCall(newValue) {
+  const originalDate = global.Date;
+  global.Date = new FakeDate(originalDate, newValue);
+}
+
+class FakeDate {
+
+  constructor(originalDate, nextNowValue) {
+    this._originalDate = originalDate;
+    this._nextNowValue = nextNowValue;
+  }
+
+  now() {
+    global.Date = this._originalDate;
+    return this._nextNowValue;
+  }
+}

--- a/test/internal/transaction-executor.test.js
+++ b/test/internal/transaction-executor.test.js
@@ -1,0 +1,326 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import TransactionExecutor from '../../src/v1/internal/transaction-executor';
+import {newError, SERVICE_UNAVAILABLE, SESSION_EXPIRED} from '../../src/v1/error';
+import {hijackNextDateNowCall, setTimeoutMock} from './timers-util';
+
+const TRANSIENT_ERROR_1 = 'Neo.TransientError.Transaction.DeadlockDetected';
+const TRANSIENT_ERROR_2 = 'Neo.TransientError.Network.CommunicationError';
+const UNKNOWN_ERROR = 'Neo.DatabaseError.General.UnknownError';
+const OOM_ERROR = 'Neo.DatabaseError.General.OutOfMemoryError';
+
+describe('TransactionExecutor', () => {
+
+  let fakeSetTimeout;
+
+  beforeEach(() => {
+    fakeSetTimeout = setTimeoutMock.install();
+  });
+
+  afterEach(() => {
+    fakeSetTimeout.uninstall();
+  });
+
+  it('should retry when transaction work returns promise rejected with SERVICE_UNAVAILABLE', done => {
+    testRetryWhenTransactionWorkReturnsRejectedPromise([SERVICE_UNAVAILABLE], done);
+  });
+
+  it('should retry when transaction work returns promise rejected with SESSION_EXPIRED', done => {
+    testRetryWhenTransactionWorkReturnsRejectedPromise([SESSION_EXPIRED], done);
+  });
+
+  it('should retry when transaction work returns promise rejected with deadlock error', done => {
+    testRetryWhenTransactionWorkReturnsRejectedPromise([TRANSIENT_ERROR_1], done);
+  });
+
+  it('should retry when transaction work returns promise rejected with communication error', done => {
+    testRetryWhenTransactionWorkReturnsRejectedPromise([TRANSIENT_ERROR_2], done);
+  });
+
+  it('should not retry when transaction work returns promise rejected with OOM error', done => {
+    testNoRetryOnUnknownError([OOM_ERROR], 1, done);
+  });
+
+  it('should not retry when transaction work returns promise rejected with unknown error', done => {
+    testNoRetryOnUnknownError([UNKNOWN_ERROR], 1, done);
+  });
+
+  it('should stop retrying when time expires', done => {
+    const executor = new TransactionExecutor();
+    let workInvocationCounter = 0;
+    const realWork = transactionWork([SERVICE_UNAVAILABLE, SESSION_EXPIRED, TRANSIENT_ERROR_1, TRANSIENT_ERROR_2], 42);
+
+    const result = executor.execute(transactionCreator(), tx => {
+      expect(tx).toBeDefined();
+      workInvocationCounter++;
+      if (workInvocationCounter === 3) {
+        hijackNextDateNowCall(Date.now() + 30001); // move next `Date.now()` call forward by 30 seconds
+      }
+      return realWork();
+    });
+
+    result.catch(error => {
+      expect(workInvocationCounter).toEqual(3);
+      expect(error.code).toEqual(TRANSIENT_ERROR_1);
+      done();
+    });
+  });
+
+  it('should retry when given transaction creator throws once', done => {
+    testRetryWhenTransactionCreatorFails(
+      [SERVICE_UNAVAILABLE],
+      done
+    );
+  });
+
+  it('should retry when given transaction creator throws many times', done => {
+    testRetryWhenTransactionCreatorFails(
+      [SERVICE_UNAVAILABLE, SESSION_EXPIRED, TRANSIENT_ERROR_2, SESSION_EXPIRED, SERVICE_UNAVAILABLE, TRANSIENT_ERROR_1],
+      done
+    );
+  });
+
+  it('should retry when given transaction work throws once', done => {
+    testRetryWhenTransactionWorkThrows([SERVICE_UNAVAILABLE], done);
+  });
+
+  it('should retry when given transaction work throws many times', done => {
+    testRetryWhenTransactionWorkThrows(
+      [SERVICE_UNAVAILABLE, TRANSIENT_ERROR_2, TRANSIENT_ERROR_2, SESSION_EXPIRED],
+      done
+    );
+  });
+
+  it('should retry when given transaction work returns rejected promise many times', done => {
+    testRetryWhenTransactionWorkReturnsRejectedPromise(
+      [SERVICE_UNAVAILABLE, SERVICE_UNAVAILABLE, TRANSIENT_ERROR_2, SESSION_EXPIRED, TRANSIENT_ERROR_1, SESSION_EXPIRED],
+      done
+    );
+  });
+
+  it('should retry when transaction commit returns rejected promise once', done => {
+    testRetryWhenTransactionCommitReturnsRejectedPromise([TRANSIENT_ERROR_1], done);
+  });
+
+  it('should retry when transaction commit returns rejected promise multiple times', done => {
+    testRetryWhenTransactionCommitReturnsRejectedPromise(
+      [TRANSIENT_ERROR_1, TRANSIENT_ERROR_1, SESSION_EXPIRED, SERVICE_UNAVAILABLE, TRANSIENT_ERROR_2],
+      done
+    );
+  });
+
+  it('should retry until database error happens', done => {
+    testNoRetryOnUnknownError(
+      [SERVICE_UNAVAILABLE, SERVICE_UNAVAILABLE, TRANSIENT_ERROR_2, SESSION_EXPIRED, UNKNOWN_ERROR, SESSION_EXPIRED],
+      5,
+      done
+    );
+  });
+
+  it('should cancel in-flight timeouts when closed', done => {
+    const executor = new TransactionExecutor();
+    // do not execute setTimeout callbacks
+    fakeSetTimeout.pause();
+
+    executor.execute(transactionCreator([SERVICE_UNAVAILABLE]), () => Promise.resolve(42));
+    executor.execute(transactionCreator([TRANSIENT_ERROR_1]), () => Promise.resolve(4242));
+    executor.execute(transactionCreator([SESSION_EXPIRED]), () => Promise.resolve(424242));
+
+    fakeSetTimeout.setTimeoutOriginal(() => {
+      executor.close();
+      expect(fakeSetTimeout.clearedTimeouts.length).toEqual(3);
+      done();
+    }, 1000);
+  });
+
+  function testRetryWhenTransactionCreatorFails(errorCodes, done) {
+    const executor = new TransactionExecutor();
+    const transactionCreator = throwingTransactionCreator(errorCodes, new FakeTransaction());
+    let workInvocationCounter = 0;
+
+    const result = executor.execute(transactionCreator, tx => {
+      expect(tx).toBeDefined();
+      workInvocationCounter++;
+      return Promise.resolve(42);
+    });
+
+    result.then(value => {
+      expect(workInvocationCounter).toEqual(1);
+      expect(value).toEqual(42);
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length);
+      done();
+    });
+  }
+
+  function testRetryWhenTransactionWorkReturnsRejectedPromise(errorCodes, done) {
+    const executor = new TransactionExecutor();
+    let workInvocationCounter = 0;
+    const realWork = transactionWork(errorCodes, 42);
+
+    const result = executor.execute(transactionCreator(), tx => {
+      expect(tx).toBeDefined();
+      workInvocationCounter++;
+      return realWork();
+    });
+
+    result.then(value => {
+      // work should have failed 'failures.length' times and succeeded 1 time
+      expect(workInvocationCounter).toEqual(errorCodes.length + 1);
+      expect(value).toEqual(42);
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length);
+      done();
+    });
+  }
+
+  function testRetryWhenTransactionCommitReturnsRejectedPromise(errorCodes, done) {
+    const executor = new TransactionExecutor();
+    let workInvocationCounter = 0;
+    const realWork = () => Promise.resolve(4242);
+
+    const result = executor.execute(transactionCreator(errorCodes), tx => {
+      expect(tx).toBeDefined();
+      workInvocationCounter++;
+      return realWork();
+    });
+
+    result.then(value => {
+      // work should have failed 'failures.length' times and succeeded 1 time
+      expect(workInvocationCounter).toEqual(errorCodes.length + 1);
+      expect(value).toEqual(4242);
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length);
+      done();
+    });
+  }
+
+  function testRetryWhenTransactionWorkThrows(errorCodes, done) {
+    const executor = new TransactionExecutor();
+    let workInvocationCounter = 0;
+    const realWork = throwingTransactionWork(errorCodes, 42);
+
+    const result = executor.execute(transactionCreator(), tx => {
+      expect(tx).toBeDefined();
+      workInvocationCounter++;
+      return realWork();
+    });
+
+    result.then(value => {
+      // work should have failed 'failures.length' times and succeeded 1 time
+      expect(workInvocationCounter).toEqual(errorCodes.length + 1);
+      expect(value).toEqual(42);
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length);
+      done();
+    });
+  }
+
+  function testNoRetryOnUnknownError(errorCodes, expectedWorkInvocationCount, done) {
+    const executor = new TransactionExecutor();
+    let workInvocationCounter = 0;
+    const realWork = transactionWork(errorCodes, 42);
+
+    const result = executor.execute(transactionCreator(), tx => {
+      expect(tx).toBeDefined();
+      workInvocationCounter++;
+      return realWork();
+    });
+
+    result.catch(error => {
+      expect(workInvocationCounter).toEqual(expectedWorkInvocationCount);
+      if (errorCodes.length === 1) {
+        expect(error.code).toEqual(errorCodes[0]);
+      } else {
+        expect(error.code).toEqual(errorCodes[expectedWorkInvocationCount - 1]);
+      }
+      done();
+    });
+  }
+
+});
+
+function transactionCreator(commitErrorCodes) {
+  const remainingErrorCodes = (commitErrorCodes || []).slice().reverse();
+  return () => new FakeTransaction(remainingErrorCodes.pop());
+}
+
+function throwingTransactionCreator(errorCodes, result) {
+  const remainingErrorCodes = errorCodes.slice().reverse();
+  return () => {
+    if (remainingErrorCodes.length === 0) {
+      return result;
+    }
+    const errorCode = remainingErrorCodes.pop();
+    throw error(errorCode);
+  };
+}
+
+function throwingTransactionWork(errorCodes, result) {
+  const remainingErrorCodes = errorCodes.slice().reverse();
+  return () => {
+    if (remainingErrorCodes.length === 0) {
+      return Promise.resolve(result);
+    }
+    const errorCode = remainingErrorCodes.pop();
+    throw error(errorCode);
+  };
+}
+
+function transactionWork(errorCodes, result) {
+  const remainingErrorCodes = errorCodes.slice().reverse();
+  return () => {
+    if (remainingErrorCodes.length === 0) {
+      return Promise.resolve(result);
+    }
+    const errorCode = remainingErrorCodes.pop();
+    return Promise.reject(error(errorCode));
+  };
+}
+
+function error(code) {
+  return newError('', code);
+}
+
+function verifyRetryDelays(fakeSetTimeout, expectedInvocationCount) {
+  const delays = fakeSetTimeout.invocationDelays;
+  expect(delays.length).toEqual(expectedInvocationCount);
+  delays.forEach((delay, index) => {
+    // delays make a geometric progression with fist element 1000 and multiplier 2.0
+    // so expected delay can be calculated as n-th element: `firstElement * pow(multiplier, n - 1)`
+    const expectedDelayWithoutJitter = 1000 * Math.pow(2.0, index);
+    const jitter = expectedDelayWithoutJitter * 0.2;
+    const min = expectedDelayWithoutJitter - jitter;
+    const max = expectedDelayWithoutJitter + jitter;
+
+    expect(delay >= min).toBeTruthy();
+    expect(delay <= max).toBeTruthy();
+  });
+}
+
+class FakeTransaction {
+
+  constructor(commitErrorCode) {
+    this._commitErrorCode = commitErrorCode;
+  }
+
+  commit() {
+    if (this._commitErrorCode) {
+      return Promise.reject(error(this._commitErrorCode));
+    }
+    return Promise.resolve();
+  }
+}

--- a/test/internal/transaction-executor.test.js
+++ b/test/internal/transaction-executor.test.js
@@ -150,6 +150,25 @@ describe('TransactionExecutor', () => {
     }, 1000);
   });
 
+  it('should allow zero max retry time', () => {
+    const executor = new TransactionExecutor(0);
+    expect(executor._maxRetryTimeMs).toEqual(0);
+  });
+
+  it('should allow zero initial delay', () => {
+    const executor = new TransactionExecutor(42, 0);
+    expect(executor._initialRetryDelayMs).toEqual(0);
+  });
+
+  it('should disallow zero multiplier', () => {
+    expect(() => new TransactionExecutor(42, 42, 0)).toThrow();
+  });
+
+  it('should allow zero jitter factor', () => {
+    const executor = new TransactionExecutor(42, 42, 42, 0);
+    expect(executor._jitterFactor).toEqual(0);
+  });
+
   function testRetryWhenTransactionCreatorFails(errorCodes, done) {
     const executor = new TransactionExecutor();
     const transactionCreator = throwingTransactionCreator(errorCodes, new FakeTransaction());

--- a/test/internal/transaction-executor.test.js
+++ b/test/internal/transaction-executor.test.js
@@ -317,6 +317,10 @@ class FakeTransaction {
     this._commitErrorCode = commitErrorCode;
   }
 
+  isOpen() {
+    return true;
+  }
+
   commit() {
     if (this._commitErrorCode) {
       return Promise.reject(error(this._commitErrorCode));

--- a/test/resources/boltkit/dead_read_server.script
+++ b/test/resources/boltkit/dead_read_server.script
@@ -1,6 +1,7 @@
 !: AUTO INIT
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO RUN "BEGIN" {}
 
 C: RUN "MATCH (n) RETURN n.name" {}
 C: PULL_ALL

--- a/test/resources/boltkit/dead_write_server.script
+++ b/test/resources/boltkit/dead_write_server.script
@@ -1,11 +1,8 @@
 !: AUTO INIT
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "COMMIT" {}
-!: AUTO RUN "ROLLBACK" {}
 !: AUTO RUN "BEGIN" {}
 
 C: RUN "CREATE (n {name:'Bob'})" {}
-   PULL_ALL
-S: SUCCESS {}
-   SUCCESS {}
+C: PULL_ALL
+S: <EXIT>

--- a/test/resources/boltkit/discover_servers.script
+++ b/test/resources/boltkit/discover_servers.script
@@ -5,10 +5,5 @@
 C: RUN "CALL dbms.cluster.routing.getServers" {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
-   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9009"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name" {}
-   PULL_ALL
-S: SUCCESS {"fields": ["n.name"]}
-   SUCCESS {}
-

--- a/test/resources/boltkit/discover_servers_and_read.script
+++ b/test/resources/boltkit/discover_servers_and_read.script
@@ -1,0 +1,14 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   SUCCESS {}
+

--- a/test/resources/boltkit/read_server.script
+++ b/test/resources/boltkit/read_server.script
@@ -1,6 +1,9 @@
 !: AUTO INIT
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO RUN "COMMIT" {}
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
 
 C: RUN "MATCH (n) RETURN n.name" {}
    PULL_ALL

--- a/test/v1/examples.test.js
+++ b/test/v1/examples.test.js
@@ -120,10 +120,10 @@ describe('examples', function() {
 
   it('should be able to configure maximum transaction retry time', function () {
     var neo4j = neo4jv1;
-    // tag::configuration[]
+    // tag::configuration-transaction-retry-time[]
     var maxRetryTimeMs = 45 * 1000; // 45 seconds
     var driver = neo4j.driver('bolt://localhost:7687', neo4j.auth.basic('neo4j', 'neo4j'), {maxTransactionRetryTime: maxRetryTimeMs});
-    //end::configuration[]
+    //end::configuration-transaction-retry-time[]
 
     var session = driver.session();
     expect(session._transactionExecutor._maxRetryTimeMs).toBe(maxRetryTimeMs);

--- a/test/v1/examples.test.js
+++ b/test/v1/examples.test.js
@@ -97,7 +97,7 @@ describe('examples', function() {
     });
   });
 
-  it('should be able to configure session pool size', function (done) {
+  it('should be able to configure connection pool size', function (done) {
    var neo4j = neo4jv1;
     // tag::configuration[]
     var driver = neo4j.driver("bolt://localhost:7687", neo4j.auth.basic("neo4j", "neo4j"), {connectionPoolSize: 50});
@@ -116,6 +116,17 @@ describe('examples', function() {
       expect(loggedCount).toBe(1);
       done();
     });
+  });
+
+  it('should be able to configure maximum transaction retry time', function () {
+    var neo4j = neo4jv1;
+    // tag::configuration[]
+    var maxRetryTimeMs = 45 * 1000; // 45 seconds
+    var driver = neo4j.driver('bolt://localhost:7687', neo4j.auth.basic('neo4j', 'neo4j'), {maxTransactionRetryTime: maxRetryTimeMs});
+    //end::configuration[]
+
+    var session = driver.session();
+    expect(session._transactionExecutor._maxRetryTimeMs).toBe(maxRetryTimeMs);
   });
 
   it('should document a statement', function(done) {

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -86,6 +86,23 @@ describe('session', () => {
     });
   });
 
+  it('should close transaction executor', done => {
+    const session = newSessionWithConnection(new FakeConnection());
+
+    let closeCalledTimes = 0;
+    const transactionExecutor = session._transactionExecutor;
+    const originalClose = transactionExecutor.close;
+    transactionExecutor.close = () => {
+      closeCalledTimes++;
+      originalClose.call(transactionExecutor);
+    };
+
+    session.close(() => {
+      expect(closeCalledTimes).toEqual(1);
+      done();
+    });
+  });
+
   it('should be possible to close driver after closing session with failed tx ', done => {
     const driver = neo4j.driver('bolt://localhost', neo4j.auth.basic('neo4j', 'neo4j'));
     const session = driver.session();

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -572,6 +572,10 @@ describe('session', () => {
   });
 
   it('should update last bookmark after every read tx commit', done => {
+    if (!serverIs31OrLater(done)) {
+      return;
+    }
+
     const bookmarkBefore = session.lastBookmark();
 
     const tx = session.beginTransaction();
@@ -592,6 +596,10 @@ describe('session', () => {
   });
 
   it('should update last bookmark after every write tx commit', done => {
+    if (!serverIs31OrLater(done)) {
+      return;
+    }
+
     const bookmarkBefore = session.lastBookmark();
 
     const tx = session.beginTransaction();
@@ -608,6 +616,10 @@ describe('session', () => {
   });
 
   it('should not lose last bookmark after run', done => {
+    if (!serverIs31OrLater(done)) {
+      return;
+    }
+
     const tx = session.beginTransaction();
     tx.run('CREATE ()').then(() => {
       tx.commit().then(() => {

--- a/test/v1/transaction.test.js
+++ b/test/v1/transaction.test.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import neo4j from "../../lib/v1";
+import neo4j from '../../lib/v1';
 
 describe('transaction', () => {
 
@@ -447,6 +447,42 @@ describe('transaction', () => {
       expect(result.records[0].get('a').toInt()).toBe(1);
       done();
     }).catch(console.log);
+  });
+
+  it('should be open when neither committed nor rolled back', () => {
+    const tx = session.beginTransaction();
+    expect(tx.isOpen()).toBeTruthy();
+  });
+
+  it('should not be open after commit', done => {
+    const tx = session.beginTransaction();
+
+    tx.run('CREATE ()').then(() => {
+      tx.commit().then(() => {
+        expect(tx.isOpen()).toBeFalsy();
+        done();
+      });
+    });
+  });
+
+  it('should not be open after rollback', done => {
+    const tx = session.beginTransaction();
+
+    tx.run('CREATE ()').then(() => {
+      tx.rollback().then(() => {
+        expect(tx.isOpen()).toBeFalsy();
+        done();
+      });
+    });
+  });
+
+  it('should not be open after run error', done => {
+    const tx = session.beginTransaction();
+
+    tx.run('RETURN').catch(() => {
+      expect(tx.isOpen()).toBeFalsy();
+      done();
+    });
   });
 
   function expectSyntaxError(error) {


### PR DESCRIPTION
3 main commits of this PR:
	
 * __Introduce transaction with retries API__
 This commit adds two new API functions:
 `Session#readTransaction()`
 `Session#writeTransaction()`
 Both take a single function as input. This function takes a single argument of type `Transaction` and returns a promise. It can be used to perform regular async operations like query execution. Introduced functions will commit/rollback transaction depending on the returned promise, so user code does not need to call `Transaction#commit()` explicitly. They also perform retries if given transaction fails with network errors (`ServiceUnavaliable` or `SessionExpired`) or with transient errors (`DeadlockDetected`, etc.). Retries are one with exponential backoff with initial delay of 1 second and total cap of 30 seconds.
 These API functions are useful to hide tolerable network problems and transient errors for both single and causal cluster deployments.
 Commit also fixes a problem in transaction error handling where `_onError` executed a rollback but did not properly wait for the returned promise to complete.

 * __TransactionExecutor checks if tx is active__
 To make sure it does not try to commit transaction that has already been committed or rolled back.
 This commit also adds a new API function `Transaction#isOpen()` which checks internal transaction state and returns `true` when transaction has not been committed/rolled back and `false` otherwise.

 * __Make maximum transaction retry time configurable__
 Commit makes driver aware of a new config property `maxTransactionRetryTime` to tune amount of time transactions executed via `Session#readTransaction(function(Transaction))` and `Session#writeTransaction(function(Transaction))` can be retried. It also adds JSDoc for `connectionPoolSize` property.

Fixes #207 