### PR TITLE
Connection timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-driver",
-  "version": "1.2.0-dev",
+  "version": "1.4.1-dev",
   "description": "Connect to Neo4j 3.1.0 and up from JavaScript",
   "author": "Neo Technology Inc.",
   "license": "Apache-2.0",

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -116,7 +116,12 @@ const USER_AGENT = "neo4j-javascript/" + VERSION;
  *       // {@link Session#readTransaction()} and {@link Session#writeTransaction()} functions. These functions
  *       // will retry the given unit of work on `ServiceUnavailable`, `SessionExpired` and transient errors with
  *       // exponential backoff using initial delay of 1 second. Default value is 30000 which is 30 seconds.
- *       maxTransactionRetryTime: 30000,
+ *       maxTransactionRetryTime: 30000, // 30 seconds
+ *
+ *       // Specify socket connection timeout in milliseconds. Non-numeric, negative and zero values are treated as an
+ *       // infinite timeout. Connection will be then bound by the timeout configured on the operating system level.
+ *       // Timeout value should be numeric and greater or equal to zero.
+ *       connectionTimeout: 5000, // 5 seconds
  *     }
  *
  * @param {string} url The URL for the Neo4j database, for instance "bolt://localhost"

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -965,6 +965,14 @@ describe('session', () => {
     });
   });
 
+  it('should respect connection timeout', done => {
+    testConnectionTimeout(false, done);
+  });
+
+  it('should respect encrypted connection timeout', done => {
+    testConnectionTimeout(true, done);
+  });
+
   function serverIs31OrLater(done) {
     // lazy way of checking the version number
     // if server has been set we know it is at least 3.1
@@ -1040,6 +1048,27 @@ describe('session', () => {
           });
         }).catch(error => reject(error));
       }).catch(error => reject(error));
+    });
+  }
+
+  function testConnectionTimeout(encrypted, done) {
+    const boltUri = 'bolt://10.0.0.0'; // use non-routable IP address which never responds
+    const config = {encrypted: encrypted, connectionTimeout: 1000};
+
+    const localDriver = neo4j.driver(boltUri, sharedNeo4j.authToken, config);
+    const session = localDriver.session();
+    session.run('RETURN 1').then(() => {
+      done.fail('Query did not fail');
+    }).catch(error => {
+      expect(error.code).toEqual(neo4j.error.SERVICE_UNAVAILABLE);
+
+      // in some environments non-routable address results in immediate 'connection refused' error and connect
+      // timeout is not fired; skip message assertion for such cases, it is important for connect attempt to not hang
+      if (error.message.indexOf('Failed to establish connection') === 0) {
+        expect(error.message).toEqual('Failed to establish connection in 1000ms');
+      }
+
+      done();
     });
   }
 


### PR DESCRIPTION
Added ability to enforce max connection timeout. It is applied to new connections and makes them terminate connection attempt after configured number of milliseconds. Feature is needed because connect part might take minutes in some environments.

NodeJS channel uses `net.Socket` when non-encrypted and it's subclass `tls.TLSSocket` when encrypted. Connection timeout is implemented using `socket.setTimeout()` function which triggers a callback after configured millis of inactivity. We first initiate a connection attempt and them set the timeout. If connection establishes before the timeout then later is canceled. Otherwise `timeout` event is fired and socket is destroyed.

WebSocket channel used in browser does not have built-in timeout functionality. That is why we simply use `setTimeout()` that closes WebSocket if it does not connect in time. Successful connection cancels the timeout.

Feature is turned of by default and can be configured using `connectionTimeout` property in the config. Example:

```javascript
const driver = neo4j.driver(
                    'bolt://localhost',
                    neo4j.auth.basic('neo4j', 'pwd'),
                    {connectionTimeout: 5000 /* 5 seconds */ });
```