### PR TITLE
Fix UnhandledPromiseRejectionWarning in result

### DIFF
--- a/src/v1/internal/connection-holder.js
+++ b/src/v1/internal/connection-holder.js
@@ -61,7 +61,7 @@ export default class ConnectionHolder {
 
   /**
    * Notify this holder that single party does not require current connection any more.
-   * @return {Promise<Connection>} promise resolved with the current connection.
+   * @return {Promise<Connection>} promise resolved with the current connection, never a rejected promise.
    */
   releaseConnection() {
     if (this._referenceCount === 0) {

--- a/src/v1/result.js
+++ b/src/v1/result.js
@@ -20,6 +20,12 @@
 import ResultSummary from './result-summary';
 import {EMPTY_CONNECTION_HOLDER} from './internal/connection-holder';
 
+const DEFAULT_ON_ERROR = error => {
+  console.log('Uncaught error when processing result: ' + error);
+};
+const DEFAULT_ON_COMPLETED = summary => {
+};
+
 /**
   * A stream of {@link Record} representing the result of a statement.
   * @access public
@@ -102,12 +108,12 @@ class Result {
    * @return
    */
   subscribe(observer) {
-    const onCompletedOriginal = observer.onCompleted;
     const self = this;
-    const onCompletedWrapper = (metadata) => {
 
+    const onCompletedOriginal = observer.onCompleted || DEFAULT_ON_COMPLETED;
+    const onCompletedWrapper = (metadata) => {
       const additionalMeta = self._metaSupplier();
-      for(let key in additionalMeta) {
+      for (let key in additionalMeta) {
         if (additionalMeta.hasOwnProperty(key)) {
           metadata[key] = additionalMeta[key];
         }
@@ -122,10 +128,7 @@ class Result {
     };
     observer.onCompleted = onCompletedWrapper;
 
-    const onErrorOriginal = observer.onError || (error => {
-      console.log("Uncaught error when processing result: " + error);
-    });
-
+    const onErrorOriginal = observer.onError || DEFAULT_ON_ERROR;
     const onErrorWrapper = error => {
       // notify connection holder that the used connection is not needed any more because error happened
       // and result can't bee consumed any further; call the original onError callback after that

--- a/test/v1/result.test.js
+++ b/test/v1/result.test.js
@@ -60,4 +60,16 @@ describe('result stream', () => {
         done()
       });
   });
+
+  it('should handle missing onCompleted', done => {
+    session.run('RETURN 1').subscribe({
+      onNext: record => {
+        expect(record.get(0).toInt()).toEqual(1);
+        done();
+      },
+      onError: error => {
+        console.log(error);
+      }
+    });
+  });
 });


### PR DESCRIPTION
It is possible to subscribe to `Result` with an observer which consists of three functions: `onNext`, `onError` and `onCompleted`. All three are optional. However result was not handling absence of `onCompleted` correctly which resulted in a failed promise and `UnhandledPromiseRejectionWarning`.

Fixes #257 