### PR TITLE
Forget CC members on DatabaseUnavailable

### DIFF
--- a/test/resources/boltkit/address_unavailable_template.script.mst
+++ b/test/resources/boltkit/address_unavailable_template.script.mst
@@ -1,0 +1,12 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+!: AUTO ACK_FAILURE
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
+!: AUTO RUN "COMMIT" {}
+
+C: RUN "{{{query}}}" {}
+C: PULL_ALL
+S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database is busy doing store copy"}
+S: IGNORED


### PR DESCRIPTION
This PR makes routing driver forget Causal Cluster members when they fail with `Neo.TransientError.General.DatabaseUnavailable` error code. It means database is either shutting down or doing store copy. Generally we should not hammer database in such state with new requests and give it some time to either recover (in case of store copy) or just stop using it.

Also restructured a bit error handling code in `RoutingDriver` and `RoutingSession`.