### PR TITLE
Do not retry transaction when it is terminated

### DIFF
--- a/test/internal/transaction-executor.test.js
+++ b/test/internal/transaction-executor.test.js
@@ -24,6 +24,8 @@ import {hijackNextDateNowCall, setTimeoutMock} from './timers-util';
 const TRANSIENT_ERROR_1 = 'Neo.TransientError.Transaction.DeadlockDetected';
 const TRANSIENT_ERROR_2 = 'Neo.TransientError.Network.CommunicationError';
 const UNKNOWN_ERROR = 'Neo.DatabaseError.General.UnknownError';
+const TX_TERMINATED_ERROR = 'Neo.TransientError.Transaction.Terminated';
+const LOCKS_TERMINATED_ERROR = 'Neo.TransientError.Transaction.LockClientStopped';
 const OOM_ERROR = 'Neo.DatabaseError.General.OutOfMemoryError';
 
 describe('TransactionExecutor', () => {
@@ -60,6 +62,14 @@ describe('TransactionExecutor', () => {
 
   it('should not retry when transaction work returns promise rejected with unknown error', done => {
     testNoRetryOnUnknownError([UNKNOWN_ERROR], 1, done);
+  });
+
+  it('should not retry when transaction work returns promise rejected with transaction termination error', done => {
+    testNoRetryOnUnknownError([TX_TERMINATED_ERROR], 1, done);
+  });
+
+  it('should not retry when transaction work returns promise rejected with locks termination error', done => {
+    testNoRetryOnUnknownError([LOCKS_TERMINATED_ERROR], 1, done);
   });
 
   it('should stop retrying when time expires', done => {

--- a/test/resources/boltkit/acquire_endpoints_and_exit.script
+++ b/test/resources/boltkit/acquire_endpoints_and_exit.script
@@ -1,0 +1,10 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}
+S: <EXIT>

--- a/test/resources/boltkit/read_server_and_exit.script
+++ b/test/resources/boltkit/read_server_and_exit.script
@@ -1,0 +1,15 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+!: AUTO RUN "COMMIT" {}
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
+
+C: RUN "MATCH (n) RETURN n.name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   RECORD ["Tina"]
+   SUCCESS {}
+S: <EXIT>


### PR DESCRIPTION
This PR makes transaction functions `Session.readTransaction()` and `Session#writeTransaction()` not retry when executed transaction was explicitly terminated by the user. Such termination can happen when `Session#close()` is called or `killQuery` procedure is used.

Transaction termination can result in two different status codes on the server, both classified as transient errors which is not entirely correct. So we need additional status code checks in the retying code.