### PR TITLE
Least connected load balancing strategy

### DIFF
--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -42,9 +42,9 @@ class Driver {
    * @constructor
    * @param {string} url
    * @param {string} userAgent
-   * @param {Object} token
-   * @param {Object} config
-   * @access private
+   * @param {object} token
+   * @param {object} config
+   * @protected
    */
   constructor(url, userAgent, token = {}, config = {}) {
     this._url = url;

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -117,6 +117,12 @@ const USER_AGENT = "neo4j-javascript/" + VERSION;
  *       // will retry the given unit of work on `ServiceUnavailable`, `SessionExpired` and transient errors with
  *       // exponential backoff using initial delay of 1 second. Default value is 30000 which is 30 seconds.
  *       maxTransactionRetryTime: 30000,
+ *
+ *       // Provide an alternative load balancing strategy for the routing driver to use.
+ *       // Driver uses "least_connected" by default.
+ *       // <b>Note:</b> We are experimenting with different strategies. This could be removed in the next minor
+ *       // version.
+ *       loadBalancingStrategy: "least_connected" | "round_robin",
  *     }
  *
  * @param {string} url The URL for the Neo4j database, for instance "bolt://localhost"

--- a/src/v1/internal/connection-providers.js
+++ b/src/v1/internal/connection-providers.js
@@ -25,7 +25,6 @@ import Rediscovery from './rediscovery';
 import hasFeature from './features';
 import {DnsHostNameResolver, DummyHostNameResolver} from './host-name-resolvers';
 import RoutingUtil from './routing-util';
-import RoundRobinLoadBalancingStrategy from './round-robin-load-balancing-strategy';
 
 class ConnectionProvider {
 
@@ -62,7 +61,7 @@ export class DirectConnectionProvider extends ConnectionProvider {
 
 export class LoadBalancer extends ConnectionProvider {
 
-  constructor(address, routingContext, connectionPool, driverOnErrorCallback) {
+  constructor(address, routingContext, connectionPool, loadBalancingStrategy, driverOnErrorCallback) {
     super();
     this._seedRouter = address;
     this._routingTable = new RoutingTable([this._seedRouter]);
@@ -70,7 +69,7 @@ export class LoadBalancer extends ConnectionProvider {
     this._connectionPool = connectionPool;
     this._driverOnErrorCallback = driverOnErrorCallback;
     this._hostNameResolver = LoadBalancer._createHostNameResolver();
-    this._loadBalancingStrategy = new RoundRobinLoadBalancingStrategy();
+    this._loadBalancingStrategy = loadBalancingStrategy;
     this._useSeedRouter = false;
   }
 

--- a/src/v1/internal/least-connected-load-balancing-strategy.js
+++ b/src/v1/internal/least-connected-load-balancing-strategy.js
@@ -16,18 +16,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import RoundRobinArrayIndex from './round-robin-array-index';
 import LoadBalancingStrategy from './load-balancing-strategy';
 
-export const ROUND_ROBIN_STRATEGY_NAME = 'round_robin';
+export const LEAST_CONNECTED_STRATEGY_NAME = 'least_connected';
 
-export default class RoundRobinLoadBalancingStrategy extends LoadBalancingStrategy {
+export default class LeastConnectedLoadBalancingStrategy extends LoadBalancingStrategy {
 
-  constructor() {
+  /**
+   * @constructor
+   * @param {Pool} connectionPool the connection pool of this driver.
+   */
+  constructor(connectionPool) {
     super();
     this._readersIndex = new RoundRobinArrayIndex();
     this._writersIndex = new RoundRobinArrayIndex();
+    this._connectionPool = connectionPool;
   }
 
   /**
@@ -49,7 +53,33 @@ export default class RoundRobinLoadBalancingStrategy extends LoadBalancingStrate
     if (length === 0) {
       return null;
     }
-    const index = roundRobinIndex.next(length);
-    return addresses[index];
+
+    // choose start index for iteration in round-rodin fashion
+    const startIndex = roundRobinIndex.next(length);
+    let index = startIndex;
+
+    let leastConnectedAddress = null;
+    let leastActiveConnections = Number.MAX_SAFE_INTEGER;
+
+    // iterate over the array to find least connected address
+    do {
+      const address = addresses[index];
+      const activeConnections = this._connectionPool.activeResourceCount(address);
+
+      if (activeConnections < leastActiveConnections) {
+        leastConnectedAddress = address;
+        leastActiveConnections = activeConnections;
+      }
+
+      // loop over to the start of the array when end is reached
+      if (index === length - 1) {
+        index = 0;
+      } else {
+        index++;
+      }
+    }
+    while (index !== startIndex);
+
+    return leastConnectedAddress;
   }
 }

--- a/src/v1/internal/load-balancing-strategy.js
+++ b/src/v1/internal/load-balancing-strategy.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-
 /**
  * A facility to select most appropriate reader or writer among the given addresses for request processing.
  */

--- a/test/internal/least-connected-load-balancing-strategy.test.js
+++ b/test/internal/least-connected-load-balancing-strategy.test.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import LeastConnectedLoadBalancingStrategy from '../../src/v1/internal/least-connected-load-balancing-strategy';
+import Pool from '../../src/v1/internal/pool';
+
+describe('LeastConnectedLoadBalancingStrategy', () => {
+
+  it('should return null when no readers', () => {
+    const knownReaders = [];
+    const strategy = new LeastConnectedLoadBalancingStrategy(new DummyPool({}));
+
+    expect(strategy.selectReader(knownReaders)).toBeNull();
+  });
+
+  it('should return null when no writers', () => {
+    const knownWriters = [];
+    const strategy = new LeastConnectedLoadBalancingStrategy(new DummyPool({}));
+
+    expect(strategy.selectWriter(knownWriters)).toBeNull();
+  });
+
+  it('should return same reader when it is the only one available and has no connections', () => {
+    const knownReaders = ['reader-1'];
+    const strategy = new LeastConnectedLoadBalancingStrategy(new DummyPool({'reader-1': 0}));
+
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-1');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-1');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-1');
+  });
+
+  it('should return same writer when it is the only one available and has no connections', () => {
+    const knownWriters = ['writer-1'];
+    const strategy = new LeastConnectedLoadBalancingStrategy(new DummyPool({'writer-1': 0}));
+
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-1');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-1');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-1');
+  });
+
+  it('should return same reader when it is the only one available and has active connections', () => {
+    const knownReaders = ['reader-1'];
+    const strategy = new LeastConnectedLoadBalancingStrategy(new DummyPool({'reader-1': 14}));
+
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-1');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-1');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-1');
+  });
+
+  it('should return same writer when it is the only one available and has active connections', () => {
+    const knownWriters = ['writer-1'];
+    const strategy = new LeastConnectedLoadBalancingStrategy(new DummyPool({'writer-1': 3}));
+
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-1');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-1');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-1');
+  });
+
+  it('should return readers in round robin order when no active connections', () => {
+    const knownReaders = ['reader-1', 'reader-2', 'reader-3'];
+    const pool = new DummyPool({'reader-1': 0, 'reader-2': 0, 'reader-3': 0});
+    const strategy = new LeastConnectedLoadBalancingStrategy(pool);
+
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-1');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-2');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-3');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-1');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-2');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-3');
+  });
+
+  it('should return writers in round robin order when no active connections', () => {
+    const knownWriters = ['writer-1', 'writer-2', 'writer-3', 'writer-4'];
+    const pool = new DummyPool({'writer-1': 0, 'writer-2': 0, 'writer-3': 0, 'writer-4': 0});
+    const strategy = new LeastConnectedLoadBalancingStrategy(pool);
+
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-1');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-2');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-3');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-4');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-1');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-2');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-3');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-4');
+  });
+
+  it('should return least connected reader', () => {
+    const knownReaders = ['reader-1', 'reader-2', 'reader-3'];
+    const pool = new DummyPool({'reader-1': 7, 'reader-2': 3, 'reader-3': 8});
+    const strategy = new LeastConnectedLoadBalancingStrategy(pool);
+
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-2');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-2');
+    expect(strategy.selectReader(knownReaders)).toEqual('reader-2');
+  });
+
+  it('should return least connected writer', () => {
+    const knownWriters = ['writer-1', 'writer-2', 'writer-3', 'writer-4'];
+    const pool = new DummyPool({'writer-1': 5, 'writer-2': 4, 'writer-3': 6, 'writer-4': 2});
+    const strategy = new LeastConnectedLoadBalancingStrategy(pool);
+
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-4');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-4');
+    expect(strategy.selectWriter(knownWriters)).toEqual('writer-4');
+  });
+
+});
+
+class DummyPool extends Pool {
+
+  constructor(activeConnections) {
+    super(() => 42);
+    this._activeConnections = activeConnections;
+  }
+
+  activeResourceCount(key) {
+    return this._activeConnections[key];
+  }
+}

--- a/test/types/v1/driver.test.ts
+++ b/test/types/v1/driver.test.ts
@@ -21,6 +21,7 @@ import Driver, {
   AuthToken,
   Config,
   EncryptionLevel,
+  LoadBalancingStrategy,
   READ,
   SessionMode,
   TrustStrategy,
@@ -54,6 +55,8 @@ const trustedCertificates: undefined | string[] = config.trustedCertificates;
 const knownHosts: undefined | string = config.knownHosts;
 const connectionPoolSize: undefined | number = config.connectionPoolSize;
 const maxTransactionRetryTime: undefined | number = config.maxTransactionRetryTime;
+const loadBalancingStrategy1: undefined | LoadBalancingStrategy = config.loadBalancingStrategy;
+const loadBalancingStrategy2: undefined | string = config.loadBalancingStrategy;
 
 const sessionMode: SessionMode = dummy;
 const sessionModeStr: string = sessionMode;

--- a/test/v1/routing-driver.test.js
+++ b/test/v1/routing-driver.test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,","
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import RoundRobinLoadBalancingStrategy from '../../src/v1/internal/round-robin-load-balancing-strategy';
+import LeastConnectedLoadBalancingStrategy from '../../src/v1/internal/least-connected-load-balancing-strategy';
+import RoutingDriver from '../../src/v1/routing-driver';
+import Pool from '../../src/v1/internal/pool';
+
+describe('RoutingDriver', () => {
+
+  it('should create least connected when nothing configured', () => {
+    const strategy = RoutingDriver._createLoadBalancingStrategy({}, new Pool());
+    expect(strategy instanceof LeastConnectedLoadBalancingStrategy).toBeTruthy();
+  });
+
+  it('should create least connected when it is configured', () => {
+    const strategy = RoutingDriver._createLoadBalancingStrategy({loadBalancingStrategy: 'least_connected'}, new Pool());
+    expect(strategy instanceof LeastConnectedLoadBalancingStrategy).toBeTruthy();
+  });
+
+  it('should create round robin when it is configured', () => {
+    const strategy = RoutingDriver._createLoadBalancingStrategy({loadBalancingStrategy: 'round_robin'}, new Pool());
+    expect(strategy instanceof RoundRobinLoadBalancingStrategy).toBeTruthy();
+  });
+
+});

--- a/test/v1/routing-driver.test.js
+++ b/test/v1/routing-driver.test.js
@@ -25,18 +25,26 @@ import Pool from '../../src/v1/internal/pool';
 describe('RoutingDriver', () => {
 
   it('should create least connected when nothing configured', () => {
-    const strategy = RoutingDriver._createLoadBalancingStrategy({}, new Pool());
+    const strategy = createStrategy({});
     expect(strategy instanceof LeastConnectedLoadBalancingStrategy).toBeTruthy();
   });
 
   it('should create least connected when it is configured', () => {
-    const strategy = RoutingDriver._createLoadBalancingStrategy({loadBalancingStrategy: 'least_connected'}, new Pool());
+    const strategy = createStrategy({loadBalancingStrategy: 'least_connected'});
     expect(strategy instanceof LeastConnectedLoadBalancingStrategy).toBeTruthy();
   });
 
   it('should create round robin when it is configured', () => {
-    const strategy = RoutingDriver._createLoadBalancingStrategy({loadBalancingStrategy: 'round_robin'}, new Pool());
+    const strategy = createStrategy({loadBalancingStrategy: 'round_robin'});
     expect(strategy instanceof RoundRobinLoadBalancingStrategy).toBeTruthy();
   });
 
+  it('should fail when unknown strategy is configured', () => {
+    expect(() => createStrategy({loadBalancingStrategy: 'wrong'})).toThrow();
+  });
+
 });
+
+function createStrategy(config) {
+  return RoutingDriver._createLoadBalancingStrategy(config, new Pool());
+}

--- a/types/v1/driver.d.ts
+++ b/types/v1/driver.d.ts
@@ -36,6 +36,8 @@ declare type TrustStrategy =
   "TRUST_CUSTOM_CA_SIGNED_CERTIFICATES" |
   "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES";
 
+declare type LoadBalancingStrategy = "least_connected" | "round_robin";
+
 declare interface Config {
   encrypted?: boolean | EncryptionLevel;
   trust?: TrustStrategy;
@@ -43,6 +45,7 @@ declare interface Config {
   knownHosts?: string;
   connectionPoolSize?: number;
   maxTransactionRetryTime?: number;
+  loadBalancingStrategy?: LoadBalancingStrategy;
 }
 
 declare type SessionMode = "READ" | "WRITE";
@@ -56,6 +59,6 @@ declare interface Driver {
   close(): void;
 }
 
-export {Driver, READ, WRITE, AuthToken, Config, EncryptionLevel, TrustStrategy, SessionMode}
+export {Driver, READ, WRITE, AuthToken, Config, EncryptionLevel, TrustStrategy, LoadBalancingStrategy, SessionMode}
 
 export default Driver;


### PR DESCRIPTION
This replaces the existing round-robin. It gives us better performance with clusters composed of different machine capacities. Lease connected load balancing strategy selects start index in round robin fashion to avoid always selecting same machine when cluster does not have any running transactions or all machines have same number of active connections.

It is possible to go back to previous round-robin load balancing strategy using an experimental config setting:
```
  {loadBalancingStrategy: 'round_robin'}
```