### PR TITLE
Read in absence of viable writer

### DIFF
--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -132,7 +132,7 @@ function driver(url, authToken, config = {}) {
     return new RoutingDriver(parseUrl(url), routingContext, USER_AGENT, authToken, config);
   } else if (scheme === 'bolt://') {
     if (!isEmptyObjectOrNull(routingContext)) {
-      throw new Error(`Routing parameters are not supported with scheme 'bolt'. Given URL: '${url}'`);
+      throw new Error(`Parameters are not supported with scheme 'bolt'. Given URL: '${url}'`);
     }
     return new Driver(parseUrl(url), USER_AGENT, authToken, config);
   } else {

--- a/src/v1/internal/round-robin-array.js
+++ b/src/v1/internal/round-robin-array.js
@@ -59,4 +59,8 @@ export default class RoundRobinArray {
   remove(item) {
     this._items = this._items.filter(element => element !== item);
   }
+
+  toString() {
+    return JSON.stringify(this._items);
+  }
 }

--- a/src/v1/internal/routing-table.js
+++ b/src/v1/internal/routing-table.js
@@ -18,6 +18,7 @@
  */
 import {int} from '../integer';
 import RoundRobinArray from './round-robin-array';
+import {READ, WRITE} from '../driver';
 
 const MIN_ROUTERS = 1;
 
@@ -53,14 +54,28 @@ export default class RoutingTable {
     return Array.from(oldServers);
   }
 
-  isStale() {
+  /**
+   * Check if this routing table is fresh to perform the required operation.
+   * @param {string} accessMode the type of operation. Allowed values are {@link READ} and {@link WRITE}.
+   * @return {boolean} <code>true</code> when this table contains servers to serve the required operation,
+   * <code>false</code> otherwise.
+   */
+  isStaleFor(accessMode) {
     return this.expirationTime.lessThan(Date.now()) ||
       this.routers.size() < MIN_ROUTERS ||
-      this.readers.isEmpty() ||
-      this.writers.isEmpty();
+      accessMode === READ && this.readers.isEmpty() ||
+      accessMode === WRITE && this.writers.isEmpty();
   }
 
   _allServers() {
     return [...this.routers.toArray(), ...this.readers.toArray(), ...this.writers.toArray()];
+  }
+
+  toString() {
+    return `RoutingTable[` +
+      `expirationTime=${this.expirationTime}, ` +
+      `routers=${this.routers}, ` +
+      `readers=${this.readers}, ` +
+      `writers=${this.writers}]`;
   }
 }

--- a/test/internal/connector.test.js
+++ b/test/internal/connector.test.js
@@ -132,9 +132,7 @@ describe('connector', () => {
   it('should notify when connection initialization fails', done => {
     const connection = connect('bolt://localhost:7474'); // wrong port
 
-    connection.initializationCompleted().then(() => {
-      console.log('THEN called: ', arguments)
-    }).catch(error => {
+    connection.initializationCompleted().catch(error => {
       expect(error).toBeDefined();
       done();
     });

--- a/test/internal/round-robin-array.test.js
+++ b/test/internal/round-robin-array.test.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import RoundRobinArray from "../../lib/v1/internal/round-robin-array";
+import RoundRobinArray from '../../lib/v1/internal/round-robin-array';
 
 describe('round-robin-array', () => {
 
@@ -196,6 +196,11 @@ describe('round-robin-array', () => {
     expect(array.next()).toEqual(3);
     expect(array.next()).toEqual(2);
     expect(array.next()).toEqual(3);
+  });
+
+  it('should have correct toString ', () => {
+    const array = new RoundRobinArray([1, 2, 3]);
+    expect(array.toString()).toEqual('[1,2,3]');
   });
 
 });

--- a/test/resources/boltkit/dead_routing_server.script
+++ b/test/resources/boltkit/dead_routing_server.script
@@ -1,0 +1,7 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+C: PULL_ALL
+S: <EXIT>

--- a/test/resources/boltkit/discover_no_writers.script
+++ b/test/resources/boltkit/discover_no_writers.script
@@ -1,0 +1,9 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9004","127.0.0.1:9005"], "role": "ROUTE"}]]
+   SUCCESS {}


### PR DESCRIPTION
Previously driver did not allow reads and writes when received routing table did not contains both routers, readers and writers. This was inconsistent with Causal Cluster which allows reads when leader is absent. Leader might be unavailable for a long time (when there is a DC failure, etc.) so it makes sense to allow clients to perform read activity.

This PR makes driver accept routing table with no writers and allow clients to perform read operations when writers are not available. It might be problematic when there is a cluster partition and one partition contains majority. For this case special care must be taken so driver does not get stuck talking only to the smaller partition which only knows about itself. This is done on best effort basis - driver tries to contact seed router if previously accepted routing table did not contain writes.

Based on #237 