### PR TITLE
Byte array support

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -48,6 +48,11 @@ var file = require('gulp-file');
 var semver = require('semver');
 var sharedNeo4j = require('./test/internal/shared-neo4j').default;
 
+/**
+ * Useful to investigate resource leaks in tests. Enable to see active sockets and file handles after the 'test' task.
+ */
+var enableActiveNodeHandlesLogging = false;
+
 gulp.task('default', ["test"]);
 
 gulp.task('browser', function(cb){
@@ -165,7 +170,7 @@ gulp.task('test-nodejs', ['install-driver-into-sandbox'], function () {
     .pipe(jasmine({
       includeStackTrace: true,
       verbose: true
-    }));
+    })).on('end', logActiveNodeHandles);
 });
 
 gulp.task('test-boltkit', ['nodejs'], function () {
@@ -173,7 +178,7 @@ gulp.task('test-boltkit', ['nodejs'], function () {
     .pipe(jasmine({
       includeStackTrace: true,
       verbose: true
-    }));
+    })).on('end', logActiveNodeHandles);
 });
 
 gulp.task('test-browser', function (cb) {
@@ -210,7 +215,7 @@ gulp.task('run-tck', ['download-tck', 'nodejs'], function() {
         'steps': 'test/v1/tck/steps/*.js',
         'format': 'progress',
         'tags' : ['~@fixed_session_pool', '~@db', '~@equality', '~@streaming_and_cursor_navigation']
-    }));
+    })).on('end', logActiveNodeHandles);
 });
 
 /** Set the project version, controls package.json and version.js */
@@ -248,5 +253,11 @@ gulp.task('run-stress-tests', function () {
     .pipe(jasmine({
       includeStackTrace: true,
       verbose: true
-    }));
+    })).on('end', logActiveNodeHandles);
 });
+
+function logActiveNodeHandles() {
+  if (enableActiveNodeHandlesLogging) {
+    console.log('-- Active NodeJS handles START\n', process._getActiveHandles(), '\n-- Active NodeJS handles END');
+  }
+}

--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -62,7 +62,7 @@ class Driver {
     /**
      * Reference to the connection provider. Initialized lazily by {@link _getOrCreateConnectionProvider}.
      * @type {ConnectionProvider}
-     * @private
+     * @protected
      */
     this._connectionProvider = null;
   }

--- a/src/v1/internal/ch-dummy.js
+++ b/src/v1/internal/ch-dummy.js
@@ -18,6 +18,7 @@
  */
 
 import {CombinedBuffer} from './buf';
+
 const observer = {
   instance: null,
   updateInstance: (instance) => {
@@ -54,6 +55,13 @@ class DummyChannel {
 
   toBuffer () {
     return new CombinedBuffer( this.written );
+  }
+
+  close(cb) {
+    this.written = [];
+    if (cb) {
+      return cb();
+    }
   }
 }
 

--- a/src/v1/internal/connection-holder.js
+++ b/src/v1/internal/connection-holder.js
@@ -49,10 +49,14 @@ export default class ConnectionHolder {
 
   /**
    * Get the current connection promise.
+   * @param {StreamObserver} streamObserver an observer for this connection.
    * @return {Promise<Connection>} promise resolved with the current connection.
    */
-  getConnection() {
-    return this._connectionPromise;
+  getConnection(streamObserver) {
+    return this._connectionPromise.then(connection => {
+      streamObserver.resolveConnection(connection);
+      return connection.initializationCompleted();
+    });
   }
 
   /**
@@ -117,7 +121,7 @@ class EmptyConnectionHolder extends ConnectionHolder {
     // nothing to initialize
   }
 
-  getConnection() {
+  getConnection(streamObserver) {
     return Promise.reject(newError('This connection holder does not serve connections'));
   }
 

--- a/src/v1/internal/connection-providers.js
+++ b/src/v1/internal/connection-providers.js
@@ -54,8 +54,7 @@ export class DirectConnectionProvider extends ConnectionProvider {
   }
 
   acquireConnection(mode) {
-    const connection = this._connectionPool.acquire(this._address);
-    const connectionPromise = Promise.resolve(connection);
+    const connectionPromise = acquireConnectionFromPool(this._connectionPool, this._address);
     return this._withAdditionalOnErrorCallback(connectionPromise, this._driverOnErrorCallback);
   }
 }
@@ -102,7 +101,7 @@ export class LoadBalancer extends ConnectionProvider {
         `Failed to obtain connection towards ${serverName} server. Known routing table is: ${this._routingTable}`,
         SESSION_EXPIRED));
     }
-    return this._connectionPool.acquire(address);
+    return acquireConnectionFromPool(this._connectionPool, address);
   }
 
   _freshRoutingTable(accessMode) {
@@ -199,10 +198,9 @@ export class LoadBalancer extends ConnectionProvider {
   }
 
   _createSessionForRediscovery(routerAddress) {
-    const connection = this._connectionPool.acquire(routerAddress);
     // initialized connection is required for routing procedure call
     // server version needs to be known to decide which routing procedure to use
-    const initializedConnectionPromise = connection.initializationCompleted();
+    const initializedConnectionPromise = acquireConnectionFromPool(this._connectionPool, routerAddress);
     const connectionProvider = new SingleConnectionProvider(initializedConnectionPromise);
     return new Session(READ, connectionProvider);
   }
@@ -262,4 +260,20 @@ export class SingleConnectionProvider extends ConnectionProvider {
     this._connectionPromise = null;
     return connectionPromise;
   }
+}
+
+// todo: test that all connection providers return initialized connections
+
+/**
+ * Acquire an initialized connection from the given connection pool for the given address. Returned connection
+ * promise will be resolved by a connection which completed initialization, i.e. received a SUCCESS response
+ * for it's INIT message.
+ * @param {Pool} connectionPool the connection pool to acquire connection from.
+ * @param {string} address the server address.
+ * @return {Promise<Connection>} the initialized connection.
+ */
+function acquireConnectionFromPool(connectionPool, address) {
+  const connection = connectionPool.acquire(address);
+  // initialized connection is required to be able to perform subsequent server version checks
+  return connection.initializationCompleted();
 }

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -480,7 +480,6 @@ class Connection {
     const serverVersion = metadata ? metadata.server : null;
     if (!this.server.version) {
       this.server.version = serverVersion;
-
       const version = ServerVersion.fromString(serverVersion);
       if (version.compareTo(VERSION_3_2_0) < 0) {
         this._packer.disableByteArrays();

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -477,10 +477,12 @@ class Connection {
    * @protected
    */
   _markInitialized(metadata) {
-    const serverVersion = metadata.server;
+    const serverVersion = metadata ? metadata.server : null;
     if (!this.server.version) {
       this.server.version = serverVersion;
-      if (ServerVersion.fromString(serverVersion).compareTo(VERSION_3_2_0) < 0) {
+
+      const version = ServerVersion.fromString(serverVersion);
+      if (version.compareTo(VERSION_3_2_0) < 0) {
         this._packer.disableByteArrays();
       }
     }
@@ -533,9 +535,7 @@ class ConnectionState {
         }
       },
       onCompleted: metaData => {
-        if (metaData && metaData.server) {
-          this._connection._markInitialized(metaData);
-        }
+        this._connection._markInitialized(metaData);
         this._initialized = true;
         if (this._resolvePromise) {
           this._resolvePromise(this._connection);

--- a/src/v1/session.js
+++ b/src/v1/session.js
@@ -75,8 +75,7 @@ class Session {
     const connectionHolder = this._connectionHolderWithMode(this._mode);
     if (!this._hasTx) {
       connectionHolder.initializeConnection();
-      connectionHolder.getConnection().then(connection => {
-        streamObserver.resolveConnection(connection);
+      connectionHolder.getConnection(streamObserver).then(connection => {
         statementRunner(connection, streamObserver);
         connection.pullAll(streamObserver);
         connection.sync();

--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -43,8 +43,7 @@ class Transaction {
       params = {bookmark: bookmark};
     }
 
-    this._connectionHolder.getConnection().then(conn => {
-      streamObserver.resolveConnection(conn);
+    this._connectionHolder.getConnection(streamObserver).then(conn => {
       conn.run('BEGIN', params, streamObserver);
       conn.pullAll(streamObserver);
     }).catch(error => streamObserver.onError(error));
@@ -167,8 +166,7 @@ let _states = {
       return {result: _runPullAll("ROLLBACK", connectionHolder, observer), state: _states.ROLLED_BACK};
     },
     run: (connectionHolder, observer, statement, parameters) => {
-      connectionHolder.getConnection().then(conn => {
-        observer.resolveConnection(conn);
+      connectionHolder.getConnection(observer).then(conn => {
         conn.run(statement, parameters || {}, observer);
         conn.pullAll(observer);
         conn.sync();
@@ -246,13 +244,11 @@ let _states = {
 };
 
 function _runPullAll(msg, connectionHolder, observer) {
-  connectionHolder.getConnection().then(
-    conn => {
-      observer.resolveConnection(conn);
-      conn.run(msg, {}, observer);
-      conn.pullAll(observer);
-      conn.sync();
-    }).catch(error => observer.onError(error));
+  connectionHolder.getConnection(observer).then(conn => {
+    conn.run(msg, {}, observer);
+    conn.pullAll(observer);
+    conn.sync();
+  }).catch(error => observer.onError(error));
 
   // for commit & rollback we need result that uses real connection holder and notifies it when
   // connection is not needed and can be safely released to the pool

--- a/test/internal/connection-providers.test.js
+++ b/test/internal/connection-providers.test.js
@@ -44,6 +44,16 @@ describe('DirectConnectionProvider', () => {
     });
   });
 
+  it('returns an initialized connection', done => {
+    const pool = newPool();
+    const connectionProvider = newDirectConnectionProvider('localhost:123', pool);
+
+    connectionProvider.acquireConnection(READ).then(connection => {
+      expect(connection.initialized).toBeTruthy();
+      done();
+    });
+  });
+
 });
 
 describe('LoadBalancer', () => {
@@ -1049,6 +1059,26 @@ describe('LoadBalancer', () => {
     });
   });
 
+  it('returns an initialized connection', done => {
+    const pool = newPool();
+    const loadBalancer = newLoadBalancer(
+      ['server-1', 'server-2'],
+      ['server-3', 'server-4'],
+      ['server-5', 'server-6'],
+      pool
+    );
+
+    loadBalancer.acquireConnection(READ).then(connection => {
+      expect(connection.initialized).toBeTruthy();
+
+      loadBalancer.acquireConnection(WRITE).then(connection => {
+        expect(connection.initialized).toBeTruthy();
+
+        done();
+      });
+    });
+  });
+
 });
 
 function newDirectConnectionProvider(address, pool) {
@@ -1126,6 +1156,7 @@ class FakeConnection {
   constructor(address, release) {
     this.address = address;
     this.release = release;
+    this.initialized = false;
   }
 
   static create(address, release) {
@@ -1133,6 +1164,7 @@ class FakeConnection {
   }
 
   initializationCompleted() {
+    this.initialized = true;
     return Promise.resolve(this);
   }
 }

--- a/test/internal/connection-providers.test.js
+++ b/test/internal/connection-providers.test.js
@@ -44,16 +44,6 @@ describe('DirectConnectionProvider', () => {
     });
   });
 
-  it('returns an initialized connection', done => {
-    const pool = newPool();
-    const connectionProvider = newDirectConnectionProvider('localhost:123', pool);
-
-    connectionProvider.acquireConnection(READ).then(connection => {
-      expect(connection.initialized).toBeTruthy();
-      done();
-    });
-  });
-
 });
 
 describe('LoadBalancer', () => {
@@ -1059,26 +1049,6 @@ describe('LoadBalancer', () => {
     });
   });
 
-  it('returns an initialized connection', done => {
-    const pool = newPool();
-    const loadBalancer = newLoadBalancer(
-      ['server-1', 'server-2'],
-      ['server-3', 'server-4'],
-      ['server-5', 'server-6'],
-      pool
-    );
-
-    loadBalancer.acquireConnection(READ).then(connection => {
-      expect(connection.initialized).toBeTruthy();
-
-      loadBalancer.acquireConnection(WRITE).then(connection => {
-        expect(connection.initialized).toBeTruthy();
-
-        done();
-      });
-    });
-  });
-
 });
 
 function newDirectConnectionProvider(address, pool) {
@@ -1156,7 +1126,6 @@ class FakeConnection {
   constructor(address, release) {
     this.address = address;
     this.release = release;
-    this.initialized = false;
   }
 
   static create(address, release) {
@@ -1164,7 +1133,6 @@ class FakeConnection {
   }
 
   initializationCompleted() {
-    this.initialized = true;
     return Promise.resolve(this);
   }
 }

--- a/test/internal/fake-connection.js
+++ b/test/internal/fake-connection.js
@@ -31,9 +31,12 @@ export default class FakeConnection {
     this.resetAsyncInvoked = 0;
     this.syncInvoked = 0;
     this.releaseInvoked = 0;
+    this.initializationInvoked = 0;
     this.seenStatements = [];
     this.seenParameters = [];
     this.server = {};
+
+    this._initializationPromise = Promise.resolve(this);
   }
 
   run(statement, parameters) {
@@ -61,7 +64,8 @@ export default class FakeConnection {
   }
 
   initializationCompleted() {
-    return Promise.resolve(this);
+    this.initializationInvoked++;
+    return this._initializationPromise;
   }
 
   isReleasedOnceOnSessionClose() {
@@ -92,6 +96,11 @@ export default class FakeConnection {
 
   withServerVersion(version) {
     this.server.version = version;
+    return this;
+  }
+
+  withFailedInitialization(error) {
+    this._initializationPromise = Promise.reject(error);
     return this;
   }
 };

--- a/test/internal/shared-neo4j.js
+++ b/test/internal/shared-neo4j.js
@@ -95,7 +95,7 @@ const password = 'password';
 const authToken = neo4j.auth.basic(username, password);
 
 const neoCtrlVersionParam = '-e';
-const defaultNeo4jVersion = '3.1.3';
+const defaultNeo4jVersion = '3.2.0';
 const defaultNeoCtrlArgs = `${neoCtrlVersionParam} ${defaultNeo4jVersion}`;
 
 function neo4jCertPath(dir) {

--- a/test/internal/tls.test.js
+++ b/test/internal/tls.test.js
@@ -197,6 +197,12 @@ describe('trust-system-ca-signed-certificates', function() {
       done();
     });
   });
+
+  afterEach(function () {
+    if (driver) {
+      driver.close();
+    }
+  });
 });
 
 describe('trust-on-first-use', function() {

--- a/test/resources/boltkit/read_server_with_version.script
+++ b/test/resources/boltkit/read_server_with_version.script
@@ -2,7 +2,7 @@
 !: AUTO PULL_ALL
 
 C: INIT "neo4j-javascript/0.0.0-dev" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
-S: SUCCESS {"server": "TheReadServerV1"}
+S: SUCCESS {"server": "Neo4j/8.8.8"}
 C: RUN "MATCH (n) RETURN n.name" {}
    PULL_ALL
 S: SUCCESS {"fields": ["n.name"]}

--- a/test/resources/boltkit/write_server_with_version.script
+++ b/test/resources/boltkit/write_server_with_version.script
@@ -2,7 +2,7 @@
 !: AUTO PULL_ALL
 
 C: INIT "neo4j-javascript/0.0.0-dev" {"credentials": "neo4j", "scheme": "basic", "principal": "neo4j"}
-S: SUCCESS {"server": "TheWriteServerV1"}
+S: SUCCESS {"server": "Neo4j/9.9.9"}
 C: RUN "CREATE (n {name:'Bob'})" {}
    PULL_ALL
 S: SUCCESS {}

--- a/test/v1/examples.test.js
+++ b/test/v1/examples.test.js
@@ -108,6 +108,7 @@ describe('examples', () => {
     const session = driver.session();
     session.run('RETURN 1').then(() => {
       session.close();
+      driver.close();
     });
   });
 
@@ -128,6 +129,7 @@ describe('examples', () => {
     const session = driver.session();
     session.run('RETURN 1').then(() => {
       session.close();
+      driver.close();
     });
   });
 
@@ -152,6 +154,7 @@ describe('examples', () => {
     const session = driver.session();
     session.run('RETURN 1').then(() => {
       session.close();
+      driver.close();
     }).catch(error => {
     });
   });
@@ -172,6 +175,7 @@ describe('examples', () => {
     const session = driver.session();
     session.run('RETURN 1').then(() => {
       session.close();
+      driver.close();
     });
   });
 
@@ -193,6 +197,7 @@ describe('examples', () => {
     const session = driver.session();
     session.run('RETURN 1').then(() => {
       session.close();
+      driver.close();
     });
   });
 
@@ -202,6 +207,8 @@ describe('examples', () => {
     // tag::kerberos-auth[]
     const driver = neo4j.driver(uri, neo4j.auth.kerberos(ticket));
     // end::kerberos-auth[]
+
+    driver.close();
   });
 
   it('cypher error example', done => {
@@ -427,6 +434,7 @@ describe('examples', () => {
     });
 
     testResultPromise.then(loggedMsg => {
+      driver.close();
       expect(loggedMsg).toEqual('Created 2 employees');
       done();
     });
@@ -450,6 +458,7 @@ describe('examples', () => {
     // end::service-unavailable[]
 
     testResultPromise.then(loggedMsg => {
+      driver.close();
       expect(loggedMsg).toBe('Unable to create node: ' + neo4j.error.SERVICE_UNAVAILABLE);
       done();
     });

--- a/test/v1/routing.driver.boltkit.it.js
+++ b/test/v1/routing.driver.boltkit.it.js
@@ -796,10 +796,10 @@ describe('routing driver', () => {
               readServer.exit(readServerExitCode => {
 
                 expect(readServerInfo.address).toBe('127.0.0.1:9005');
-                expect(readServerInfo.version).toBe('TheReadServerV1');
+                expect(readServerInfo.version).toBe('Neo4j/8.8.8');
 
                 expect(writeServerInfo.address).toBe('127.0.0.1:9007');
-                expect(writeServerInfo.version).toBe('TheWriteServerV1');
+                expect(writeServerInfo.version).toBe('Neo4j/9.9.9');
 
                 expect(routingServerExitCode).toEqual(0);
                 expect(writeServerExitCode).toEqual(0);
@@ -852,10 +852,10 @@ describe('routing driver', () => {
                   readServer.exit(readServerExitCode => {
 
                     expect(readSummary.server.address).toBe('127.0.0.1:9005');
-                    expect(readSummary.server.version).toBe('TheReadServerV1');
+                    expect(readSummary.server.version).toBe('Neo4j/8.8.8');
 
                     expect(writeSummary.server.address).toBe('127.0.0.1:9007');
-                    expect(writeSummary.server.version).toBe('TheWriteServerV1');
+                    expect(writeSummary.server.version).toBe('Neo4j/9.9.9');
 
                     expect(routingServerExitCode).toEqual(0);
                     expect(writeServerExitCode).toEqual(0);

--- a/test/v1/stress.test.js
+++ b/test/v1/stress.test.js
@@ -217,12 +217,12 @@ describe('stress tests', () => {
   function verifyRecord(record) {
     const node = record.get(0);
 
-    if (!_.isEqual(['Person', 'Employee'], node.labels)) {
+    if (!arraysEqual(['Person', 'Employee'], node.labels)) {
       return new Error(`Unexpected labels in node: ${JSON.stringify(node)}`);
     }
 
     const propertyKeys = _.keys(node.properties);
-    if (!_.isEmpty(propertyKeys) && !_.isEqual(['name', 'salary'], propertyKeys)) {
+    if (!_.isEmpty(propertyKeys) && !arraysEqual(['name', 'salary'], propertyKeys)) {
       return new Error(`Unexpected property keys in node: ${JSON.stringify(node)}`);
     }
 
@@ -296,6 +296,10 @@ describe('stress tests', () => {
     }).catch(error => {
       console.log('Error clearing the database: ', error);
     });
+  }
+
+  function arraysEqual(array1, array2) {
+    return _.difference(array1, array2).length === 0;
   }
 
   class Context {

--- a/test/v1/tck/steps/erroreportingsteps.js
+++ b/test/v1/tck/steps/erroreportingsteps.js
@@ -65,7 +65,14 @@ module.exports = function () {
   this.When(/^I set up a driver to an incorrect port$/, function (callback) {
     var self = this;
     var driver = neo4j.driver("bolt://localhost:7777", neo4j.auth.basic(sharedNeo4j.username, sharedNeo4j.password));
-    driver.onError = function (error) { self.error = error; callback()};
+    driver.onSuccess = function () {
+      driver.close();
+    };
+    driver.onError = function (error) {
+      driver.close();
+      self.error = error;
+      callback();
+    };
     driver.session().beginTransaction();
     setTimeout(callback, 1000);
   });

--- a/test/v1/types.test.js
+++ b/test/v1/types.test.js
@@ -143,7 +143,7 @@ describe('byte arrays', () => {
   let originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
   let serverSupportsByteArrays = false;
 
-  beforeEach(done => {
+  beforeAll(done => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
     const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken);
@@ -156,7 +156,7 @@ describe('byte arrays', () => {
     });
   });
 
-  afterEach(() => {
+  afterAll(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
 

--- a/test/v1/types.test.js
+++ b/test/v1/types.test.js
@@ -17,133 +17,137 @@
  * limitations under the License.
  */
 
-var neo4j = require("../../lib/v1");
-var sharedNeo4j = require("../internal/shared-neo4j").default;
+import neo4j from '../../src/v1';
+import sharedNeo4j from '../internal/shared-neo4j';
 
-describe('floating point values', function() {
-  it('should support float 1.0 ', testVal( 1 ) );
-  it('should support float 0.0 ', testVal( 0.0 ) );
-  it('should support pretty big float ', testVal( 3.4028235e+38 ) ); // Max 32-bit
-  it('should support really big float ', testVal( 1.7976931348623157e+308 ) ); // Max 64-bit
-  it('should support pretty small float ', testVal( 1.4e-45 ) ); // Min 32-bit
-  it('should support really small float ', testVal( 4.9e-324 ) ); // Min 64-bit
+describe('floating point values', () => {
+  it('should support float 1.0 ', testValue(1));
+  it('should support float 0.0 ', testValue(0.0));
+  it('should support pretty big float ', testValue(3.4028235e+38)); // Max 32-bit
+  it('should support really big float ', testValue(1.7976931348623157e+308)); // Max 64-bit
+  it('should support pretty small float ', testValue(1.4e-45)); // Min 32-bit
+  it('should support really small float ', testValue(4.9e-324)); // Min 64-bit
 });
 
-describe('integer values', function() {
-  it('should support integer 1 ', testVal( neo4j.int(1) ) );
-  it('should support integer 0 ', testVal( neo4j.int(0) ) );
-  it('should support integer -1 ', testVal( neo4j.int(-1) ) );
-  it('should support integer larger than JS Numbers can model', testVal( neo4j.int("0x7fffffffffffffff") ) );
-  it('should support integer smaller than JS Numbers can model', testVal( neo4j.int("0x8000000000000000") ) );
+describe('integer values', () => {
+  it('should support integer 1 ', testValue(neo4j.int(1)));
+  it('should support integer 0 ', testValue(neo4j.int(0)));
+  it('should support integer -1 ', testValue(neo4j.int(-1)));
+  it('should support integer larger than JS Numbers can model', testValue(neo4j.int('0x7fffffffffffffff')));
+  it('should support integer smaller than JS Numbers can model', testValue(neo4j.int('0x8000000000000000')));
 });
 
-describe('boolean values', function() {
-  it('should support true ',  testVal( true ) );
-  it('should support false ', testVal( false ) );
+describe('boolean values', () => {
+  it('should support true ', testValue(true));
+  it('should support false ', testValue(false));
 });
 
-describe('string values', function() {
-  it('should support empty string ',   testVal( "" ) );
-  it('should support simple string ',  testVal( "abcdefghijklmnopqrstuvwxyz" ) );
-  it('should support awesome string ', testVal( "All makt åt Tengil, vår befriare." ) );
+describe('string values', () => {
+  it('should support empty string ', testValue(''));
+  it('should support simple string ', testValue('abcdefghijklmnopqrstuvwxyz'));
+  it('should support awesome string ', testValue('All makt åt Tengil, vår befriare.'));
 });
 
-describe('list values', function() {
-  it('should support empty lists ',   testVal( [] ) );
-  it('should support sparse lists ',   testVal( [ undefined, 4 ], [ null, 4 ] ) );
-  it('should support float lists ',   testVal( [ 1,2,3 ] ) );
-  it('should support boolean lists ', testVal( [ true, false ] ) );
-  it('should support string lists ',  testVal( [ "", "hello!" ] ) );
-  it('should support list lists ',    testVal( [ [], [1,2,3] ] ) );
-  it('should support map lists ',     testVal( [ {}, {a:12} ] ) );
+describe('list values', () => {
+  it('should support empty lists ', testValue([]));
+  it('should support sparse lists ', testValue([undefined, 4], [null, 4]));
+  it('should support float lists ', testValue([1, 2, 3]));
+  it('should support boolean lists ', testValue([true, false]));
+  it('should support string lists ', testValue(['', 'hello!']));
+  it('should support list lists ', testValue([[], [1, 2, 3]]));
+  it('should support map lists ', testValue([{}, {a: 12}]));
 });
 
-describe('map values', function() {
-  it('should support empty maps ', testVal( {} ) );
-  it('should support basic maps ', testVal( {a:1, b:{}, c:[], d:{e:1}} ) );
-  it('should support sparse maps ', testVal( {foo: undefined, bar: null}, {bar: null} ) );
+describe('map values', () => {
+  it('should support empty maps ', testValue({}));
+  it('should support basic maps ', testValue({a: 1, b: {}, c: [], d: {e: 1}}));
+  it('should support sparse maps ', testValue({foo: undefined, bar: null}, {bar: null}));
 });
 
-describe('node values', function() {
-  it('should support returning nodes ', function(done) {
+describe('node values', () => {
+  it('should support returning nodes ', done => {
     // Given
-    var driver = neo4j.driver("bolt://localhost", sharedNeo4j.authToken);
-    var session = driver.session();
+    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken);
+    const session = driver.session();
 
     // When
-    session.run("CREATE (n:User {name:'Lisa'}) RETURN n, id(n)").then(function(result) {
-        var node = result.records[0].get('n');
+    session.run('CREATE (n:User {name:\'Lisa\'}) RETURN n, id(n)').then(result => {
+      const node = result.records[0].get('n');
 
-        expect( node.properties ).toEqual( { name:"Lisa" } );
-        expect( node.labels ).toEqual( ["User"] );
-        // expect( node.identity ).toEqual( rs[0]['id(n)'] ); // TODO
-        driver.close();
-        done();
+      expect(node.properties).toEqual({name: 'Lisa'});
+      expect(node.labels).toEqual(['User']);
+      expect(node.identity).toEqual(result.records[0].get('id(n)'));
+      driver.close();
+      done();
 
-      });
+    });
   });
 });
 
-describe('relationship values', function() {
-  it('should support returning relationships', function(done) {
+describe('relationship values', () => {
+  it('should support returning relationships', done => {
     // Given
-    var driver = neo4j.driver("bolt://localhost", sharedNeo4j.authToken);
-    var session = driver.session();
+    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken);
+    const session = driver.session();
 
     // When
-    session.run("CREATE ()-[r:User {name:'Lisa'}]->() RETURN r, id(r)").then(function(result) {
-        var rel = result.records[0].get('r');
+    session.run('CREATE ()-[r:User {name:\'Lisa\'}]->() RETURN r, id(r)').then(result => {
+      const rel = result.records[0].get('r');
 
-        expect( rel.properties ).toEqual( { name:"Lisa" } );
-        expect( rel.type ).toEqual( "User" );
-        // expect( rel.identity ).toEqual( rs[0]['id(r)'] ); // TODO
-        driver.close();
-        done();
+      expect(rel.properties).toEqual({name: 'Lisa'});
+      expect(rel.type).toEqual('User');
+      expect(rel.identity).toEqual(result.records[0].get('id(r)'));
+      driver.close();
+      done();
 
-      });
+    });
   });
 });
 
-describe('path values', function() {
-  it('should support returning paths', function(done) {
+describe('path values', () => {
+  it('should support returning paths', done => {
     // Given
-    var driver = neo4j.driver("bolt://localhost", sharedNeo4j.authToken);
-    var session = driver.session();
+    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken);
+    const session = driver.session();
 
     // When
-    session.run("CREATE p=(:User { name:'Lisa' })<-[r:KNOWS {since:1234.0}]-() RETURN p")
-      .then(function(result) {
-        var path = result.records[0].get('p');
+    session.run('CREATE p=(:User { name:\'Lisa\' })<-[r:KNOWS {since:1234.0}]-() RETURN p')
+      .then(result => {
+        const path = result.records[0].get('p');
 
-        expect( path.start.properties ).toEqual( { name:"Lisa" } );
-        expect( path.end.properties ).toEqual( { } );
+        expect(path.start.properties).toEqual({name: 'Lisa'});
+        expect(path.end.properties).toEqual({});
 
         // Accessing path segments
-        expect( path.length ).toEqual( 1 );
-        for (var i = 0; i < path.length; i++) {
-          var segment = path.segments[i];
+        expect(path.length).toEqual(1);
+        for (let i = 0; i < path.length; i++) {
+          const segment = path.segments[i];
           // The direction of the path segment goes from lisa to the blank node
-          expect( segment.start.properties ).toEqual( { name:"Lisa" } );
-          expect( segment.end.properties ).toEqual( { } );
+          expect(segment.start.properties).toEqual({name: 'Lisa'});
+          expect(segment.end.properties).toEqual({});
           // Which is the inverse of the relationship itself!
-          expect( segment.relationship.properties ).toEqual( { since: 1234 } );
+          expect(segment.relationship.properties).toEqual({since: 1234});
         }
         driver.close();
         done();
-      }).catch(function(err) { console.log(err); });
+      }).catch(err => {
+      console.log(err);
+    });
   });
 });
 
-function testVal( val, expected ) {
-  return function( done ) {
-    var driver = neo4j.driver("bolt://localhost", sharedNeo4j.authToken);
-    var session = driver.session();
+function testValue(actual, expected) {
+  return done => {
+    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken);
+    const session = driver.session();
 
-    session.run("RETURN {val} as v", {val: val})
-      .then( function( result ) {
-        expect( result.records[0].get('v') ).toEqual( expected || val );
+    session.run('RETURN {val} as v', {val: actual})
+      .then(result => {
+        expect(result.records[0].get('v')).toEqual(expected || actual);
         driver.close();
         done();
-      }).catch(function(err) { console.log(err); });
-  }
+      }).catch(err => {
+      console.log(err);
+    });
+  };
 }


### PR DESCRIPTION
Allow driver to receive and send byte arrays. They are represented by instances of `Int8Array` class. Feature only supported by 3.2+ servers and driver performs version check to fail early.