### PR TITLE
Fixed timeout when acquiring connection from pool

### DIFF
--- a/src/v1/internal/pool.js
+++ b/src/v1/internal/pool.js
@@ -162,10 +162,10 @@ class Pool {
     // check if there are any pending requests
     const requests = this._acquireRequests[key];
     if (requests) {
-      var pending = requests.shift();
+      const pending = requests.shift();
 
       if (pending) {
-        var resource = this._acquire(key);
+        const resource = this._acquire(key);
         if (resource) {
           pending.resolve(resource);
 


### PR DESCRIPTION
Connection pool has limited size and returns `Promise<Connection>` instead of `Connection` directly. Returned promise can be failed when connection acquisition timeout has fired. Pool uses helper function `util#promiseOrTimeout()` to race acquisition and timeout promises.

This function allowed both timeout callback to be invoked and connection to be acquired. It cleared the timeout outside of the raced promises. As result connection was acquired but timeout callback failed in background. It tried to clear non-existing pending acquisition attempts.

This PR fixes the problem by including `#clearTimeout()` call in the chain of raced promises.

Fixes #304 