### PR TITLE
Errors from Result will now contain the caller stack trace

### DIFF
--- a/src/v1/result.js
+++ b/src/v1/result.js
@@ -138,7 +138,9 @@ class Result {
       // notify connection holder that the used connection is not needed any more because error happened
       // and result can't bee consumed any further; call the original onError callback after that
       self._connectionHolder.releaseConnection().then(() => {
-        error.stack = error.stack + '\n' + this._stack;
+        // Error.prototype.toString() concatenates error.name and error.message nicely
+        // then we add the rest of the stack trace
+        error.stack = error.toString() + '\n' + this._stack;
         onErrorOriginal.call(observer, error);
       });
     };

--- a/src/v1/result.js
+++ b/src/v1/result.js
@@ -45,6 +45,7 @@ class Result {
    * @param {ConnectionHolder} connectionHolder - to be notified when result is either fully consumed or error happened.
    */
   constructor(streamObserver, statement, parameters, metaSupplier, connectionHolder) {
+    this._stack = (new Error('')).stack.substr(6); // we don't need the 'Error\n' part
     this._streamObserver = streamObserver;
     this._p = null;
     this._statement = statement;
@@ -137,6 +138,7 @@ class Result {
       // notify connection holder that the used connection is not needed any more because error happened
       // and result can't bee consumed any further; call the original onError callback after that
       self._connectionHolder.releaseConnection().then(() => {
+        error.stack = error.stack + '\n' + this._stack;
         onErrorOriginal.call(observer, error);
       });
     };


### PR DESCRIPTION
Consider the following code: 
```js
const fn_a = cb => fn_b(cb);
const fn_b = cb => fn_c(cb);
const fn_c = cb => session.run('RETURN 1/0 AS x').catch(cb).then(_ => cb(void 0, _));
```

Before, when the execution had an error, we would get the following stack track: 
```js
Neo4jError: / by zero
    at new Neo4jError (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/error.js:76:132)
    at newError (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/error.js:66:10)
    at Connection._handleMessage (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/connector.js:356:56)
    at Dechunker.Connection._dechunker.onmessage (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/connector.js:287:12)
    at Dechunker._onHeader (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/chunking.js:246:14)
    at Dechunker.AWAITING_CHUNK (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/chunking.js:199:21)
    at Dechunker.write (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/chunking.js:257:28)
    at NodeChannel.self._ch.onmessage (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/connector.js:260:27)
    at TLSSocket.<anonymous> (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/ch-node.js:308:16)
    at emitOne (events.js:115:13)
```

In this case is easy to pinpoint the issue, but in a broader environment where there are a lot of queries, like for example in an API endpoint, It's hard find the bad one, even harder if the error doesn't contain any cypher at all for you to try to match against.

This change stores the current calling stack trace in `this._stack` in the constructor of `Result` and concatenates it with the original stack trace of `Result` in cases when `Result` throws an error.

```js
Neo4jError: / by zero
    at new Neo4jError (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/error.js:76:132)
    at newError (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/error.js:66:10)
    at Connection._handleMessage (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/connector.js:356:56)
    at Dechunker.Connection._dechunker.onmessage (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/connector.js:287:12)
    at Dechunker._onHeader (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/chunking.js:246:14)
    at Dechunker.AWAITING_CHUNK (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/chunking.js:199:21)
    at Dechunker.write (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/chunking.js:257:28)
    at NodeChannel.self._ch.onmessage (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/connector.js:260:27)
    at TLSSocket.<anonymous> (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/internal/ch-node.js:308:16)
    at emitOne (events.js:115:13)
    at new Result (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/result.js:73:19)
    at Session._run (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/session.js:122:14)
    at Session.run (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/lib/v1/session.js:101:19)
    at fn_c (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:18:39)
    at fn_b (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:12:23)
    at fn_a (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:11:23)
    at __dirname (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:30:9)
    at Object.<anonymous> (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:31:3)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
```

With the new stack trace, the location of the issue is immediately available to the developer to look at and fix.

```js
...
    at fn_c (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:18:39)
    at fn_b (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:12:23)
    at fn_a (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:11:23)
    at __dirname (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:30:9)
    at Object.<anonymous> (/Users/Stefan/Desktop/GitHub/neo4j-javascript-driver/test.js:31:3)
...
```

Also included test for it and all the other test are passing.