### PR TITLE
Experimental HTTP support via transactional Cypher endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2822,11 +2822,6 @@
         }
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
@@ -3728,14 +3723,6 @@
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
       "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
       "dev": true
-    },
-    "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "requires": {
-        "is-function": "1.0.1"
-      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -4891,22 +4878,6 @@
       "dev": true,
       "requires": {
         "find-index": "0.1.1"
-      }
-    },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-        }
       }
     },
     "global-modules": {
@@ -6339,11 +6310,6 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
-    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
@@ -7443,14 +7409,6 @@
         "mime-db": "1.30.0"
       }
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "0.1.1"
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -8010,15 +7968,6 @@
             "is-extglob": "1.0.0"
           }
         }
-      }
-    },
-    "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
-      "requires": {
-        "for-each": "0.3.2",
-        "trim": "0.0.1"
       }
     },
     "parse-json": {
@@ -9778,11 +9727,6 @@
       "dev": true,
       "optional": true
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -10471,17 +10415,6 @@
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
       "dev": true
     },
-    "xhr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
-      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
-      "requires": {
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "parse-headers": "2.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "xml-name-validator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
@@ -10498,7 +10431,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "yargs": {
       "version": "3.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2822,6 +2822,11 @@
         }
       }
     },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
@@ -3723,6 +3728,14 @@
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
       "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "requires": {
+        "is-function": "1.0.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -4878,6 +4891,22 @@
       "dev": true,
       "requires": {
         "find-index": "0.1.1"
+      }
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        }
       }
     },
     "global-modules": {
@@ -6310,6 +6339,11 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
@@ -7409,6 +7443,14 @@
         "mime-db": "1.30.0"
       }
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -7968,6 +8010,15 @@
             "is-extglob": "1.0.0"
           }
         }
+      }
+    },
+    "parse-headers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "requires": {
+        "for-each": "0.3.2",
+        "trim": "0.0.1"
       }
     },
     "parse-json": {
@@ -9727,6 +9778,11 @@
       "dev": true,
       "optional": true
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -10415,6 +10471,17 @@
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
       "dev": true
     },
+    "xhr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
+      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
+      "requires": {
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
+      }
+    },
     "xml-name-validator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
@@ -10431,8 +10498,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yargs": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "run-tck": "gulp run-tck",
     "run-ts-declaration-tests": "gulp run-ts-declaration-tests",
     "docs": "esdoc -c esdoc.json",
-    "versionRelease": "gulp set --version $VERSION && npm version $VERSION --no-git-tag-version"
+    "versionRelease": "gulp set --version $VERSION && npm version $VERSION --no-git-tag-version",
+    "browser": "gulp browser && gulp test-browser"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",
@@ -70,6 +71,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.18.0",
-    "url-parse": "^1.2.0"
+    "url-parse": "^1.2.0",
+    "xhr": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   },
   "dependencies": {
     "babel-runtime": "^6.18.0",
-    "url-parse": "^1.2.0",
-    "xhr": "^2.4.1"
+    "url-parse": "^1.2.0"
   }
 }

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -28,6 +28,7 @@ import RoutingDriver from './routing-driver';
 import VERSION from '../version';
 import {assertString, isEmptyObjectOrNull} from './internal/util';
 import urlUtil from './internal/url-util';
+import HttpDriver from './internal/http/http-driver';
 
 /**
  * @property {function(username: string, password: string, realm: ?string)} basic the function to create a
@@ -186,6 +187,8 @@ function driver(url, authToken, config = {}) {
       throw new Error(`Parameters are not supported with scheme 'bolt'. Given URL: '${url}'`);
     }
     return new Driver(parsedUrl.hostAndPort, USER_AGENT, authToken, config);
+  } else if (parsedUrl.scheme === 'http') {
+    return new HttpDriver(parsedUrl, USER_AGENT, authToken, config);
   } else {
     throw new Error(`Unknown scheme: ${parsedUrl.scheme}`);
   }

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -187,7 +187,7 @@ function driver(url, authToken, config = {}) {
       throw new Error(`Parameters are not supported with scheme 'bolt'. Given URL: '${url}'`);
     }
     return new Driver(parsedUrl.hostAndPort, USER_AGENT, authToken, config);
-  } else if (parsedUrl.scheme === 'http') {
+  } else if (parsedUrl.scheme === 'http' || parsedUrl.scheme === 'https') {
     return new HttpDriver(parsedUrl, USER_AGENT, authToken, config);
   } else {
     throw new Error(`Unknown scheme: ${parsedUrl.scheme}`);

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -179,7 +179,7 @@ const USER_AGENT = "neo4j-javascript/" + VERSION;
  */
 function driver(url, authToken, config = {}) {
   assertString(url, 'Bolt URL');
-  const parsedUrl = urlUtil.parseBoltUrl(url);
+  const parsedUrl = urlUtil.parseDatabaseUrl(url);
   if (parsedUrl.scheme === 'bolt+routing') {
     return new RoutingDriver(parsedUrl.hostAndPort, parsedUrl.query, USER_AGENT, authToken, config);
   } else if (parsedUrl.scheme === 'bolt') {

--- a/src/v1/internal/ch-config.js
+++ b/src/v1/internal/ch-config.js
@@ -22,8 +22,6 @@ import {SERVICE_UNAVAILABLE} from '../error';
 
 const DEFAULT_CONNECTION_TIMEOUT_MILLIS = 5000; // 5 seconds by default
 
-export const DEFAULT_PORT = 7687;
-
 export default class ChannelConfig {
 
   /**

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -586,7 +586,7 @@ class ConnectionState {
  */
 function connect(url, config = {}, connectionErrorCode = null) {
   const Ch = config.channel || Channel;
-  const parsedUrl = urlUtil.parseBoltUrl(url);
+  const parsedUrl = urlUtil.parseDatabaseUrl(url);
   const channelConfig = new ChannelConfig(parsedUrl, config, connectionErrorCode);
   return new Connection(new Ch(channelConfig), parsedUrl.hostAndPort, config.disableLosslessIntegers);
 }

--- a/src/v1/internal/host-name-resolvers.js
+++ b/src/v1/internal/host-name-resolvers.js
@@ -41,7 +41,7 @@ export class DnsHostNameResolver extends HostNameResolver {
   }
 
   resolve(seedRouter) {
-    const parsedAddress = urlUtil.parseBoltUrl(seedRouter);
+    const parsedAddress = urlUtil.parseDatabaseUrl(seedRouter);
 
     return new Promise((resolve) => {
       this._dns.lookup(parsedAddress.host, {all: true}, (error, addresses) => {

--- a/src/v1/internal/http/http-data-converter.js
+++ b/src/v1/internal/http/http-data-converter.js
@@ -71,10 +71,7 @@ export default class HttpDataConverter {
    * @return {object[][]} raw records from the response.
    */
   extractRawRecords(response) {
-
     const result = extractResult(response);
-
-
     if (result) {
       const data = result.data;
       if (data) {
@@ -153,8 +150,6 @@ function extractResult(response) {
 }
 
 function extractRawRecord(data) {
-
-
   const row = data.row;
 
   const nodesById = indexNodesById(data);
@@ -208,8 +203,6 @@ function indexRelationshipsById(data) {
 }
 
 function extractRawRecordElement(index, data, nodesById, relationshipsById) {
-
-
   const element = data.row ? data.row[index] : null;
   const elementMetadata = data.meta ? data.meta[index] : null;
 

--- a/src/v1/internal/http/http-data-converter.js
+++ b/src/v1/internal/http/http-data-converter.js
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isInt} from '../../integer';
+import {Node, Path, PathSegment, Relationship} from '../../graph-types';
+import {Neo4jError, SERVICE_UNAVAILABLE} from '../../error';
+
+export default class HttpDataConverter {
+
+  encodeStatementParameters(parameters) {
+    return encodeQueryParameters(parameters);
+  }
+
+  /**
+   * Convert network error to a {@link Neo4jError}.
+   * @param {object} error the error to convert.
+   * @return {Neo4jError} new driver friendly error.
+   */
+  convertNetworkError(error) {
+    return new Neo4jError(error.message, SERVICE_UNAVAILABLE);
+  }
+
+  /**
+   * Attempts to extract error from transactional cypher endpoint response and convert it to {@link Neo4jError}.
+   * @param {object} response the response.
+   * @return {Neo4jError|null} new driver friendly error, if exists.
+   */
+  extractError(response) {
+    const errors = response.errors;
+    if (errors) {
+      const error = errors[0];
+      if (error) {
+        const code = error.code;
+        const message = error.message;
+        return new Neo4jError(message, code);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Extracts record metadata (array of column names) from transactional cypher endpoint response.
+   * @param {object} response the response.
+   * @return {object} new metadata object.
+   */
+  extractRecordMetadata(response) {
+    const result = extractResult(response);
+    const fields = result ? result.columns : [];
+    return {fields: fields};
+  }
+
+  /**
+   * Extracts raw records (each raw record is just an array of value) from transactional cypher endpoint response.
+   * @param {object} response the response.
+   * @return {object[][]} raw records from the response.
+   */
+  extractRawRecords(response) {
+
+    const result = extractResult(response);
+
+
+    if (result) {
+      const data = result.data;
+      if (data) {
+        return data.map(element => extractRawRecord(element));
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Extracts metadata for a completed statement.
+   * @param {object} response the response.
+   * @return {object} metadata as object.
+   */
+  extractStatementMetadata(response) {
+    const result = extractResult(response);
+    if (result) {
+      const stats = result.stats;
+      if (stats) {
+        const convertedStats = Object.keys(stats).reduce((newStats, key) => {
+          if (key === 'contains_updates') {
+            // skip because such key does not exist in bolt
+            return newStats;
+          }
+
+          // fix key name for future parsing by StatementStatistics class
+          const newKey = (key === 'relationship_deleted' ? 'relationships_deleted' : key).replace('_', '-');
+          newStats[newKey] = stats[key];
+          return newStats;
+        }, {});
+
+        return {stats: convertedStats};
+      }
+    }
+    return {};
+  }
+}
+
+function encodeQueryParameters(parameters) {
+  if (parameters && typeof parameters === 'object') {
+    return Object.keys(parameters).reduce((result, key) => {
+      result[key] = encodeQueryParameter(parameters[key]);
+      return result;
+    }, {});
+  }
+  return parameters;
+}
+
+function encodeQueryParameter(value) {
+  if (value instanceof Node) {
+    throw new Neo4jError('It is not allowed to pass nodes in query parameters');
+  } else if (value instanceof Relationship) {
+    throw new Neo4jError('It is not allowed to pass relationships in query parameters');
+  } else if (value instanceof Path) {
+    throw new Neo4jError('It is not allowed to pass paths in query parameters');
+  } else if (isInt(value)) {
+    return value.toNumber();
+  } else if (Array.isArray(value)) {
+    return value.map(element => encodeQueryParameter(element));
+  } else if (typeof value === 'object') {
+    return encodeQueryParameters(value);
+  } else {
+    return value;
+  }
+}
+
+function extractResult(response) {
+  const results = response.results;
+  if (results) {
+    const result = results[0];
+    if (result) {
+      return result;
+    }
+  }
+  return null;
+}
+
+function extractRawRecord(data) {
+
+
+  const row = data.row;
+
+  const nodesById = indexNodesById(data);
+  const relationshipsById = indexRelationshipsById(data);
+
+  if (row) {
+    return row.map((ignore, index) => extractRawRecordElement(index, data, nodesById, relationshipsById));
+  }
+  return [];
+}
+
+function indexNodesById(data) {
+  const graph = data.graph;
+  if (graph) {
+    const nodes = graph.nodes;
+    if (nodes) {
+      return nodes.reduce((result, node) => {
+
+        const identity = convertNumber(node.id);
+        const labels = node.labels;
+        const properties = convertPrimitiveValue(node.properties);
+        result[node.id] = new Node(identity, labels, properties);
+
+        return result;
+      }, {});
+    }
+  }
+  return {};
+}
+
+function indexRelationshipsById(data) {
+  const graph = data.graph;
+  if (graph) {
+    const relationships = graph.relationships;
+    if (relationships) {
+      return relationships.reduce((result, relationship) => {
+
+        const identity = convertNumber(relationship.id);
+        const startNode = convertNumber(relationship.startNode);
+        const endNode = convertNumber(relationship.endNode);
+        const type = relationship.type;
+        const properties = convertPrimitiveValue(relationship.properties);
+        result[relationship.id] = new Relationship(identity, startNode, endNode, type, properties);
+
+        return result;
+
+      }, {});
+    }
+  }
+  return {};
+}
+
+function extractRawRecordElement(index, data, nodesById, relationshipsById) {
+
+
+  const element = data.row ? data.row[index] : null;
+  const elementMetadata = data.meta ? data.meta[index] : null;
+
+  if (elementMetadata) {
+    // element is either a Node, Relationship or Path
+    return convertComplexValue(elementMetadata, nodesById, relationshipsById);
+  } else {
+    // element is a primitive, like number, string, array or object
+    return convertPrimitiveValue(element);
+  }
+}
+
+function convertComplexValue(elementMetadata, nodesById, relationshipsById) {
+  if (isNodeMetadata(elementMetadata)) {
+    return nodesById[elementMetadata.id];
+  } else if (isRelationshipMetadata(elementMetadata)) {
+    return relationshipsById[elementMetadata.id];
+  } else if (isPathMetadata(elementMetadata)) {
+    return convertPath(elementMetadata, nodesById, relationshipsById);
+  } else {
+    return null;
+  }
+}
+
+function convertPath(metadata, nodesById, relationshipsById) {
+  let startNode = null;
+  let relationship = null;
+  const pathSegments = [];
+
+  for (let i = 0; i < metadata.length; i++) {
+    const element = metadata[i];
+    const elementId = element.id;
+    const elementType = element.type;
+
+    const nodeExpected = (startNode === null && relationship === null) || (startNode !== null && relationship !== null);
+    if (nodeExpected && elementType !== 'node') {
+      throw new Neo4jError(`Unable to parse path, node expected but got: ${JSON.stringify(element)} in ${JSON.stringify(metadata)}`);
+    }
+    if (!nodeExpected && elementType === 'node') {
+      throw new Neo4jError(`Unable to parse path, relationship expected but got: ${JSON.stringify(element)} in ${JSON.stringify(metadata)}`);
+    }
+
+    if (nodeExpected) {
+      const node = nodesById[elementId];
+      if (startNode === null) {
+        startNode = node;
+      } else if (startNode !== null && relationship !== null) {
+        const pathSegment = new PathSegment(startNode, relationship, node);
+        pathSegments.push(pathSegment);
+        startNode = node;
+        relationship = null;
+      } else {
+        throw new Neo4jError(`Unable to parse path, illegal node configuration: ${JSON.stringify(metadata)}`);
+      }
+    } else {
+      if (relationship === null) {
+        relationship = relationshipsById[elementId];
+      } else {
+        throw new Neo4jError(`Unable to parse path, illegal relationship configuration: ${JSON.stringify(metadata)}`);
+      }
+    }
+  }
+
+  const lastPathSegment = pathSegments[pathSegments.length - 1];
+  if ((lastPathSegment && lastPathSegment.end !== startNode) || relationship !== null) {
+    throw new Neo4jError(`Unable to parse path: ${JSON.stringify(metadata)}`);
+  }
+
+  return createPath(pathSegments);
+}
+
+function createPath(pathSegments) {
+  const pathStartNode = pathSegments[0].start;
+  const pathEndNode = pathSegments[pathSegments.length - 1].end;
+  return new Path(pathStartNode, pathEndNode, pathSegments);
+}
+
+function convertPrimitiveValue(element) {
+  if (element == null || element === undefined) {
+    return null;
+  } else if (typeof element === 'number') {
+    return convertNumber(element);
+  } else if (Array.isArray(element)) {
+    return element.map(element => convertPrimitiveValue(element));
+  } else if (typeof element === 'object') {
+    return Object.keys(element).reduce((result, key) => {
+      result[key] = convertPrimitiveValue(element[key]);
+      return result;
+    }, {});
+  } else {
+    return element;
+  }
+}
+
+function convertNumber(value) {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+function isNodeMetadata(metadata) {
+  return !Array.isArray(metadata) && typeof metadata === 'object' && metadata.type === 'node';
+}
+
+function isRelationshipMetadata(metadata) {
+  return !Array.isArray(metadata) && typeof metadata === 'object' && metadata.type === 'relationship';
+}
+
+function isPathMetadata(metadata) {
+  return Array.isArray(metadata);
+}

--- a/src/v1/internal/http/http-data-converter.js
+++ b/src/v1/internal/http/http-data-converter.js
@@ -21,6 +21,8 @@ import {isInt} from '../../integer';
 import {Node, Path, PathSegment, Relationship} from '../../graph-types';
 import {Neo4jError, SERVICE_UNAVAILABLE} from '../../error';
 
+const CREDENTIALS_EXPIRED_CODE = 'Neo.ClientError.Security.CredentialsExpired';
+
 export default class HttpDataConverter {
 
   encodeStatementParameters(parameters) {
@@ -46,7 +48,10 @@ export default class HttpDataConverter {
     if (errors) {
       const error = errors[0];
       if (error) {
-        const code = error.code;
+        // endpoint returns 'Neo.ClientError.Security.Forbidden' code and 'password_change' that points to another endpoint
+        // this is different from code returned via Bolt and less descriptive
+        // make code same as in Bolt, if password change is required
+        const code = response.password_change ? CREDENTIALS_EXPIRED_CODE : error.code;
         const message = error.message;
         return new Neo4jError(message, code);
       }

--- a/src/v1/internal/http/http-driver.js
+++ b/src/v1/internal/http/http-driver.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Driver from '../../driver';
+import HttpSession from './http-session';
+
+export default class HttpDriver extends Driver {
+
+  constructor(url, userAgent, token, config) {
+    super(url, userAgent, token, config);
+    this._sessionIdGenerator = 0;
+    this._openSessions = {};
+  }
+
+  session() {
+    const id = this._sessionIdGenerator;
+    this._sessionIdGenerator++;
+    const session = new HttpSession(this._url, this._token, this._config);
+    this._openSessions[id] = session;
+    return session;
+  }
+
+  close() {
+    Object.keys(this._openSessions).forEach(id => {
+      const session = this._openSessions[id];
+      if (session) {
+        session.close();
+      }
+      delete this._openSessions[id];
+    });
+  }
+}

--- a/src/v1/internal/http/http-session.js
+++ b/src/v1/internal/http/http-session.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {WRITE} from '../../driver';
+import Session from '../../session';
+import {assertCypherStatement} from '../util';
+import {Neo4jError} from '../../error';
+import HttpStatementRunner from './http-statement-runner';
+
+export default class HttpSession extends Session {
+
+  constructor(url, authToken, config) {
+    super(WRITE, null, null, config);
+    this._statementRunner = new HttpStatementRunner(url, authToken);
+  }
+
+  run(statement, parameters = {}) {
+    if (typeof statement === 'object' && statement.text) {
+      parameters = statement.parameters || {};
+      statement = statement.text;
+    }
+    assertCypherStatement(statement);
+
+    return this._statementRunner.run(statement, parameters);
+  }
+
+  beginTransaction() {
+    throwTransactionsNotSupported();
+  }
+
+  readTransaction() {
+    throwTransactionsNotSupported();
+  }
+
+  writeTransaction() {
+    throwTransactionsNotSupported();
+  }
+
+  lastBookmark() {
+    throw new Neo4jError('Experimental HTTP driver does not support bookmarks and routing');
+  }
+
+  close(callback = (() => null)) {
+    callback();
+  }
+}
+
+function throwTransactionsNotSupported() {
+  throw new Neo4jError('Experimental HTTP driver does not support transactions');
+}

--- a/src/v1/internal/http/http-statement-runner.js
+++ b/src/v1/internal/http/http-statement-runner.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import xhr from 'xhr';
+import StreamObserver from '../stream-observer';
+import Result from '../../result';
+import {EMPTY_CONNECTION_HOLDER} from '../connection-holder';
+import HttpDataConverter from './http-data-converter';
+
+export default class HttpStatementRunner {
+
+  constructor(url, authToken) {
+    this._serverInfoSupplier = createServerInfoSupplier(url);
+    this._transactionCommitUrl = createTransactionCommitUrl(url);
+    this._headers = createHttpHeaders(authToken);
+    this._converter = new HttpDataConverter();
+  }
+
+  run(statement, parameters) {
+    const streamObserver = new StreamObserver();
+    sendPostRequest(statement, parameters, streamObserver, this._transactionCommitUrl, this._headers, this._converter);
+    return new Result(streamObserver, statement, parameters, this._serverInfoSupplier, EMPTY_CONNECTION_HOLDER);
+  }
+}
+
+function createServerInfoSupplier(url) {
+  return () => {
+    return {server: {address: url.hostAndPort}};
+  };
+}
+
+function createTransactionCommitUrl(url) {
+  return url.scheme + '://' + url.host + ':' + url.port + '/db/data/transaction/commit';
+}
+
+function createHttpHeaders(authToken) {
+  const basicAuthToken = 'Basic ' + btoa(authToken.principal + ':' + authToken.credentials);
+  return {
+    'Accept': 'application/json; charset=UTF-8',
+    'Content-Type': 'application/json',
+    'Authorization': basicAuthToken
+  };
+}
+
+function sendPostRequest(statement, parameters, streamObserver, transactionCommitUrl, headers, converter) {
+  try {
+    xhr.post(
+      transactionCommitUrl,
+      {
+        headers: headers,
+        body: createStatementJson(statement, parameters, converter)
+      },
+      (error, response) => processPostResponse(error, response, converter, streamObserver)
+    );
+  } catch (e) {
+    streamObserver.onError(e);
+  }
+}
+
+function createStatementJson(statement, parameters, converter, streamObserver) {
+  try {
+    return createStatementJsonOrThrow(statement, parameters, converter);
+  } catch (e) {
+    streamObserver.onError(e);
+  }
+}
+
+function createStatementJsonOrThrow(statement, parameters, converter) {
+  const encodedParameters = converter.encodeStatementParameters(parameters);
+  return JSON.stringify({
+    statements: [{
+      statement: statement,
+      parameters: encodedParameters,
+      resultDataContents: ['row', 'graph'],
+      includeStats: true
+    }]
+  });
+}
+
+function processPostResponse(error, response, converter, streamObserver) {
+  try {
+    processPostResponseOrThrow(error, response, converter, streamObserver);
+  } catch (e) {
+    streamObserver.onError(e);
+  }
+}
+
+function processPostResponseOrThrow(error, response, converter, streamObserver) {
+  if (error) {
+    const neo4jError = converter.convertNetworkError(error);
+    streamObserver.onError(neo4jError);
+  } else {
+    const responseJson = JSON.parse(response.body);
+
+    const neo4jError = converter.extractError(responseJson);
+    if (neo4jError) {
+      streamObserver.onError(neo4jError);
+    } else {
+      const recordMetadata = converter.extractRecordMetadata(responseJson);
+      streamObserver.onCompleted(recordMetadata);
+
+      const rawRecords = converter.extractRawRecords(responseJson);
+      rawRecords.forEach(rawRecord => streamObserver.onNext(rawRecord));
+
+      const statementMetadata = converter.extractStatementMetadata(responseJson);
+      streamObserver.onCompleted(statementMetadata);
+    }
+  }
+}

--- a/test/internal/ch-config.test.js
+++ b/test/internal/ch-config.test.js
@@ -25,7 +25,7 @@ import {SERVICE_UNAVAILABLE} from '../../src/v1/error';
 describe('ChannelConfig', () => {
 
   it('should respect given Url', () => {
-    const url = urlUtil.parseBoltUrl('bolt://neo4j.com:4242');
+    const url = urlUtil.parseDatabaseUrl('bolt://neo4j.com:4242');
 
     const config = new ChannelConfig(url, {}, '');
 

--- a/test/internal/ch-websocket.test.js
+++ b/test/internal/ch-websocket.test.js
@@ -75,7 +75,7 @@ describe('WebSocketChannel', () => {
         };
       };
 
-      const url = urlUtil.parseBoltUrl('bolt://localhost:7687');
+      const url = urlUtil.parseDatabaseUrl('bolt://localhost:7687');
       const driverConfig = {connectionTimeout: 4242};
       const channelConfig = new ChannelConfig(url, driverConfig, SERVICE_UNAVAILABLE);
 
@@ -112,7 +112,7 @@ describe('WebSocketChannel', () => {
       };
     };
 
-    const url = urlUtil.parseBoltUrl(boltAddress);
+    const url = urlUtil.parseDatabaseUrl(boltAddress);
     // disable connection timeout, so that WebSocketChannel does not set any timeouts
     const driverConfig = {connectionTimeout: 0};
     const channelConfig = new ChannelConfig(url, driverConfig, SERVICE_UNAVAILABLE);

--- a/test/internal/host-name-resolvers.test.js
+++ b/test/internal/host-name-resolvers.test.js
@@ -72,7 +72,7 @@ describe('DnsHostNameResolver', () => {
 
         addresses.forEach(address => {
           expectToBeDefined(address);
-          const parsedUrl = urlUtil.parseBoltUrl(address);
+          const parsedUrl = urlUtil.parseDatabaseUrl(address);
           expect(parsedUrl.scheme).toBeNull();
           expectToBeDefined(parsedUrl.host);
           expect(parsedUrl.port).toEqual(7687); // default port should be appended
@@ -91,7 +91,7 @@ describe('DnsHostNameResolver', () => {
 
         addresses.forEach(address => {
           expectToBeDefined(address);
-          const parsedUrl = urlUtil.parseBoltUrl(address);
+          const parsedUrl = urlUtil.parseDatabaseUrl(address);
           expect(parsedUrl.scheme).toBeNull();
           expectToBeDefined(parsedUrl.host);
           expect(parsedUrl.port).toEqual(7474);

--- a/test/internal/http-driver.test.js
+++ b/test/internal/http-driver.test.js
@@ -225,6 +225,21 @@ describe('http driver', () => {
     });
   });
 
+  it('should use default HTTP port', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    const driver = neo4j.driver('http://localhost', sharedNeo4j.authToken);
+    const session = driver.session();
+    session.run('RETURN 4242').then(result => {
+      expect(result.records[0].get(0)).toEqual(4242);
+      expect(result.summary.server.address).toEqual('localhost:7474');
+      done();
+    });
+  });
+
   function testSendAndReceiveWithReturnQuery(values, done) {
     const query = 'RETURN $value';
 

--- a/test/internal/http-driver.test.js
+++ b/test/internal/http-driver.test.js
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import neo4j from '../../src/v1';
+import sharedNeo4j from '../internal/shared-neo4j';
+import testUtils from './test-utils';
+
+describe('http driver', () => {
+
+  let boltDriver;
+  let httpDriver;
+
+  beforeEach(done => {
+    boltDriver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {disableLosslessIntegers: true});
+    httpDriver = neo4j.driver('http://localhost:7474', sharedNeo4j.authToken);
+
+    const session = boltDriver.session();
+    session.run('MATCH (n) DETACH DELETE n').then(() => {
+      session.close(() => {
+        done();
+      });
+    });
+  });
+
+  afterEach(() => {
+    if (boltDriver) {
+      boltDriver.close();
+      boltDriver = null;
+    }
+    if (httpDriver) {
+      httpDriver.close();
+      httpDriver = null;
+    }
+  });
+
+  it('should send and receive primitives', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    const primitiveValues = [
+      null,
+      0, 1, 2, 3, 42, -1, -2, -3, 100, -100, 424242, -424242,
+      0.12345, -0.12345, 1.25, -1.25, 5.99, -5.99, 1000.99, -1000.99, 1234.56789, -1234.56789,
+      neo4j.int(0), neo4j.int(1), neo4j.int(-1), neo4j.int(42), neo4j.int(-42), neo4j.int(12345), neo4j.int(-12345),
+      '', 'hello', 'hello world!', 'Thor and Mjölnir', 'Хеллоу'
+    ];
+
+    testSendAndReceiveWithReturnQuery(primitiveValues, done);
+  });
+
+  it('should send and receive arrays', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    const arrayValues = [
+      [],
+      [42], [-42], [1, 2, 3], [-1, -2, -3], [1, 2, 3, 4, 5, 6, 7, 10000000], [-10000000, 42, 7, 6, 5, 4, 3, 2, 1],
+      [0.001], [-0.19, 0.19], [100.25, 123.456, 90.99, 88.112], [-901.33, -90.90, 133, 144, 77835],
+      [''], ['hello'], ['hello', ' ', 'world', '!'], ['Thor', ' ', 'has ', 'Mjölnir'], ['Hello', ' is ', 'Хеллоу'],
+    ];
+
+    testSendAndReceiveWithReturnQuery(arrayValues, done);
+  });
+
+  it('should send and receive objects', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    const objectValues = [
+      {},
+      {name: 'Sam', age: 20, salary: 100}, {name: 'Tom', age: 20, scores: [1, 2, 3], values: [neo4j.int(1), neo4j.int(42)]},
+      {name: 'Cat', value: neo4j.int(42), info: {otherName: 'Dog', wight: neo4j.int(20), otherInfo: {likes: ['eat', 'drink']}}}
+    ];
+
+    testSendAndReceiveWithReturnQuery(objectValues, done);
+  });
+
+  it('should receive nodes', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    runSetupQueries([
+      `CREATE (:Node1)`,
+      `CREATE (:Node2 {name: 'Node2'})`,
+      `CREATE (:Node3 {name: 'Node3', age: 42})`,
+      `CREATE (:Node4 {name: 'Node4', age: 4242, value: 42.05})`,
+      `CREATE (:Node5:Cat:Dog {name: 'Node5', age: 12, value: -0.006, scores: [0.25, -0.15, 100], likes: ['food', 'drinks']})`
+    ]).then(() => {
+      testReceivingOfResults([
+        `MATCH (n:Node1) RETURN n`,
+        `MATCH (n:Node2) RETURN n`,
+        `MATCH (n:Node3) RETURN n`,
+        `MATCH (n:Node4) RETURN n`,
+        `MATCH (n:Node5) RETURN n`,
+        `MATCH (a:Node1), (b:Node2) RETURN a, b`,
+        `MATCH (a:Node1), (b:Node2), (c:Node3) RETURN a AS aaa, b AS bbb, c AS ccc`,
+        `MATCH (a:Node1), (b:Node2), (c:Node3), (d:Node4), (e:Node5) RETURN a, b, c, d, e AS eee`,
+        `MATCH (a:Node1), (b:Node2), (c:Node3), (d:Node4), (e:Node5) RETURN e, a, c, d, b`,
+        `MATCH (n) RETURN n`
+      ], done);
+    });
+  });
+
+  it('should receive relationships', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    runSetupQueries([
+      `CREATE (:Node1)-[:KNOWS]->(:Node2)`,
+      `CREATE (:Node3)-[:KNOWS {name: 'foo'}]->(:Node4)`,
+      `CREATE (:Node5)-[:KNOWS {name: 'foo', value: 42, score: 12.5, values: [1,2,3, -42], strings: ['a','b','c']}]->(:Node6)`,
+    ]).then(() => {
+      testReceivingOfResults([
+        `MATCH (:Node1)-[r]->(:Node2) RETURN r`,
+        `MATCH (:Node3)-[r]->(:Node4) RETURN r`,
+        `MATCH (:Node5)-[r]->(:Node6) RETURN r`,
+        `MATCH ()-[r]-() RETURN r`
+      ], done);
+    });
+  });
+
+  it('should receive paths', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    runSetupQueries([
+      `CREATE (:Person1 {name: 'Person1'})-[:KNOWS {value: 42}]->(:Person2 {name: 'Person2', surname: 'Person2', value: 1})`,
+      `CREATE (:Person3 {name: 'Person3'})-[:KNOWS {since: 123}]->
+              (:Person4 {name: 'Person4'})<-[:LIKES {why: 'why!'}]-
+              (:Person5 {name: 'Person5'})-[:KNOWS]->
+              (:Person6 {name: 'Person6'})`
+    ]).then(() => {
+      testReceivingOfResults([
+        `MATCH p=((:Person1)-[:KNOWS]->(:Person2)) RETURN p`,
+        `MATCH p=((:Person2)-[:KNOWS]-(:Person1)) RETURN p`,
+        `MATCH p=((:Person3)-[:KNOWS]-(:Person4)-[:LIKES]-(:Person5)) RETURN p`,
+        `MATCH p=((:Person3)-[*]-(:Person6)) RETURN p`,
+        `MATCH p=(()-[*]-()) RETURN p`,
+      ], done);
+    });
+  });
+
+  it('should receive errors', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    const query = 'UNWIND [1,2,3,0] AS x RETURN 10/x';
+
+    const boltErrorPromise = runQueryAndGetError(query, boltDriver);
+    const httpErrorPromise = runQueryAndGetError(query, httpDriver);
+
+    Promise.all([boltErrorPromise, httpErrorPromise]).then(errors => {
+      expect(errors.length).toEqual(2);
+      const boltError = errors[0];
+      const httpError = errors[1];
+
+      expect(boltError.name).toEqual(httpError.name);
+      expect(boltError.code).toEqual(httpError.code);
+      expect(boltError.message).toEqual(httpError.message);
+
+      done();
+    });
+  });
+
+  it('should receive server address', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    const query = `CREATE (n1:Node1 {name: 'Node1'})-[r:LIKES {date: 12345}]->(n2:Node2 {name: 'Node2'}) RETURN n1, r, n2`;
+
+    runQueryAndGetSummary(query, httpDriver).then(summary => {
+      expect(summary.server.address).toEqual('localhost:7474');
+      done();
+    });
+  });
+
+  it('should receive statement statistics', done => {
+    if (testUtils.isServer()) {
+      done();
+      return;
+    }
+
+    const query = `CREATE (n1:Node {value: 1}), (n2:Node {name: '2', value: 2}) WITH n1, n2 DELETE n1 RETURN n1, n2`;
+
+    const boltStatementStatisticsPromise = runQueryAndGetStatementStatistics(query, boltDriver);
+    const httpStatementStatisticsPromise = runQueryAndGetStatementStatistics(query, httpDriver);
+
+    Promise.all([boltStatementStatisticsPromise, httpStatementStatisticsPromise]).then(stats => {
+      const boltStatementStatistics = stats[0];
+      const httpStatementStatistics = stats[1];
+      expect(boltStatementStatistics).toEqual(httpStatementStatistics);
+      done();
+    });
+  });
+
+  function testSendAndReceiveWithReturnQuery(values, done) {
+    const query = 'RETURN $value';
+
+    const boltResultsPromise = Promise.all(values.map(value => runQueryAndGetResults(query, {value: value}, boltDriver)));
+    const httpResultsPromise = Promise.all(values.map(value => runQueryAndGetResults(query, {value: value}, httpDriver)));
+
+    assertResultsAreEqual(boltResultsPromise, httpResultsPromise, values.length, done);
+  }
+
+  function testReceivingOfResults(queries, done) {
+    const boltResultsPromise = Promise.all(queries.map(query => runQueryAndGetResults(query, {}, boltDriver)));
+    const httpResultsPromise = Promise.all(queries.map(query => runQueryAndGetResults(query, {}, httpDriver)));
+
+    assertResultsAreEqual(boltResultsPromise, httpResultsPromise, queries.length, done);
+  }
+
+  function assertResultsAreEqual(boltResultsPromise, httpResultsPromise, expectedLength, done) {
+    Promise.all([boltResultsPromise, httpResultsPromise]).then(results => {
+      const boltResults = results[0];
+      const httpResults = results[1];
+
+      expect(boltResults.length).toEqual(expectedLength);
+      expect(httpResults.length).toEqual(expectedLength);
+
+      for (let i = 0; i < expectedLength; i++) {
+        const boltResultRow = boltResults[i];
+        const httpResultRow = httpResults[i];
+        expect(boltResultRow).toEqual(httpResultRow);
+      }
+
+      done();
+    });
+  }
+
+  function runQueryAndGetResults(query, params, driver) {
+    const session = driver.session();
+    return session.run(query, params).then(result => {
+      session.close();
+      return result.records.map(record => record.keys.map(key => record.get(key)));
+    });
+  }
+
+  function runQueryAndGetError(query, driver) {
+    const session = driver.session();
+    return session.run(query).catch(error => error);
+  }
+
+  function runQueryAndGetStatementStatistics(query, driver) {
+    return runQueryAndGetSummary(query, driver).then(summary => summary.counters);
+  }
+
+  function runQueryAndGetSummary(query, driver) {
+    const session = driver.session();
+    return session.run(query).then(result => result.summary);
+  }
+
+  function runSetupQueries(queries) {
+    const session = boltDriver.session();
+    return session.writeTransaction(tx => {
+      queries.forEach(query => tx.run(query));
+      return null;
+    });
+  }
+
+});

--- a/test/internal/url-util.test.js
+++ b/test/internal/url-util.test.js
@@ -18,7 +18,6 @@
  */
 
 import urlUtil from '../../src/v1/internal/url-util';
-import {DEFAULT_PORT} from '../../src/v1/internal/ch-config';
 
 describe('url-util', () => {
 
@@ -716,6 +715,14 @@ describe('url-util', () => {
     expect(() => urlUtil.formatIPv6Address('1afc:0:a33:85a3::ff2f]', 4000)).toThrow();
   });
 
+  it('should use default ports when no port specified', () => {
+    expect(parse('bolt://localhost').port).toEqual(urlUtil.defaultPortForScheme('bolt'));
+    expect(parse('bolt+routing://localhost').port).toEqual(urlUtil.defaultPortForScheme('bolt'));
+
+    expect(parse('http://localhost').port).toEqual(urlUtil.defaultPortForScheme('http'));
+    expect(parse('https://localhost').port).toEqual(urlUtil.defaultPortForScheme('https'));
+  });
+
   function verifyUrl(urlString, expectedUrl) {
     const url = parse(urlString);
 
@@ -732,7 +739,7 @@ describe('url-util', () => {
     if (expectedUrl.port) {
       expect(url.port).toEqual(expectedUrl.port);
     } else {
-      expect(url.port).toEqual(DEFAULT_PORT);
+      expect(url.port).toEqual(urlUtil.defaultPortForScheme(expectedUrl.scheme));
     }
 
     verifyHostAndPort(url, expectedUrl);
@@ -745,7 +752,7 @@ describe('url-util', () => {
   }
 
   function verifyHostAndPort(url, expectedUrl) {
-    const port = expectedUrl.port === 0 || expectedUrl.port ? expectedUrl.port : DEFAULT_PORT;
+    const port = expectedUrl.port === 0 || expectedUrl.port ? expectedUrl.port : urlUtil.defaultPortForScheme(expectedUrl.scheme);
 
     if (expectedUrl.ipv6) {
       expect(url.hostAndPort).toEqual(`[${expectedUrl.host}]:${port}`);
@@ -755,7 +762,7 @@ describe('url-util', () => {
   }
 
   function parse(url) {
-    return urlUtil.parseBoltUrl(url);
+    return urlUtil.parseDatabaseUrl(url);
   }
 
 });


### PR DESCRIPTION
PR adds a driver implementation that use REST API. It now only supports `Session#run()`, not explicit transactions or routing. Driver will only expose native numbers because it receives JSON which can't represent large integers. Behaviour is similar to Bolt driver configured with `{disableLosslessIntegers: true}`.

This is an **experimental feature** and should under no circumstances be used in production environment!

Based on https://github.com/neo4j/neo4j-javascript-driver/pull/323