### PR TITLE
Propagate authentication errors

### DIFF
--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -57,7 +57,7 @@ UNBOUND_RELATIONSHIP = 0x72,
 PATH = 0x50,
 //sent before version negotiation
 MAGIC_PREAMBLE = 0x6060B017,
-DEBUG = false;
+DEBUG = true;
 
 let URLREGEX = new RegExp([
   "([^/]+//)?",          // scheme

--- a/test/internal/connector.test.js
+++ b/test/internal/connector.test.js
@@ -117,6 +117,30 @@ describe('connector', () => {
     channel.onmessage(packedFailureMessage(errorCode, errorMessage));
   });
 
+  it('should notify provided observer when connection initialization completes', done => {
+    const connection = connect('bolt://localhost');
+
+    connection.initialize('mydriver/0.0.0', basicAuthToken(), {
+      onCompleted: metaData => {
+        expect(connection.isOpen()).toBeTruthy();
+        expect(metaData).toBeDefined();
+        done();
+      },
+    });
+  });
+
+  it('should notify provided observer when connection initialization fails', done => {
+    const connection = connect('bolt://localhost:7474'); // wrong port
+
+    connection.initialize('mydriver/0.0.0', basicAuthToken(), {
+      onError: error => {
+        expect(connection.isOpen()).toBeFalsy();
+        expect(error).toBeDefined();
+        done();
+      },
+    });
+  });
+
   function packedHandshakeMessage() {
     const result = alloc(4);
     result.putInt32(0, 1);

--- a/test/internal/connector.test.js
+++ b/test/internal/connector.test.js
@@ -141,6 +141,30 @@ describe('connector', () => {
     });
   });
 
+  it('should fail all new observers after initialization error', done => {
+    const connection = connect('bolt://localhost:7474'); // wrong port
+
+    connection.initialize('mydriver/0.0.0', basicAuthToken(), {
+      onError: initialError => {
+        expect(initialError).toBeDefined();
+
+        connection.run('RETURN 1', {}, {
+          onError: error1 => {
+            expect(error1).toEqual(initialError);
+
+            connection.initialize('mydriver/0.0.0', basicAuthToken(), {
+              onError: error2 => {
+                expect(error2).toEqual(initialError);
+
+                done();
+              }
+            });
+          }
+        });
+      },
+    });
+  });
+
   function packedHandshakeMessage() {
     const result = alloc(4);
     result.putInt32(0, 1);

--- a/test/resources/boltkit/failed_auth.script
+++ b/test/resources/boltkit/failed_auth.script
@@ -1,0 +1,6 @@
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: INIT "neo4j-javascript/0.0.0-dev" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
+S: FAILURE {"code": "Neo.ClientError.Security.Unauthorized", "message": "Some server auth error message"}
+S: <EXIT>

--- a/test/v1/driver.test.js
+++ b/test/v1/driver.test.js
@@ -80,7 +80,7 @@ describe('driver', () => {
 
   it('should fail early on wrong credentials', done => {
     // Given
-    driver = neo4j.driver("bolt://localhost", neo4j.auth.basic("neo4j", "who would use such a password"));
+    driver = neo4j.driver("bolt://localhost", wrongCredentials());
 
     // Expect
     driver.onError = err => {
@@ -91,6 +91,16 @@ describe('driver', () => {
 
     // When
     startNewTransaction(driver);
+  });
+
+  it('should fail queries on wrong credentials', done => {
+    driver = neo4j.driver("bolt://localhost", wrongCredentials());
+
+    const session = driver.session();
+    session.run('RETURN 1').catch(error => {
+      expect(error.code).toEqual('Neo.ClientError.Security.Unauthorized');
+      done();
+    });
   });
 
   it('should indicate success early on correct credentials', done => {
@@ -205,6 +215,10 @@ describe('driver', () => {
   function startNewTransaction(driver) {
     const session = driver.session();
     expect(session.beginTransaction()).toBeDefined();
+  }
+
+  function wrongCredentials() {
+    return neo4j.auth.basic('neo4j', 'who would use such a password');
   }
 
 });

--- a/test/v1/routing.driver.boltkit.it.js
+++ b/test/v1/routing.driver.boltkit.it.js
@@ -1549,6 +1549,33 @@ describe('routing driver', () => {
     });
   });
 
+  it('should fail rediscovery on auth error', done => {
+    if (!boltkit.BoltKitSupport) {
+      done();
+      return;
+    }
+
+    const kit = new boltkit.BoltKit();
+    const router = kit.start('./test/resources/boltkit/failed_auth.script', 9010);
+
+    kit.run(() => {
+      const driver = newDriver('bolt+routing://127.0.0.1:9010');
+      const session = driver.session();
+      session.run('RETURN 1').catch(error => {
+        expect(error.code).toEqual('Neo.ClientError.Security.Unauthorized');
+        expect(error.message).toEqual('Some server auth error message');
+
+        session.close(() => {
+          driver.close();
+          router.exit(code => {
+            expect(code).toEqual(0);
+            done();
+          });
+        });
+      });
+    });
+  });
+
   function moveNextDateNow30SecondsForward() {
     const currentTime = Date.now();
     hijackNextDateNowCall(currentTime + 30 * 1000 + 1);


### PR DESCRIPTION
Authentication errors happen during connection initialization when INIT message is send. Server validates provided credentials and then responds with either SUCCESS if credentials are fine or with FAILURE and closes the connection when credentials are wrong. Previously auth errors were not propagated to external observers (including those defined by user's Result promise). This means auth errors were only propagated to `Driver.onError` callback but all other places received `ServiceUnavailable` or `SessionExpired` because of closed connection.

This commit makes driver treat INIT error as fatal and corresponding connection as broken. Initialization error is memorized and propagated to all message observers. So they see specific failure reason and not generic `ServiceUnavailable` \ `SessionExpired`.

Fixes #233 