### PR TITLE
Treat one router as valid in routing table

### DIFF
--- a/src/v1/internal/routing-table.js
+++ b/src/v1/internal/routing-table.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {int} from "../integer";
-import RoundRobinArray from "./round-robin-array";
+import {int} from '../integer';
+import RoundRobinArray from './round-robin-array';
 
 const MIN_ROUTERS = 1;
 
@@ -55,7 +55,7 @@ export default class RoutingTable {
 
   isStale() {
     return this.expirationTime.lessThan(Date.now()) ||
-      this.routers.size() <= MIN_ROUTERS ||
+      this.routers.size() < MIN_ROUTERS ||
       this.readers.isEmpty() ||
       this.writers.isEmpty();
   }

--- a/test/internal/routing-table.test.js
+++ b/test/internal/routing-table.test.js
@@ -16,9 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import RoutingTable from "../../src/v1/internal/routing-table";
-import RoundRobinArray from "../../src/v1/internal/round-robin-array";
-import {int} from "../../src/v1/integer";
+import RoutingTable from '../../src/v1/internal/routing-table';
+import RoundRobinArray from '../../src/v1/internal/round-robin-array';
+import {int} from '../../src/v1/integer';
 
 describe('routing-table', () => {
 
@@ -32,9 +32,9 @@ describe('routing-table', () => {
     expect(table.isStale()).toBeTruthy();
   });
 
-  it('should be stale when has single router', () => {
+  it('should not be stale when has single router', () => {
     const table = createTable([1], [2, 3], [4, 5], notExpired());
-    expect(table.isStale()).toBeTruthy();
+    expect(table.isStale()).toBeFalsy();
   });
 
   it('should be stale when no readers', () => {

--- a/test/resources/boltkit/discover_one_router.script
+++ b/test/resources/boltkit/discover_one_router.script
@@ -1,0 +1,9 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9003","127.0.0.1:9004"], "role": "READ"},{"addresses": ["127.0.0.1:9005"], "role": "ROUTE"}]]
+   SUCCESS {}


### PR DESCRIPTION
Previously driver considered routing table with single router to be stale and had to perform rediscovery before read/write transaction. Requirement to have more than 1 router is quite strict and can easily be violated by partially unavailable clusters. Additional rediscoveries in such cases add more load on the available core server.

This PR makes driver tread routing table with single router as not stale, given that other non-staleness requirements are satisfied as well.

Based on https://github.com/neo4j/neo4j-javascript-driver/pull/235