### PR TITLE
Support in-dev Neo4j version

### DIFF
--- a/src/v1/internal/server-version.js
+++ b/src/v1/internal/server-version.js
@@ -20,6 +20,7 @@
 import {assertString} from './util';
 
 const SERVER_VERSION_REGEX = new RegExp('^(Neo4j/)?(\\d+)\\.(\\d+)(?:\\.)?(\\d*)(\\.|-|\\+)?([0-9A-Za-z-.]*)?$');
+const NEO4J_IN_DEV_VERSION_STRING = 'Neo4j/dev';
 
 class ServerVersion {
 
@@ -47,6 +48,10 @@ class ServerVersion {
     }
 
     assertString(versionStr, 'Neo4j version string');
+
+    if (versionStr.toLowerCase() === NEO4J_IN_DEV_VERSION_STRING.toLowerCase()) {
+      return VERSION_IN_DEV;
+    }
 
     const version = versionStr.match(SERVER_VERSION_REGEX);
     if (!version) {
@@ -80,7 +85,7 @@ class ServerVersion {
 }
 
 function parseIntStrict(str, name) {
-  const value = parseInt(str);
+  const value = parseInt(str, 10);
   if (!value && value !== 0) {
     throw new Error(`Unparsable number ${name}: '${str}'`);
   }
@@ -93,11 +98,13 @@ function compareInts(x, y) {
 
 const VERSION_3_1_0 = new ServerVersion(3, 1, 0);
 const VERSION_3_2_0 = new ServerVersion(3, 2, 0);
+const VERSION_IN_DEV = new ServerVersion(0, 0, 0);
 
 export {
   ServerVersion,
   VERSION_3_1_0,
-  VERSION_3_2_0
+  VERSION_3_2_0,
+  VERSION_IN_DEV
 };
 
 

--- a/test/internal/server-version.test.js
+++ b/test/internal/server-version.test.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import {ServerVersion, VERSION_3_2_0} from '../../src/v1/internal/server-version';
+import {ServerVersion, VERSION_3_2_0, VERSION_IN_DEV} from '../../src/v1/internal/server-version';
 
 describe('ServerVersion', () => {
 
@@ -74,6 +74,10 @@ describe('ServerVersion', () => {
     verifyVersion(parse('Neo4j/3.0-RC01'), 3, 0, 0);
     verifyVersion(parse('Neo4j/2.3-SNAPSHOT'), 2, 3, 0);
     verifyVersion(parse('Neo4j/2.2-M09'), 2, 2, 0);
+
+    verifyVersion(parse('Neo4j/dev'), 0, 0, 0);
+    verifyVersion(parse('Neo4j/DEV'), 0, 0, 0);
+    verifyVersion(parse('Neo4j/Dev'), 0, 0, 0);
   });
 
   it('should compare equal versions', () => {
@@ -103,6 +107,12 @@ describe('ServerVersion', () => {
     expect(new ServerVersion(1, 8, 2).compareTo(new ServerVersion(1, 8, 8))).toBeLessThan(0);
     expect(new ServerVersion(9, 9, 9).compareTo(new ServerVersion(9, 9, 0))).toBeGreaterThan(0);
     expect(new ServerVersion(3, 3, 3).compareTo(new ServerVersion(3, 3, 42))).toBeLessThan(0);
+  });
+
+  it('should compare dev version', () => {
+    expect(new ServerVersion(3, 1, 0).compareTo(VERSION_IN_DEV)).toBeGreaterThan(0);
+    expect(new ServerVersion(3, 3, 6).compareTo(VERSION_IN_DEV)).toBeGreaterThan(0);
+    expect(new ServerVersion(2, 3, 0).compareTo(VERSION_IN_DEV)).toBeGreaterThan(0);
   });
 
 });


### PR DESCRIPTION
Driver receives Neo4j version in response for INIT message. Released versions have format `Neo4j/X.Y.Z` and in-dev version has `Neo4j/dev`. Previously driver was not able to parse the later and failed.

This PR fixes the problem, `ServerVersion` will now be able to represent an in-dev version. Such `ServerVersion` is treated lower than any other version because driver can't know which features it supports and which it does not.