### PR TITLE
Fix temporal ITs to only generate DST-safe time

### DIFF
--- a/test/v1/temporal-types.test.js
+++ b/test/v1/temporal-types.test.js
@@ -32,13 +32,7 @@ const MIN_TIME_ZONE_OFFSET = -MAX_TIME_ZONE_OFFSET;
 const SECONDS_PER_MINUTE = 60;
 const MIN_ZONE_ID = 'Etc/GMT+12';
 const MAX_ZONE_ID = 'Etc/GMT-14';
-const ZONE_IDS = ['Europe/Zaporozhye', 'America/Argentina/Mendoza', 'Etc/GMT-12', 'Asia/Jayapura', 'Pacific/Auckland', 'America/Argentina/Rio_Gallegos',
-  'America/Tegucigalpa', 'Europe/Skopje', 'Africa/Lome', 'America/Eirunepe', 'Pacific/Port_Moresby', 'America/Merida', 'Asia/Qyzylorda', 'Hongkong',
-  'America/Paramaribo', 'Pacific/Wallis', 'Antarctica/Mawson', 'America/Metlakatla', 'Indian/Reunion', 'Asia/Chungking', 'Canada/Central', 'Etc/GMT-6',
-  'UCT', 'America/Belem', 'Europe/Belgrade', 'Singapore', 'Israel', 'Europe/London', 'America/Yellowknife', 'Europe/Uzhgorod', 'Etc/GMT+7',
-  'America/Indiana/Winamac', 'Asia/Kuala_Lumpur', 'America/Cuiaba', 'Europe/Sofia', 'Asia/Kuching', 'Australia/Lord_Howe', 'America/Porto_Acre',
-  'America/Indiana/Indianapolis', 'Africa/Windhoek', 'Atlantic/Cape_Verde', 'Asia/Kuwait', 'America/Barbados', 'Egypt', 'GB-Eire', 'Antarctica/South_Pole',
-  'America/Kentucky/Louisville', 'Asia/Yangon', 'CET', 'Etc/GMT+11', 'Asia/Dubai', 'Europe/Stockholm'];
+const ZONE_IDS = ['Europe/Zaporozhye', 'Europe/London', 'UTC', 'Africa/Cairo'];
 
 describe('temporal-types', () => {
 
@@ -434,16 +428,20 @@ describe('temporal-types', () => {
 
   function randomDateTimeWithZoneOffset() {
     return new neo4j.DateTimeWithZoneOffset(
-      randomLocalDateTime(),
+      randomDstSafeLocalDateTime(),
       randomZoneOffsetSeconds()
     );
   }
 
   function randomDateTimeWithZoneId() {
     return new neo4j.DateTimeWithZoneId(
-      randomLocalDateTime(),
+      randomDstSafeLocalDateTime(),
       randomZoneId()
     );
+  }
+
+  function randomDstSafeLocalDateTime() {
+    return new neo4j.LocalDateTime(randomDate(), randomDstSafeLocalTime());
   }
 
   function randomLocalDateTime() {
@@ -468,6 +466,15 @@ describe('temporal-types', () => {
   function randomLocalTime() {
     return new neo4j.LocalTime(
       randomInt(0, 23),
+      randomInt(0, 59),
+      randomInt(0, 59),
+      randomInt(0, MAX_NANO_OF_SECOND)
+    );
+  }
+
+  function randomDstSafeLocalTime() {
+    return new neo4j.LocalTime(
+      randomInt(4, 23), // do not generate hours in range where DST adjustment happens
       randomInt(0, 59),
       randomInt(0, 59),
       randomInt(0, MAX_NANO_OF_SECOND)


### PR DESCRIPTION
Randomized tests for `DateTime` Cypher type generate random date-time values with time zone (either offset or id). They used to be flaky because sometimes generated instant was invalid. Such instant pointed to a non-existing time during a Daylight Saving Time adjustment/jump. Such time values are adjusted to the nearest valid value by the database. This made tests fail because received value was different from the sent value.

This PR fixes the problem by making random `DateTime` generator never generate hour of the day that is in the DST adjustment range. It also reduces the number of test time zones to couple popular ones. This is done to make sure all tested time zones are supported by the JVM, neo4j database is running on.