### PR TITLE
Introduce 'disableLosslessIntegers' config option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-driver",
-  "version": "1.5.0-dev",
+  "version": "1.6.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -157,6 +157,17 @@ const USER_AGENT = "neo4j-javascript/" + VERSION;
  *       // result in no timeout being applied. Connection establishment will be then bound by the timeout configured
  *       // on the operating system level. Default value is 5000, which is 5 seconds.
  *       connectionTimeout: 5000, // 5 seconds
+ *
+ *       // Make this driver always return and accept native JavaScript number for integer values, instead of the
+ *       // dedicated {@link Integer} class. Values that do not fit in native number bit range will be represented as
+ *       // <code>Number.NEGATIVE_INFINITY</code> or <code>Number.POSITIVE_INFINITY</code>. Driver will fail to encode
+ *       // {@link Integer} values passed as query parameters when this setting is set to <code>true</code>.
+ *       // <b>Warning:</b> It is not safe to enable this setting when JavaScript applications are not the only ones
+ *       // interacting with the database. Stored numbers might in such case be not representable by native
+ *       // {@link Number} type and thus driver will return lossy values. For example, this might happen when data was
+ *       // initially imported using neo4j import tool and contained numbers larger than
+ *       // <code>Number.MAX_SAFE_INTEGER</code>. Driver will then return positive infinity, which is lossy.
+ *       useNativeNumbers: false,
  *     }
  *
  * @param {string} url The URL for the Neo4j database, for instance "bolt://localhost"

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -158,16 +158,17 @@ const USER_AGENT = "neo4j-javascript/" + VERSION;
  *       // on the operating system level. Default value is 5000, which is 5 seconds.
  *       connectionTimeout: 5000, // 5 seconds
  *
- *       // Make this driver always return and accept native JavaScript number for integer values, instead of the
+ *       // Make this driver always return native JavaScript numbers for integer values, instead of the
  *       // dedicated {@link Integer} class. Values that do not fit in native number bit range will be represented as
- *       // <code>Number.NEGATIVE_INFINITY</code> or <code>Number.POSITIVE_INFINITY</code>. Driver will fail to encode
- *       // {@link Integer} values passed as query parameters when this setting is set to <code>true</code>.
- *       // <b>Warning:</b> It is not safe to enable this setting when JavaScript applications are not the only ones
+ *       // <code>Number.NEGATIVE_INFINITY</code> or <code>Number.POSITIVE_INFINITY</code>.
+ *       // <b>Warning:</b> It is not always safe to enable this setting when JavaScript applications are not the only ones
  *       // interacting with the database. Stored numbers might in such case be not representable by native
- *       // {@link Number} type and thus driver will return lossy values. For example, this might happen when data was
+ *       // {@link Number} type and thus driver will return lossy values. This might also happen when data was
  *       // initially imported using neo4j import tool and contained numbers larger than
  *       // <code>Number.MAX_SAFE_INTEGER</code>. Driver will then return positive infinity, which is lossy.
- *       useNativeNumbers: false,
+ *       // Default value for this option is <code>false</code> because native JavaScript numbers might result
+ *       // in loss of precision in the general case.
+ *       disableLosslessIntegers: false,
  *     }
  *
  * @param {string} url The URL for the Neo4j database, for instance "bolt://localhost"

--- a/src/v1/integer.js
+++ b/src/v1/integer.js
@@ -89,6 +89,21 @@ class Integer {
   toNumber(){ return this.high * TWO_PWR_32_DBL + (this.low >>> 0); }
 
   /**
+   * Converts the Integer to native number or -Infinity/+Infinity when it does not fit.
+   * @return {number}
+   * @package
+   */
+  toNumberOrInfinity() {
+    if (this.lessThan(Integer.MIN_SAFE_VALUE)) {
+      return Number.NEGATIVE_INFINITY;
+    } else if (this.greaterThan(Integer.MAX_SAFE_VALUE)) {
+      return Number.POSITIVE_INFINITY;
+    } else {
+      return this.toNumber();
+    }
+  }
+
+  /**
    * Converts the Integer to a string written in the specified radix.
    * @param {number=} radix Radix (2-36), defaults to 10
    * @returns {string}

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -164,10 +164,10 @@ class Connection {
    * @constructor
    * @param {NodeChannel|WebSocketChannel} channel - channel with a 'write' function and a 'onmessage' callback property.
    * @param {string} url - the hostname and port to connect to.
-   * @param {boolean} useNativeNumbers if this connection should treat/convert all received numbers
+   * @param {boolean} disableLosslessIntegers if this connection should convert all received integers to native JS numbers
    * (including native {@link Number} type or our own {@link Integer}) as native {@link Number}.
    */
-  constructor(channel, url, useNativeNumbers = false) {
+  constructor(channel, url, disableLosslessIntegers = false) {
     /**
      * An ordered queue of observers, each exchange response (zero or more
      * RECORD messages followed by a SUCCESS message) we recieve will be routed
@@ -181,8 +181,8 @@ class Connection {
     this._ch = channel;
     this._dechunker = new Dechunker();
     this._chunker = new Chunker( channel );
-    this._packer = new Packer(this._chunker, useNativeNumbers);
-    this._unpacker = new Unpacker(useNativeNumbers);
+    this._packer = new Packer(this._chunker, disableLosslessIntegers);
+    this._unpacker = new Unpacker(disableLosslessIntegers);
 
     this._isHandlingFailure = false;
     this._currentFailure = null;
@@ -589,7 +589,7 @@ function connect(url, config = {}, connectionErrorCode = null) {
   const Ch = config.channel || Channel;
   const parsedUrl = urlUtil.parseBoltUrl(url);
   const channelConfig = new ChannelConfig(parsedUrl, config, connectionErrorCode);
-  return new Connection(new Ch(channelConfig), parsedUrl.hostAndPort, config.useNativeNumbers);
+  return new Connection(new Ch(channelConfig), parsedUrl.hostAndPort, config.disableLosslessIntegers);
 }
 
 export {

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -162,11 +162,12 @@ class Connection {
 
   /**
    * @constructor
-   * @param channel - channel with a 'write' function and a 'onmessage'
-   *                  callback property
-   * @param url - url to connect to
+   * @param {NodeChannel|WebSocketChannel} channel - channel with a 'write' function and a 'onmessage' callback property.
+   * @param {string} url - the hostname and port to connect to.
+   * @param {boolean} useNativeNumbers if this connection should treat/convert all received numbers
+   * (including native {@link Number} type or our own {@link Integer}) as native {@link Number}.
    */
-  constructor (channel, url) {
+  constructor(channel, url, useNativeNumbers = false) {
     /**
      * An ordered queue of observers, each exchange response (zero or more
      * RECORD messages followed by a SUCCESS message) we recieve will be routed
@@ -180,8 +181,8 @@ class Connection {
     this._ch = channel;
     this._dechunker = new Dechunker();
     this._chunker = new Chunker( channel );
-    this._packer = new Packer( this._chunker );
-    this._unpacker = new Unpacker();
+    this._packer = new Packer(this._chunker, useNativeNumbers);
+    this._unpacker = new Unpacker(useNativeNumbers);
 
     this._isHandlingFailure = false;
     this._currentFailure = null;
@@ -588,7 +589,7 @@ function connect(url, config = {}, connectionErrorCode = null) {
   const Ch = config.channel || Channel;
   const parsedUrl = urlUtil.parseBoltUrl(url);
   const channelConfig = new ChannelConfig(parsedUrl, config, connectionErrorCode);
-  return new Connection(new Ch(channelConfig), parsedUrl.hostAndPort);
+  return new Connection(new Ch(channelConfig), parsedUrl.hostAndPort, config.useNativeNumbers);
 }
 
 export {

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -164,8 +164,7 @@ class Connection {
    * @constructor
    * @param {NodeChannel|WebSocketChannel} channel - channel with a 'write' function and a 'onmessage' callback property.
    * @param {string} url - the hostname and port to connect to.
-   * @param {boolean} disableLosslessIntegers if this connection should convert all received integers to native JS numbers
-   * (including native {@link Number} type or our own {@link Integer}) as native {@link Number}.
+   * @param {boolean} disableLosslessIntegers if this connection should convert all received integers to native JS numbers.
    */
   constructor(channel, url, disableLosslessIntegers = false) {
     /**
@@ -181,7 +180,7 @@ class Connection {
     this._ch = channel;
     this._dechunker = new Dechunker();
     this._chunker = new Chunker( channel );
-    this._packer = new Packer(this._chunker, disableLosslessIntegers);
+    this._packer = new Packer(this._chunker);
     this._unpacker = new Unpacker(disableLosslessIntegers);
 
     this._isHandlingFailure = false;

--- a/src/v1/internal/packstream.js
+++ b/src/v1/internal/packstream.js
@@ -80,13 +80,13 @@ class Packer {
   /**
    * @constructor
    * @param {Chunker} channel the chunker backed by a network channel.
-   * @param {boolean} useNativeNumbers if this packer should treat/convert all received numbers
+   * @param {boolean} disableLosslessIntegers if this packer should convert all received integers to native JS numbers
    * (including native {@link Number} type or our own {@link Integer}) as native {@link Number}.
    */
-  constructor(channel, useNativeNumbers = false) {
+  constructor(channel, disableLosslessIntegers = false) {
     this._ch = channel;
     this._byteArraysSupported = true;
-    this._useNativeNumbers = useNativeNumbers;
+    this._disableLosslessIntegers = disableLosslessIntegers;
   }
 
   /**
@@ -158,7 +158,7 @@ class Packer {
    * @private
    */
   _packableInteger(x, onError) {
-    if (this._useNativeNumbers) {
+    if (this._disableLosslessIntegers) {
       // pack Integer objects only when native numbers are not used, fail otherwise
       // Integer can't represent special values like Number.NEGATIVE_INFINITY
       // and should not be used at all when native numbers are enabled
@@ -343,15 +343,15 @@ class Unpacker {
 
   /**
    * @constructor
-   * @param {boolean} useNativeNumbers if this unpacker should treat/convert all received numbers
+   * @param {boolean} disableLosslessIntegers if this unpacker should convert all received integers to native JS numbers
    * (including native {@link Number} type or our own {@link Integer}) as native {@link Number}.
    */
-  constructor(useNativeNumbers = false) {
+  constructor(disableLosslessIntegers = false) {
     // Higher level layers can specify how to map structs to higher-level objects.
     // If we receive a struct that has a signature that does not have a mapper,
     // we simply return a Structure object.
     this.structMappers = {};
-    this._useNativeNumbers = useNativeNumbers;
+    this._disableLosslessIntegers = disableLosslessIntegers;
   }
 
   unpack(buffer) {
@@ -429,7 +429,7 @@ class Unpacker {
       const high = buffer.readInt32();
       const low = buffer.readInt32();
       const integer = new Integer(low, high);
-      return this._useNativeNumbers ? integer.toNumberOrInfinity() : integer;
+      return this._disableLosslessIntegers ? integer.toNumberOrInfinity() : integer;
     } else {
       return null;
     }

--- a/test/types/v1/driver.test.ts
+++ b/test/types/v1/driver.test.ts
@@ -17,16 +17,7 @@
  * limitations under the License.
  */
 
-import Driver, {
-  AuthToken,
-  Config,
-  EncryptionLevel,
-  LoadBalancingStrategy,
-  READ,
-  SessionMode,
-  TrustStrategy,
-  WRITE
-} from "../../../types/v1/driver";
+import Driver, {AuthToken, Config, EncryptionLevel, LoadBalancingStrategy, READ, SessionMode, TrustStrategy, WRITE} from "../../../types/v1/driver";
 import {Parameters} from "../../../types/v1/statement-runner";
 import Session from "../../../types/v1/session";
 import {Neo4jError} from "../../../types/v1/error";
@@ -61,7 +52,7 @@ const loadBalancingStrategy1: undefined | LoadBalancingStrategy = config.loadBal
 const loadBalancingStrategy2: undefined | string = config.loadBalancingStrategy;
 const maxConnectionLifetime: undefined | number = config.maxConnectionLifetime;
 const connectionTimeout: undefined | number = config.connectionTimeout;
-const useNativeNumbers: undefined | boolean = config.useNativeNumbers;
+const disableLosslessIntegers: undefined | boolean = config.disableLosslessIntegers;
 
 const sessionMode: SessionMode = dummy;
 const sessionModeStr: string = sessionMode;

--- a/test/types/v1/driver.test.ts
+++ b/test/types/v1/driver.test.ts
@@ -59,6 +59,9 @@ const connectionPoolSize: undefined | number = config.connectionPoolSize;
 const maxTransactionRetryTime: undefined | number = config.maxTransactionRetryTime;
 const loadBalancingStrategy1: undefined | LoadBalancingStrategy = config.loadBalancingStrategy;
 const loadBalancingStrategy2: undefined | string = config.loadBalancingStrategy;
+const maxConnectionLifetime: undefined | number = config.maxConnectionLifetime;
+const connectionTimeout: undefined | number = config.connectionTimeout;
+const useNativeNumbers: undefined | boolean = config.useNativeNumbers;
 
 const sessionMode: SessionMode = dummy;
 const sessionModeStr: string = sessionMode;

--- a/test/types/v1/graph-types.test.ts
+++ b/test/types/v1/graph-types.test.ts
@@ -26,6 +26,9 @@ const node1Id: Integer = node1.identity;
 const node1Labels: string[] = node1.labels;
 const node1Props: object = node1.properties;
 
+const node2: Node<number> = new Node(2, ["Person", "Employee"], {name: "Alice"});
+const node2Id: number = node2.identity;
+
 const rel1: Relationship = new Relationship(int(1), int(2), int(3), "KNOWS", {since: 12345});
 const rel1String: string = rel1.toString();
 const rel1Id: Integer = rel1.identity;
@@ -41,13 +44,35 @@ const rel2Id: Integer = rel2.identity;
 const rel2Type: string = rel2.type;
 const rel2Props: object = rel2.properties;
 
+const rel4: Relationship<number> = new Relationship(2, 3, 4, "KNOWS", {since: 12345});
+const rel4Id: number = rel4.identity;
+const rel4Start: number = rel4.start;
+const rel4End: number = rel4.end;
+
+const rel5: UnboundRelationship<number> = new UnboundRelationship(5, "KNOWS", {since: 12345});
+const rel5Id: number = rel5.identity;
+const rel6 = rel5.bind(24, 42);
+const rel6Id: number = rel6.identity;
+const rel6Start: number = rel6.start;
+const rel6End: number = rel6.end;
+
 const pathSegment1: PathSegment = new PathSegment(node1, rel1, node1);
 const pathSegment1Start: Node = pathSegment1.start;
 const pathSegment1Rel: Relationship = pathSegment1.relationship;
 const pathSegment1End: Node = pathSegment1.end;
+
+const pathSegment2: PathSegment<number> = new PathSegment(node2, rel4, node2);
+const pathSegment2Start: Node<number> = pathSegment2.start;
+const pathSegment2Rel: Relationship<number> = pathSegment2.relationship;
+const pathSegment2End: Node<number> = pathSegment2.end;
 
 const path1: Path = new Path(node1, node1, [pathSegment1]);
 const path1Start: Node = path1.start;
 const path1End: Node = path1.end;
 const path1Segments: PathSegment[] = path1.segments;
 const path1Length: number = path1.length;
+
+const path2: Path<number> = new Path(node2, node2, [pathSegment2]);
+const path2Start: Node<number> = path2.start;
+const path2End: Node<number> = path2.end;
+const path2Segments: PathSegment<number>[] = path2.segments;

--- a/test/types/v1/result-summary.test.ts
+++ b/test/types/v1/result-summary.test.ts
@@ -17,27 +17,20 @@
  * limitations under the License.
  */
 
-import ResultSummary, {
-  Notification,
-  NotificationPosition,
-  Plan,
-  ProfiledPlan,
-  ServerInfo,
-  StatementStatistic
-} from "../../../types/v1/result-summary";
+import ResultSummary, {Notification, NotificationPosition, Plan, ProfiledPlan, ServerInfo, StatementStatistic} from "../../../types/v1/result-summary";
 import Integer from "../../../types/v1/integer";
 
 const dummy: any = null;
 
-const sum: ResultSummary = dummy;
+const sum1: ResultSummary = dummy;
 
-const stmt = sum.statement;
+const stmt = sum1.statement;
 const stmtText: string = stmt.text;
 const stmtParams: object = stmt.parameters;
 
-const str: string = sum.statementType;
+const str: string = sum1.statementType;
 
-const counters: StatementStatistic = sum.counters;
+const counters: StatementStatistic = sum1.counters;
 
 const containsUpdates: boolean = counters.containsUpdates();
 const nodesCreated: number = counters.nodesCreated();
@@ -52,13 +45,13 @@ const indexesRemoved: number = counters.indexesRemoved();
 const constraintsAdded: number = counters.constraintsAdded();
 const constraintsRemoved: number = counters.constraintsRemoved();
 
-const plan: Plan = sum.plan;
+const plan: Plan = sum1.plan;
 const planOperatorType: string = plan.operatorType;
 const planIdentifiers: string[] = plan.identifiers;
 const planArguments: { [key: string]: string } = plan.arguments;
 const planChildren: Plan[] = plan.children;
 
-const profile: ProfiledPlan = sum.profile;
+const profile: ProfiledPlan = sum1.profile;
 const profileOperatorType: string = profile.operatorType;
 const profileIdentifiers: string[] = profile.identifiers;
 const profileArguments: { [key: string]: string } = profile.arguments;
@@ -66,7 +59,7 @@ const profileDbHits: number = profile.dbHits;
 const profileRows: number = profile.rows;
 const profileChildren: ProfiledPlan[] = profile.children;
 
-const notifications: Notification[] = sum.notifications;
+const notifications: Notification[] = sum1.notifications;
 const notification: Notification = notifications[0];
 const code: string = notification.code;
 const title: string = notification.title;
@@ -78,12 +71,20 @@ const offset: number = position2.offset;
 const line: number = position2.line;
 const column: number = position2.column;
 
-const server: ServerInfo = sum.server;
+const server: ServerInfo = sum1.server;
 const address: string = server.address;
 const version: string = server.version;
 
-const resultConsumedAfter: Integer = sum.resultConsumedAfter;
-const resultAvailableAfter: Integer = sum.resultAvailableAfter;
+const resultConsumedAfter1: Integer = sum1.resultConsumedAfter;
+const resultAvailableAfter1: Integer = sum1.resultAvailableAfter;
 
-const hasPlan: boolean = sum.hasPlan();
-const hasProfile: boolean = sum.hasProfile();
+const hasPlan: boolean = sum1.hasPlan();
+const hasProfile: boolean = sum1.hasProfile();
+
+const sum2: ResultSummary<number> = dummy;
+const resultConsumedAfter2: number = sum2.resultConsumedAfter;
+const resultAvailableAfter2: number = sum2.resultAvailableAfter;
+
+const sum3: ResultSummary<Integer> = dummy;
+const resultConsumedAfter3: Integer = sum3.resultConsumedAfter;
+const resultAvailableAfter3: Integer = sum3.resultAvailableAfter;

--- a/test/v1/driver.test.js
+++ b/test/v1/driver.test.js
@@ -338,14 +338,14 @@ describe('driver', () => {
 
   nativeNumbers.forEach(number => {
 
-    it(`should return native number ${number} when useNativeNumbers=true`, done => {
+    it(`should return native number ${number} when disableLosslessIntegers=true`, done => {
       testNativeNumberInReturnedRecord(number, done);
     });
 
   });
 
-  it('should fail to pack Integer when useNativeNumbers=true', done => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {useNativeNumbers: true});
+  it('should fail to pack Integer when disableLosslessIntegers=true', done => {
+    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {disableLosslessIntegers: true});
     const session = driver.session();
 
     session.run('RETURN $number', {number: neo4j.int(42)})
@@ -379,7 +379,7 @@ describe('driver', () => {
   }
 
   function testNativeNumberInReturnedRecord(number, done) {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {useNativeNumbers: true});
+    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {disableLosslessIntegers: true});
 
     const session = driver.session();
     session.run('RETURN $number AS n0, $number AS n1', {number: number}).then(result => {

--- a/test/v1/integer.test.js
+++ b/test/v1/integer.test.js
@@ -17,27 +17,52 @@
  * limitations under the License.
  */
 
-var v1 = require('../../lib/v1');
-var int = v1.int;
-var integer = v1.integer;
+import neo4j from '../../src/v1';
+import Integer from '../../src/v1/integer';
 
-describe('Pool', function() {
-  it('exposes inSafeRange function', function () {
-    expect(integer.inSafeRange(int("9007199254740991"))).toBeTruthy();
-    expect(integer.inSafeRange(int("9007199254740992"))).toBeFalsy();
-    expect(integer.inSafeRange(int("-9007199254740991"))).toBeTruthy();
-    expect(integer.inSafeRange(int("-9007199254740992"))).toBeFalsy();
+const int = neo4j.int;
+const integer = neo4j.integer;
+
+describe('Integer', () => {
+
+  it('exposes inSafeRange function', () => {
+    expect(integer.inSafeRange(int('9007199254740991'))).toBeTruthy();
+    expect(integer.inSafeRange(int('9007199254740992'))).toBeFalsy();
+    expect(integer.inSafeRange(int('-9007199254740991'))).toBeTruthy();
+    expect(integer.inSafeRange(int('-9007199254740992'))).toBeFalsy();
   });
 
-  it('exposes toNumber function', function () {
-    expect(integer.toNumber(int("9007199254740991"))).toEqual(9007199254740991);
-    expect(integer.toNumber(int("-9007199254740991"))).toEqual(-9007199254740991);
+  it('exposes toNumber function', () => {
+    expect(integer.toNumber(int('9007199254740991'))).toEqual(9007199254740991);
+    expect(integer.toNumber(int('-9007199254740991'))).toEqual(-9007199254740991);
   });
 
-  it('exposes toString function', function () {
-    expect(integer.toString(int("9007199254740991"))).toEqual("9007199254740991");
-    expect(integer.toString(int("9007199254740992"))).toEqual("9007199254740992");
-    expect(integer.toString(int("-9007199254740991"))).toEqual("-9007199254740991");
-    expect(integer.toString(int("-9007199254740992"))).toEqual("-9007199254740992");
+  it('exposes toString function', () => {
+    expect(integer.toString(int('9007199254740991'))).toEqual('9007199254740991');
+    expect(integer.toString(int('9007199254740992'))).toEqual('9007199254740992');
+    expect(integer.toString(int('-9007199254740991'))).toEqual('-9007199254740991');
+    expect(integer.toString(int('-9007199254740992'))).toEqual('-9007199254740992');
   });
+
+  it('converts to number when safe', () => {
+    expect(int('42').toNumberOrInfinity()).toEqual(42);
+    expect(int('4242').toNumberOrInfinity()).toEqual(4242);
+    expect(int('-999').toNumberOrInfinity()).toEqual(-999);
+    expect(int('1000000000').toNumberOrInfinity()).toEqual(1000000000);
+    expect(Integer.MIN_SAFE_VALUE.toNumberOrInfinity()).toEqual(Integer.MIN_SAFE_VALUE.toNumber());
+    expect(Integer.MAX_SAFE_VALUE.toNumberOrInfinity()).toEqual(Integer.MAX_SAFE_VALUE.toNumber());
+  });
+
+  it('converts to negative infinity when too small', () => {
+    expect(Integer.MIN_SAFE_VALUE.subtract(1).toNumberOrInfinity()).toEqual(Number.NEGATIVE_INFINITY);
+    expect(Integer.MIN_SAFE_VALUE.subtract(42).toNumberOrInfinity()).toEqual(Number.NEGATIVE_INFINITY);
+    expect(Integer.MIN_SAFE_VALUE.subtract(100).toNumberOrInfinity()).toEqual(Number.NEGATIVE_INFINITY);
+  });
+
+  it('converts to positive infinity when too large', () => {
+    expect(Integer.MAX_SAFE_VALUE.add(1).toNumberOrInfinity()).toEqual(Number.POSITIVE_INFINITY);
+    expect(Integer.MAX_SAFE_VALUE.add(24).toNumberOrInfinity()).toEqual(Number.POSITIVE_INFINITY);
+    expect(Integer.MAX_SAFE_VALUE.add(999).toNumberOrInfinity()).toEqual(Number.POSITIVE_INFINITY);
+  });
+
 });

--- a/types/v1/driver.d.ts
+++ b/types/v1/driver.d.ts
@@ -54,7 +54,7 @@ declare interface Config {
   loadBalancingStrategy?: LoadBalancingStrategy;
   maxConnectionLifetime?: number;
   connectionTimeout?: number;
-  useNativeNumbers?: boolean;
+  disableLosslessIntegers?: boolean;
 }
 
 declare type SessionMode = "READ" | "WRITE";

--- a/types/v1/driver.d.ts
+++ b/types/v1/driver.d.ts
@@ -54,6 +54,7 @@ declare interface Config {
   loadBalancingStrategy?: LoadBalancingStrategy;
   maxConnectionLifetime?: number;
   connectionTimeout?: number;
+  useNativeNumbers?: boolean;
 }
 
 declare type SessionMode = "READ" | "WRITE";

--- a/types/v1/graph-types.d.ts
+++ b/types/v1/graph-types.d.ts
@@ -19,7 +19,9 @@
 
 import Integer from "./integer";
 
-declare class Node<T extends (Integer | number) = Integer> {
+declare type NumberOrInteger = number | Integer;
+
+declare class Node<T extends NumberOrInteger = Integer> {
   identity: T;
   labels: string[];
   properties: object;
@@ -31,7 +33,7 @@ declare class Node<T extends (Integer | number) = Integer> {
   toString(): string;
 }
 
-declare class Relationship<T extends (Integer | number) = Integer> {
+declare class Relationship<T extends NumberOrInteger = Integer> {
   identity: T;
   start: T;
   end: T;
@@ -47,7 +49,7 @@ declare class Relationship<T extends (Integer | number) = Integer> {
   toString(): string;
 }
 
-declare class UnboundRelationship<T extends (Integer | number) = Integer> {
+declare class UnboundRelationship<T extends NumberOrInteger = Integer> {
   identity: T;
   type: string;
   properties: object;
@@ -61,7 +63,7 @@ declare class UnboundRelationship<T extends (Integer | number) = Integer> {
   toString(): string;
 }
 
-declare class PathSegment<T extends (Integer | number) = Integer> {
+declare class PathSegment<T extends NumberOrInteger = Integer> {
   start: Node<T>;
   relationship: Relationship<T>;
   end: Node<T>;
@@ -71,7 +73,7 @@ declare class PathSegment<T extends (Integer | number) = Integer> {
               end: Node<T>);
 }
 
-declare class Path<T extends (Integer | number) = Integer> {
+declare class Path<T extends NumberOrInteger = Integer> {
   start: Node<T>;
   end: Node<T>;
   segments: PathSegment<T>[];
@@ -87,5 +89,6 @@ export {
   Relationship,
   UnboundRelationship,
   Path,
-  PathSegment
+  PathSegment,
+  NumberOrInteger
 }

--- a/types/v1/graph-types.d.ts
+++ b/types/v1/graph-types.d.ts
@@ -19,67 +19,67 @@
 
 import Integer from "./integer";
 
-declare class Node {
-  identity: Integer;
+declare class Node<T extends (Integer | number) = Integer> {
+  identity: T;
   labels: string[];
   properties: object;
 
-  constructor(identity: Integer,
+  constructor(identity: T,
               labels: string[],
               properties: object)
 
   toString(): string;
 }
 
-declare class Relationship {
-  identity: Integer;
-  start: Integer;
-  end: Integer;
+declare class Relationship<T extends (Integer | number) = Integer> {
+  identity: T;
+  start: T;
+  end: T;
   type: string;
   properties: object;
 
-  constructor(identity: Integer,
-              start: Integer,
-              end: Integer,
+  constructor(identity: T,
+              start: T,
+              end: T,
               type: string,
               properties: object);
 
   toString(): string;
 }
 
-declare class UnboundRelationship {
-  identity: Integer;
+declare class UnboundRelationship<T extends (Integer | number) = Integer> {
+  identity: T;
   type: string;
   properties: object;
 
-  constructor(identity: Integer,
+  constructor(identity: T,
               type: string,
               properties: object);
 
-  bind(start: Integer, end: Integer): Relationship;
+  bind(start: T, end: T): Relationship<T>;
 
   toString(): string;
 }
 
-declare class PathSegment {
-  start: Node;
-  relationship: Relationship;
-  end: Node;
+declare class PathSegment<T extends (Integer | number) = Integer> {
+  start: Node<T>;
+  relationship: Relationship<T>;
+  end: Node<T>;
 
-  constructor(start: Node,
-              rel: Relationship,
-              end: Node);
+  constructor(start: Node<T>,
+              rel: Relationship<T>,
+              end: Node<T>);
 }
 
-declare class Path {
-  start: Node;
-  end: Node;
-  segments: PathSegment[];
+declare class Path<T extends (Integer | number) = Integer> {
+  start: Node<T>;
+  end: Node<T>;
+  segments: PathSegment<T>[];
   length: number;
 
-  constructor(start: Node,
-              end: Node,
-              segments: PathSegment[]);
+  constructor(start: Node<T>,
+              end: Node<T>,
+              segments: PathSegment<T>[]);
 }
 
 export {

--- a/types/v1/result-summary.d.ts
+++ b/types/v1/result-summary.d.ts
@@ -19,7 +19,7 @@
 
 import Integer from "./integer";
 
-declare interface ResultSummary {
+declare interface ResultSummary<T extends (Integer | number) = Integer> {
   statement: { text: string, parameters: { [key: string]: any } };
   statementType: string;
   counters: StatementStatistic;
@@ -27,8 +27,8 @@ declare interface ResultSummary {
   profile: ProfiledPlan;
   notifications: Notification[];
   server: ServerInfo;
-  resultConsumedAfter: Integer;
-  resultAvailableAfter: Integer;
+  resultConsumedAfter: T;
+  resultAvailableAfter: T;
 
   hasPlan(): boolean;
 

--- a/types/v1/result-summary.d.ts
+++ b/types/v1/result-summary.d.ts
@@ -18,8 +18,9 @@
  */
 
 import Integer from "./integer";
+import {NumberOrInteger} from "./graph-types";
 
-declare interface ResultSummary<T extends (Integer | number) = Integer> {
+declare interface ResultSummary<T extends NumberOrInteger = Integer> {
   statement: { text: string, parameters: { [key: string]: any } };
   statementType: string;
   counters: StatementStatistic;


### PR DESCRIPTION
This boolean option allows users to make driver accept and represent integer values as native JavaScript `Number`s instead of driver's special `Integer`s. When this option is set to `true` driver will fail to encode `Integer` values passed as query parameters. All returned `Record`, `Node`, `Relationship`, etc. will have their integer fields as native `Number`s. Object returned by `Record#toObject()` will also contain native numbers.

**Warning:** enabling this setting can potentially make driver return lossy integer values. This would be the case when database contain integer values which do not fit in `[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]` range. Such integers will then be represented as `Number.NEGATIVE_INFINITY` or `Number.POSITIVE_INFINITY`, which is lossy and different from what is actually stored in the database. That is why this option is set to `false` by default. Driver's `Integer` class is able to represent integer values beyond `[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]` and thus is a much safer option in the general case.

Fixes #322 
Related to #245, #225, #122