### PR TITLE
use reduce for `generateFieldLookup`

### DIFF
--- a/src/v1/record.js
+++ b/src/v1/record.js
@@ -20,9 +20,13 @@
 import {newError} from './error';
 
 function generateFieldLookup( keys ) {
-  let lookup = {};
-  keys.forEach( (name, idx) => { lookup[name] = idx; });
-  return lookup;
+  return keys.reduce(
+    (acc, name, index) => {
+      acc[name] = index
+      return acc
+    },
+    {}
+  );
 }
 
 /**

--- a/src/v1/record.js
+++ b/src/v1/record.js
@@ -21,8 +21,8 @@ import {newError} from './error';
 
 function generateFieldLookup( keys ) {
   return keys.reduce(
-    (acc, name, index) => {
-      acc[name] = index
+    (acc, key, index) => {
+      acc[key] = index
       return acc
     },
     {}


### PR DESCRIPTION
This changes an implementation detail in `src/v1/record` to use `reduce` instead of `forEach` to clarify that we are transforming an Array -> Object.

Open to suggestion; If we use [transform-object-rest-spread](https://babeljs.io/docs/plugins/transform-object-rest-spread/),  we can also ensure immutability in the future.

```js
function generateFieldLookup( keys ) {
  return keys.reduce(
    (acc, key, index) => ({
      ...acc,
      [key]: index,
    }),
    {}
  )
}
```