### PR TITLE
fix neo4jerror name issue

### DIFF
--- a/src/v1/error.js
+++ b/src/v1/error.js
@@ -44,6 +44,7 @@ class Neo4jError extends Error {
     super( message );
     this.message = message;
     this.code = code;
+    this.name = "Neo4jError"
   }
 }
 

--- a/test/internal/connector.test.js
+++ b/test/internal/connector.test.js
@@ -233,6 +233,7 @@ describe('connector', () => {
     expect(() => {
       throw error;
     }).toThrow(new Neo4jError(expectedMessage, expectedCode));
+    expect(error.name).toBe("Neo4jError");
   }
 
   function basicAuthToken() {


### PR DESCRIPTION
`instanceof Neo4jError` will return false but you can use the property `name` instead to determine the error.
Fixes [218](https://github.com/neo4j/neo4j-javascript-driver/issues/218)