### PR TITLE
Add TS declaration for driver callbacks

### DIFF
--- a/test/types/v1/driver.test.ts
+++ b/test/types/v1/driver.test.ts
@@ -28,6 +28,7 @@ import Driver, {
 } from "../../../types/v1/driver";
 import {Parameters} from "../../../types/v1/statement-runner";
 import Session from "../../../types/v1/session";
+import {Neo4jError} from "../../../types/v1/error";
 
 const dummy: any = null;
 
@@ -82,3 +83,15 @@ session1.run("RETURN 1").then(result => {
 });
 
 const close: void = driver.close();
+
+driver.onCompleted = (metadata: { server: string }) => {
+  console.log(metadata.server);
+};
+
+driver.onCompleted({server: "Neo4j/3.2.0"});
+
+driver.onError = (error: Neo4jError) => {
+  console.log(error);
+};
+
+driver.onError(new Neo4jError("message", "code"));

--- a/types/v1/driver.d.ts
+++ b/types/v1/driver.d.ts
@@ -19,6 +19,7 @@
 
 import Session from "./session";
 import {Parameters} from "./statement-runner";
+import {Neo4jError} from "./error";
 
 declare interface AuthToken {
   scheme: string;
@@ -54,6 +55,9 @@ declare interface Driver {
   session(mode?: SessionMode, bookmark?: string): Session;
 
   close(): void;
+
+  onCompleted?: (metadata: { server: string }) => void;
+  onError?: (error: Neo4jError) => void;
 }
 
 export {Driver, READ, WRITE, AuthToken, Config, EncryptionLevel, TrustStrategy, SessionMode}


### PR DESCRIPTION
PR adds `Driver.onCompleted` and `Driver.onError` callbacks to the TypeScript declaration.

Based on https://github.com/neo4j/neo4j-javascript-driver/pull/273.
@janwo thanks a lot for the original PR. Could you please review this one?