### PR TITLE
Remember seed uri and DNS-lookup during rediscovery

### DIFF
--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -500,5 +500,7 @@ export {
     connect,
     parseScheme,
     parseUrl,
+    parseHost,
+    parsePort,
     Connection
 }

--- a/src/v1/internal/features.js
+++ b/src/v1/internal/features.js
@@ -40,6 +40,17 @@ const FEATURES = {
     } catch (e) {
       return false;
     }
+  },
+  dns_lookup: () => {
+    try {
+      const lookupFunction = require('dns').lookup;
+      if (lookupFunction && typeof lookupFunction === 'function') {
+        return true;
+      }
+      return false;
+    } catch (e) {
+      return false;
+    }
   }
 };
 

--- a/src/v1/internal/host-name-resolvers.js
+++ b/src/v1/internal/host-name-resolvers.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {parseHost, parsePort} from './connector';
+
+class HostNameResolver {
+
+  resolve() {
+    throw new Error('Abstract function');
+  }
+}
+
+export class DummyHostNameResolver extends HostNameResolver {
+
+  resolve(seedRouter) {
+    return resolveToItself(seedRouter);
+  }
+}
+
+export class DnsHostNameResolver extends HostNameResolver {
+
+  constructor() {
+    super();
+    this._dns = require('dns');
+  }
+
+  resolve(seedRouter) {
+    const seedRouterHost = parseHost(seedRouter);
+    const seedRouterPort = parsePort(seedRouter);
+
+    return new Promise((resolve) => {
+      this._dns.lookup(seedRouterHost, {all: true}, (error, addresses) => {
+        if (error) {
+          resolve(resolveToItself(seedRouter));
+        } else {
+          const addressesWithPorts = addresses.map(address => addressWithPort(address, seedRouterPort));
+          resolve(addressesWithPorts);
+        }
+      });
+    });
+  }
+}
+
+function resolveToItself(address) {
+  return Promise.resolve([address]);
+}
+
+function addressWithPort(addressObject, port) {
+  const address = addressObject.address;
+  if (port) {
+    return address + ':' + port;
+  }
+  return address;
+}

--- a/test/internal/host-name-resolvers.test.js
+++ b/test/internal/host-name-resolvers.test.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DnsHostNameResolver, DummyHostNameResolver} from '../../src/v1/internal/host-name-resolvers';
+import hasFeature from '../../src/v1/internal/features';
+import {parseHost, parsePort, parseScheme} from '../../src/v1/internal/connector';
+
+describe('DummyHostNameResolver', () => {
+
+  it('should resolve given address to itself', done => {
+    const seedRouter = 'localhost';
+    const resolver = new DummyHostNameResolver();
+
+    resolver.resolve(seedRouter).then(addresses => {
+      expect(addresses.length).toEqual(1);
+      expect(addresses[0]).toEqual(seedRouter);
+      done();
+    });
+  });
+
+  it('should resolve given address with port to itself', done => {
+    const seedRouter = 'localhost:7474';
+    const resolver = new DummyHostNameResolver();
+
+    resolver.resolve(seedRouter).then(addresses => {
+      expect(addresses.length).toEqual(1);
+      expect(addresses[0]).toEqual(seedRouter);
+      done();
+    });
+  });
+
+});
+
+describe('DnsHostNameResolver', () => {
+
+  if (hasFeature('dns_lookup')) {
+
+    let originalTimeout;
+
+    beforeEach(() => {
+      // it sometimes takes couple seconds to perform dns lookup, increase the async test timeout
+      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+    });
+
+    afterEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+    });
+
+    it('should resolve address', done => {
+      const seedRouter = 'neo4j.com';
+      const resolver = new DnsHostNameResolver();
+
+      resolver.resolve(seedRouter).then(addresses => {
+        expect(addresses.length).toBeGreaterThan(0);
+
+        addresses.forEach(address => {
+          expectToBeDefined(address);
+          expect(parseScheme(address)).toEqual('');
+          expectToBeDefined(parseHost(address));
+          expect(parsePort(address)).not.toBeDefined();
+        });
+
+        done();
+      });
+    });
+
+    it('should resolve address with port', done => {
+      const seedRouter = 'neo4j.com:7474';
+      const resolver = new DnsHostNameResolver();
+
+      resolver.resolve(seedRouter).then(addresses => {
+        expect(addresses.length).toBeGreaterThan(0);
+
+        addresses.forEach(address => {
+          expectToBeDefined(address);
+          expect(parseScheme(address)).toEqual('');
+          expectToBeDefined(parseHost(address));
+          expect(parsePort(address)).toEqual('7474');
+        });
+
+        done();
+      });
+    });
+
+    it('should resolve unresolvable address to itself', done => {
+      const seedRouter = '127.0.0.1'; // IP can't be resolved
+      const resolver = new DnsHostNameResolver();
+
+      resolver.resolve(seedRouter).then(addresses => {
+        expect(addresses.length).toEqual(1);
+        expect(addresses[0]).toEqual(seedRouter);
+        done();
+      });
+    });
+
+    it('should resolve unresolvable address with port to itself', done => {
+      const seedRouter = '127.0.0.1:7474'; // IP can't be resolved
+      const resolver = new DnsHostNameResolver();
+
+      resolver.resolve(seedRouter).then(addresses => {
+        expect(addresses.length).toEqual(1);
+        expect(addresses[0]).toEqual(seedRouter);
+        done();
+      });
+    });
+
+  }
+});
+
+function expectToBeDefined(value) {
+  expect(value).toBeDefined();
+  expect(value).not.toBeNull();
+}

--- a/test/resources/boltkit/rediscover_using_initial_router.script
+++ b/test/resources/boltkit/rediscover_using_initial_router.script
@@ -1,0 +1,18 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+!: AUTO RUN "BEGIN" {}
+!: AUTO RUN "COMMIT" {}
+!: AUTO RUN "ROLLBACK" {}
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001","127.0.0.1:9009","127.0.0.1:9010"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9011"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   SUCCESS {}

--- a/test/v1/routing.driver.boltkit.it.js
+++ b/test/v1/routing.driver.boltkit.it.js
@@ -1465,7 +1465,7 @@ describe('routing driver', () => {
       return;
     }
 
-    const kit = new boltkit.BoltKit(true);
+    const kit = new boltkit.BoltKit();
     const router1 = kit.start('./test/resources/boltkit/acquire_endpoints.script', 9010);
 
     kit.run(() => {


### PR DESCRIPTION
Routing driver now memorizes seed router uri that was used on driver creation. It is later used as a fallback in case no existing routers respond during rediscovery. Also DNS resolution of this seed uri is performed if platform supports DNS lookup (only NodeJS, functionality not available in browser).

This functionality is useful when seed address exists in DNS record and does not correspond to any causal cluster member. Such setup allows driver to switch to a completely different causal cluster using DNS record manipulations.