### PR TITLE
Multiple bookmarks support

### DIFF
--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -23,6 +23,7 @@ import {connect} from './internal/connector';
 import StreamObserver from './internal/stream-observer';
 import {newError, SERVICE_UNAVAILABLE} from './error';
 import {DirectConnectionProvider} from './internal/connection-providers';
+import Bookmark from './internal/bookmark';
 
 const READ = 'READ', WRITE = 'WRITE';
 /**
@@ -115,13 +116,14 @@ class Driver {
    * made available for others to use.
    *
    * @param {string} [mode=WRITE] the access mode of this session, allowed values are {@link READ} and {@link WRITE}.
-   * @param {string} [bookmark=null] the initial reference to some previous transaction. Value is optional and
-   * absence indicates that that the bookmark does not exist or is unknown.
+   * @param {string|string[]} [bookmarkOrBookmarks=null] the initial reference or references to some previous
+   * transactions. Value is optional and absence indicates that that the bookmarks do not exist or are unknown.
    * @return {Session} new session.
    */
-  session(mode, bookmark) {
+  session(mode, bookmarkOrBookmarks) {
     const sessionMode = Driver._validateSessionMode(mode);
     const connectionProvider = this._getOrCreateConnectionProvider();
+    const bookmark = new Bookmark(bookmarkOrBookmarks);
     return this._createSession(sessionMode, connectionProvider, bookmark, this._config);
   }
 

--- a/src/v1/internal/bookmark.js
+++ b/src/v1/internal/bookmark.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as util from './util';
+
+const BOOKMARK_KEY = 'bookmark';
+const BOOKMARKS_KEY = 'bookmarks';
+const BOOKMARK_PREFIX = 'neo4j:bookmark:v1:tx';
+
+const UNKNOWN_BOOKMARK_VALUE = -1;
+
+export default class Bookmark {
+
+  /**
+   * @constructor
+   * @param {string|string[]} values single bookmark as string or multiple bookmarks as a string array.
+   */
+  constructor(values) {
+    this._values = asStringArray(values);
+    this._maxValue = maxBookmark(this._values);
+  }
+
+  /**
+   * Check if the given bookmark is meaningful and can be send to the database.
+   * @return {boolean} returns <code>true</code> bookmark has a value, <code>false</code> otherwise.
+   */
+  isEmpty() {
+    return this._maxValue === null;
+  }
+
+  /**
+   * Get maximum value of this bookmark as string.
+   * @return {string|null} the maximum value or <code>null</code> if it is not defined.
+   */
+  maxBookmarkAsString() {
+    return this._maxValue;
+  }
+
+  /**
+   * Get this bookmark as an object for begin transaction call.
+   * @return {object} the value of this bookmark as object.
+   */
+  asBeginTransactionParameters() {
+    if (this.isEmpty()) {
+      return {};
+    }
+
+    // Driver sends {bookmark: "max", bookmarks: ["one", "two", "max"]} instead of simple
+    // {bookmarks: ["one", "two", "max"]} for backwards compatibility reasons. Old servers can only accept single
+    // bookmark that is why driver has to parse and compare given list of bookmarks. This functionality will
+    // eventually be removed.
+    return {
+      [BOOKMARK_KEY]: this._maxValue,
+      [BOOKMARKS_KEY]: this._values
+    };
+  }
+}
+
+/**
+ * Converts given value to an array.
+ * @param {string|string[]} [value=undefined] argument to convert.
+ * @return {string[]} value converted to an array.
+ */
+function asStringArray(value) {
+  if (!value) {
+    return [];
+  }
+
+  if (util.isString(value)) {
+    return [value];
+  }
+
+  if (Array.isArray(value)) {
+    const result = [];
+    for (let i = 0; i < value.length; i++) {
+      const element = value[i];
+      if (!util.isString(element)) {
+        throw new TypeError(`Bookmark should be a string, given: '${element}'`);
+      }
+      result.push(element);
+    }
+    return result;
+  }
+
+  throw new TypeError(`Bookmark should either be a string or a string array, given: '${value}'`);
+}
+
+/**
+ * Find latest bookmark in the given array of bookmarks.
+ * @param {string[]} bookmarks array of bookmarks.
+ * @return {string|null} latest bookmark value.
+ */
+function maxBookmark(bookmarks) {
+  if (!bookmarks || bookmarks.length === 0) {
+    return null;
+  }
+
+  let maxBookmark = bookmarks[0];
+  let maxValue = bookmarkValue(maxBookmark);
+
+  for (let i = 1; i < bookmarks.length; i++) {
+    const bookmark = bookmarks[i];
+    const value = bookmarkValue(bookmark);
+
+    if (value > maxValue) {
+      maxBookmark = bookmark;
+      maxValue = value;
+    }
+  }
+
+  return maxBookmark;
+}
+
+/**
+ * Calculate numeric value for the given bookmark.
+ * @param {string} bookmark argument to get numeric value for.
+ * @return {number} value of the bookmark.
+ */
+function bookmarkValue(bookmark) {
+  if (bookmark && bookmark.indexOf(BOOKMARK_PREFIX) === 0) {
+    const result = parseInt(bookmark.substring(BOOKMARK_PREFIX.length));
+    return result ? result : UNKNOWN_BOOKMARK_VALUE;
+  }
+  return UNKNOWN_BOOKMARK_VALUE;
+}

--- a/src/v1/internal/util.js
+++ b/src/v1/internal/util.js
@@ -116,6 +116,7 @@ function trimAndVerify(string, name, url) {
 
 export {
   isEmptyObjectOrNull,
+  isString,
   assertString,
   parseScheme,
   parseUrl,

--- a/test/internal/bookmark.test.js
+++ b/test/internal/bookmark.test.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Bookmark from '../../src/v1/internal/bookmark';
+
+describe('Bookmark', () => {
+
+  it('should be possible to construct bookmark from string', () => {
+    const bookmark = new Bookmark('neo4j:bookmark:v1:tx412');
+
+    expect(bookmark.isEmpty()).toBeFalsy();
+    expect(bookmark.maxBookmarkAsString()).toEqual('neo4j:bookmark:v1:tx412');
+  });
+
+  it('should be possible to construct bookmark from string array', () => {
+    const bookmark = new Bookmark(['neo4j:bookmark:v1:tx1', 'neo4j:bookmark:v1:tx2', 'neo4j:bookmark:v1:tx3']);
+
+    expect(bookmark.isEmpty()).toBeFalsy();
+    expect(bookmark.maxBookmarkAsString()).toEqual('neo4j:bookmark:v1:tx3');
+  });
+
+  it('should be possible to construct bookmark from null', () => {
+    const bookmark = new Bookmark(null);
+
+    expect(bookmark.isEmpty()).toBeTruthy();
+    expect(bookmark.maxBookmarkAsString()).toBeNull();
+  });
+
+  it('should be possible to construct bookmark from undefined', () => {
+    const bookmark = new Bookmark(undefined);
+
+    expect(bookmark.isEmpty()).toBeTruthy();
+    expect(bookmark.maxBookmarkAsString()).toBeNull();
+  });
+
+  it('should be possible to construct bookmark from an empty string', () => {
+    const bookmark = new Bookmark('');
+
+    expect(bookmark.isEmpty()).toBeTruthy();
+    expect(bookmark.maxBookmarkAsString()).toBeNull();
+  });
+
+  it('should be possible to construct bookmark from empty array', () => {
+    const bookmark = new Bookmark([]);
+
+    expect(bookmark.isEmpty()).toBeTruthy();
+    expect(bookmark.maxBookmarkAsString()).toBeNull();
+  });
+
+  it('should not be possible to construct bookmark from object', () => {
+    expect(() => new Bookmark({})).toThrowError(TypeError);
+    expect(() => new Bookmark({bookmark: 'neo4j:bookmark:v1:tx1'})).toThrowError(TypeError);
+  });
+
+  it('should not be possible to construct bookmark from number array', () => {
+    expect(() => new Bookmark([1, 2, 3])).toThrowError(TypeError);
+  });
+
+  it('should not be possible to construct bookmark from mixed array', () => {
+    expect(() => new Bookmark(['neo4j:bookmark:v1:tx1', 2, 'neo4j:bookmark:v1:tx3'])).toThrowError(TypeError);
+  });
+
+  it('should keep unparsable bookmark', () => {
+    const bookmark = new Bookmark('neo4j:bookmark:v1:txWrong');
+
+    expect(bookmark.isEmpty()).toBeFalsy();
+    expect(bookmark.maxBookmarkAsString()).toEqual('neo4j:bookmark:v1:txWrong');
+  });
+
+  it('should skip unparsable bookmarks', () => {
+    const bookmark = new Bookmark(['neo4j:bookmark:v1:tx42', 'neo4j:bookmark:v1:txWrong', 'neo4j:bookmark:v1:tx4242']);
+
+    expect(bookmark.isEmpty()).toBeFalsy();
+    expect(bookmark.maxBookmarkAsString()).toEqual('neo4j:bookmark:v1:tx4242');
+  });
+
+  it('should turn into empty transaction params when empty', () => {
+    const bookmark = new Bookmark(null);
+
+    expect(bookmark.isEmpty()).toBeTruthy();
+    expect(bookmark.asBeginTransactionParameters()).toEqual({});
+  });
+
+  it('should turn into transaction params when represents single bookmark', () => {
+    const bookmark = new Bookmark('neo4j:bookmark:v1:tx142');
+
+    expect(bookmark.isEmpty()).toBeFalsy();
+    expect(bookmark.asBeginTransactionParameters()).toEqual({
+      bookmark: 'neo4j:bookmark:v1:tx142',
+      bookmarks: ['neo4j:bookmark:v1:tx142']
+    });
+  });
+
+  it('should turn into transaction params when represents multiple bookmarks', () => {
+    const bookmark = new Bookmark(
+      ['neo4j:bookmark:v1:tx1', 'neo4j:bookmark:v1:tx3', 'neo4j:bookmark:v1:tx42', 'neo4j:bookmark:v1:tx5']
+    );
+
+    expect(bookmark.isEmpty()).toBeFalsy();
+    expect(bookmark.asBeginTransactionParameters()).toEqual({
+      bookmark: 'neo4j:bookmark:v1:tx42',
+      bookmarks: ['neo4j:bookmark:v1:tx1', 'neo4j:bookmark:v1:tx3', 'neo4j:bookmark:v1:tx42', 'neo4j:bookmark:v1:tx5']
+    });
+  });
+
+});

--- a/test/resources/boltkit/multiple_bookmarks.script
+++ b/test/resources/boltkit/multiple_bookmarks.script
@@ -1,0 +1,16 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx94", "bookmarks": ["neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56", "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68"]}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "CREATE (n {name:'Bob'})" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {"bookmark": "neo4j:bookmark:v1:tx95"}
+C: RUN "COMMIT" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}

--- a/test/resources/boltkit/read_tx_with_bookmarks.script
+++ b/test/resources/boltkit/read_tx_with_bookmarks.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "BEGIN" {"bookmark": "OldBookmark"}
+C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx42", "bookmarks": ["neo4j:bookmark:v1:tx42"]}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
@@ -11,7 +11,7 @@ C: RUN "MATCH (n) RETURN n.name AS name" {}
 S: SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]
    RECORD ["Alice"]
-   SUCCESS {"bookmark": "NewBookmark"}
+   SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
 C: RUN "COMMIT" {}
    PULL_ALL
 S: SUCCESS {}

--- a/test/resources/boltkit/write_read_tx_with_bookmark_override.script
+++ b/test/resources/boltkit/write_read_tx_with_bookmark_override.script
@@ -2,19 +2,19 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "BEGIN" {"bookmark": "BookmarkA"}
+C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx42", "bookmarks": ["neo4j:bookmark:v1:tx42"]}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
 C: RUN "CREATE (n {name:'Bob'})" {}
    PULL_ALL
 S: SUCCESS {}
-   SUCCESS {"bookmark": "BookmarkB"}
+   SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
 C: RUN "COMMIT" {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "BEGIN" {"bookmark": "BookmarkOverride"}
+C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx99", "bookmarks": ["neo4j:bookmark:v1:tx99"]}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
@@ -22,7 +22,7 @@ C: RUN "MATCH (n) RETURN n.name AS name" {}
    PULL_ALL
 S: SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]
-   SUCCESS {"bookmark": "BookmarkC"}
+   SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
 C: RUN "COMMIT" {}
    PULL_ALL
 S: SUCCESS {}

--- a/test/resources/boltkit/write_read_tx_with_bookmarks.script
+++ b/test/resources/boltkit/write_read_tx_with_bookmarks.script
@@ -2,19 +2,19 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "BEGIN" {"bookmark": "BookmarkA"}
+C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx42", "bookmarks": ["neo4j:bookmark:v1:tx42"]}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
 C: RUN "CREATE (n {name:'Bob'})" {}
    PULL_ALL
 S: SUCCESS {}
-   SUCCESS {"bookmark": "BookmarkB"}
+   SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
 C: RUN "COMMIT" {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "BEGIN" {"bookmark": "BookmarkB"}
+C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx4242", "bookmarks": ["neo4j:bookmark:v1:tx4242"]}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
@@ -22,7 +22,7 @@ C: RUN "MATCH (n) RETURN n.name AS name" {}
    PULL_ALL
 S: SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]
-   SUCCESS {"bookmark": "BookmarkC"}
+   SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
 C: RUN "COMMIT" {}
    PULL_ALL
 S: SUCCESS {}

--- a/test/resources/boltkit/write_tx_with_bookmarks.script
+++ b/test/resources/boltkit/write_tx_with_bookmarks.script
@@ -2,14 +2,14 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "BEGIN" {"bookmark": "OldBookmark"}
+C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx42", "bookmarks": ["neo4j:bookmark:v1:tx42"]}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
 C: RUN "CREATE (n {name:'Bob'})" {}
    PULL_ALL
 S: SUCCESS {}
-   SUCCESS {"bookmark": "NewBookmark"}
+   SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
 C: RUN "COMMIT" {}
    PULL_ALL
 S: SUCCESS {}

--- a/test/v1/direct.driver.boltkit.it.js
+++ b/test/v1/direct.driver.boltkit.it.js
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import neo4j from '../../lib/v1';
-import {READ, WRITE} from '../../lib/v1/driver';
+import neo4j from '../../src/v1';
+import {READ, WRITE} from '../../src/v1/driver';
 import boltkit from './boltkit';
 import sharedNeo4j from '../internal/shared-neo4j';
 
@@ -62,7 +62,7 @@ describe('direct driver', () => {
 
     kit.run(() => {
       const driver = createDriver();
-      const session = driver.session(READ, 'OldBookmark');
+      const session = driver.session(READ, 'neo4j:bookmark:v1:tx42');
       const tx = session.beginTransaction();
       tx.run('MATCH (n) RETURN n.name AS name').then(result => {
         const records = result.records;
@@ -71,7 +71,7 @@ describe('direct driver', () => {
         expect(records[1].get('name')).toEqual('Alice');
 
         tx.commit().then(() => {
-          expect(session.lastBookmark()).toEqual('NewBookmark');
+          expect(session.lastBookmark()).toEqual('neo4j:bookmark:v1:tx4242');
 
           session.close(() => {
             driver.close();
@@ -96,14 +96,14 @@ describe('direct driver', () => {
 
     kit.run(() => {
       const driver = createDriver();
-      const session = driver.session(WRITE, 'OldBookmark');
+      const session = driver.session(WRITE, 'neo4j:bookmark:v1:tx42');
       const tx = session.beginTransaction();
       tx.run('CREATE (n {name:\'Bob\'})').then(result => {
         const records = result.records;
         expect(records.length).toEqual(0);
 
         tx.commit().then(() => {
-          expect(session.lastBookmark()).toEqual('NewBookmark');
+          expect(session.lastBookmark()).toEqual('neo4j:bookmark:v1:tx4242');
 
           session.close(() => {
             driver.close();
@@ -128,14 +128,14 @@ describe('direct driver', () => {
 
     kit.run(() => {
       const driver = createDriver();
-      const session = driver.session(WRITE, 'BookmarkA');
+      const session = driver.session(WRITE, 'neo4j:bookmark:v1:tx42');
       const writeTx = session.beginTransaction();
       writeTx.run('CREATE (n {name:\'Bob\'})').then(result => {
         const records = result.records;
         expect(records.length).toEqual(0);
 
         writeTx.commit().then(() => {
-          expect(session.lastBookmark()).toEqual('BookmarkB');
+          expect(session.lastBookmark()).toEqual('neo4j:bookmark:v1:tx4242');
 
           const readTx = session.beginTransaction();
           readTx.run('MATCH (n) RETURN n.name AS name').then(result => {
@@ -144,7 +144,7 @@ describe('direct driver', () => {
             expect(records[0].get('name')).toEqual('Bob');
 
             readTx.commit().then(() => {
-              expect(session.lastBookmark()).toEqual('BookmarkC');
+              expect(session.lastBookmark()).toEqual('neo4j:bookmark:v1:tx424242');
 
               session.close(() => {
                 driver.close();
@@ -171,23 +171,23 @@ describe('direct driver', () => {
 
     kit.run(() => {
       const driver = createDriver();
-      const session = driver.session(WRITE, 'BookmarkA');
+      const session = driver.session(WRITE, 'neo4j:bookmark:v1:tx42');
       const writeTx = session.beginTransaction();
       writeTx.run('CREATE (n {name:\'Bob\'})').then(result => {
         const records = result.records;
         expect(records.length).toEqual(0);
 
         writeTx.commit().then(() => {
-          expect(session.lastBookmark()).toEqual('BookmarkB');
+          expect(session.lastBookmark()).toEqual('neo4j:bookmark:v1:tx4242');
 
-          const readTx = session.beginTransaction('BookmarkOverride');
+          const readTx = session.beginTransaction('neo4j:bookmark:v1:tx99');
           readTx.run('MATCH (n) RETURN n.name AS name').then(result => {
             const records = result.records;
             expect(records.length).toEqual(1);
             expect(records[0].get('name')).toEqual('Bob');
 
             readTx.commit().then(() => {
-              expect(session.lastBookmark()).toEqual('BookmarkC');
+              expect(session.lastBookmark()).toEqual('neo4j:bookmark:v1:tx424242');
 
               session.close(() => {
                 driver.close();
@@ -215,14 +215,14 @@ describe('direct driver', () => {
 
     kit.run(() => {
       const driver = createDriver();
-      const session = driver.session(WRITE, 'BookmarkA');
+      const session = driver.session(WRITE, 'neo4j:bookmark:v1:tx42');
       const writeTx = session.beginTransaction();
       writeTx.run('CREATE (n {name:\'Bob\'})').then(result => {
         const records = result.records;
         expect(records.length).toEqual(0);
 
         writeTx.commit().then(() => {
-          expect(session.lastBookmark()).toEqual('BookmarkB');
+          expect(session.lastBookmark()).toEqual('neo4j:bookmark:v1:tx4242');
 
           const readTx = session.beginTransaction(null);
           readTx.run('MATCH (n) RETURN n.name AS name').then(result => {
@@ -231,7 +231,7 @@ describe('direct driver', () => {
             expect(records[0].get('name')).toEqual('Bob');
 
             readTx.commit().then(() => {
-              expect(session.lastBookmark()).toEqual('BookmarkC');
+              expect(session.lastBookmark()).toEqual('neo4j:bookmark:v1:tx424242');
 
               session.close(() => {
                 driver.close();

--- a/test/v1/transaction.test.js
+++ b/test/v1/transaction.test.js
@@ -233,7 +233,7 @@ describe('transaction', () => {
     }
 
     const tx = session.beginTransaction();
-    expect(session.lastBookmark()).not.toBeDefined();
+    expect(session.lastBookmark()).toBeNull();
     tx.run("CREATE (:TXNode1)").then(() => {
       tx.run("CREATE (:TXNode2)").then(() => {
         tx.commit().then(() => {
@@ -249,7 +249,7 @@ describe('transaction', () => {
       return;
     }
 
-    expect(session.lastBookmark()).not.toBeDefined();
+    expect(session.lastBookmark()).toBeNull();
     const tx1 = session.beginTransaction();
 
     tx1.run('CREATE ()').then(() => {
@@ -282,7 +282,7 @@ describe('transaction', () => {
       return;
     }
 
-    expect(session.lastBookmark()).not.toBeDefined();
+    expect(session.lastBookmark()).toBeNull();
     const tx1 = session.beginTransaction();
 
     tx1.run('CREATE ()').then(() => {


### PR DESCRIPTION
Previously it was possible to only supply a single bookmark when creating a new session. However there is a use-case to be able to supply multiple bookmarks when multiple concurrent tasks execute write queries and then reader should be able to observe all those writes. To achieve this driver now allows passing an array of bookmarks to `Driver#session()` function.

Driver will now send:
```
{
    bookmark: "max",
    bookmarks: ["one", "two", "max"]
}
```
instead of simple:
```
{
    bookmark: "max"
}
```

this is done to maintain backwards compatibility with databases that only support a single bookmark. It forces driver to parse and compare bookmarks which violates the fact that bookmarks are opaque. This is done only to maintain backwards compatibility and should not be copied. Code doing this will eventually be removed.

Related Bolt server PR: https://github.com/neo4j/neo4j/pull/9404