### PR TITLE
Support number props in spatial and temporal types

### DIFF
--- a/src/v1/internal/packstream-v1.js
+++ b/src/v1/internal/packstream-v1.js
@@ -400,6 +400,15 @@ class Unpacker {
     throw newError('Unknown packed value with marker ' + marker.toString(16));
   }
 
+  unpackInteger(buffer) {
+    const marker = buffer.readUInt8();
+    const result = this._unpackInteger(marker, buffer);
+    if (result == null) {
+      throw newError('Unable to unpack integer value with marker ' + marker.toString(16));
+    }
+    return result;
+  }
+
   _unpackBoolean(marker) {
     if (marker == TRUE) {
       return true;
@@ -413,7 +422,13 @@ class Unpacker {
   _unpackNumberOrInteger(marker, buffer) {
     if (marker == FLOAT_64) {
       return buffer.readFloat64();
-    } else if (marker >= 0 && marker < 128) {
+    } else {
+      return this._unpackInteger(marker, buffer);
+    }
+  }
+
+  _unpackInteger(marker, buffer) {
+    if (marker >= 0 && marker < 128) {
       return int(marker);
     } else if (marker >= 240 && marker < 256) {
       return int(marker - 256);

--- a/src/v1/spatial-types.js
+++ b/src/v1/spatial-types.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import {int} from './integer';
-
 const POINT_IDENTIFIER_PROPERTY = '__isPoint__';
 
 /**
@@ -29,13 +27,13 @@ export class Point {
 
   /**
    * @constructor
-   * @param {number|Integer} srid the coordinate reference system identifier.
+   * @param {Integer|number} srid the coordinate reference system identifier.
    * @param {number} x the <code>x</code> coordinate of the point.
    * @param {number} y the <code>y</code> coordinate of the point.
    * @param {number} [z=undefined] the <code>y</code> coordinate of the point or <code>undefined</code> if point has 2 dimensions.
    */
   constructor(srid, x, y, z) {
-    this.srid = int(srid);
+    this.srid = srid;
     this.x = x;
     this.y = y;
     this.z = z;

--- a/test/v1/temporal-types.test.js
+++ b/test/v1/temporal-types.test.js
@@ -40,6 +40,7 @@ describe('temporal-types', () => {
 
   let originalTimeout;
   let driver;
+  let driverWithNativeNumbers;
   let session;
   let serverVersion;
 
@@ -48,6 +49,8 @@ describe('temporal-types', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
     driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken);
+    driverWithNativeNumbers = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {disableLosslessIntegers: true});
+
     ServerVersion.fromDriver(driver).then(version => {
       serverVersion = version;
       done();
@@ -60,6 +63,11 @@ describe('temporal-types', () => {
     if (driver) {
       driver.close();
       driver = null;
+    }
+
+    if (driverWithNativeNumbers) {
+      driverWithNativeNumbers.close();
+      driverWithNativeNumbers = null;
     }
   });
 
@@ -96,6 +104,15 @@ describe('temporal-types', () => {
     testSendAndReceiveRandomTemporalValues(() => randomDuration(), done);
   });
 
+  it('should send and receive Duration when disableLosslessIntegers=true', done => {
+    if (neo4jDoesNotSupportTemporalTypes(done)) {
+      return;
+    }
+    session = driverWithNativeNumbers.session();
+
+    testSendReceiveTemporalValue(new neo4j.Duration(4, 15, 931, 99953), done);
+  });
+
   it('should send and receive array of Duration', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
@@ -129,6 +146,15 @@ describe('temporal-types', () => {
 
     const minLocalTime = localTime(0, 0, 0, 0);
     testSendReceiveTemporalValue(minLocalTime, done);
+  });
+
+  it('should send and receive LocalTime when disableLosslessIntegers=true', done => {
+    if (neo4jDoesNotSupportTemporalTypes(done)) {
+      return;
+    }
+    session = driverWithNativeNumbers.session();
+
+    testSendReceiveTemporalValue(new neo4j.LocalTime(12, 32, 56, 12345), done);
   });
 
   it('should send and receive random LocalTime', done => {
@@ -174,6 +200,15 @@ describe('temporal-types', () => {
     testSendReceiveTemporalValue(minTime, done);
   });
 
+  it('should send and receive Time when disableLosslessIntegers=true', done => {
+    if (neo4jDoesNotSupportTemporalTypes(done)) {
+      return;
+    }
+    session = driverWithNativeNumbers.session();
+
+    testSendReceiveTemporalValue(new neo4j.Time(22, 19, 32, 18381, MAX_TIME_ZONE_OFFSET), done);
+  });
+
   it('should send and receive random Time', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
@@ -215,6 +250,15 @@ describe('temporal-types', () => {
 
     const minDate = date(MIN_YEAR, 1, 1);
     testSendReceiveTemporalValue(minDate, done);
+  });
+
+  it('should send and receive Date when disableLosslessIntegers=true', done => {
+    if (neo4jDoesNotSupportTemporalTypes(done)) {
+      return;
+    }
+    session = driverWithNativeNumbers.session();
+
+    testSendReceiveTemporalValue(new neo4j.Date(1923, 8, 14), done);
   });
 
   it('should send and receive random Date', done => {
@@ -260,6 +304,15 @@ describe('temporal-types', () => {
     testSendReceiveTemporalValue(minLocalDateTime, done);
   });
 
+  it('should send and receive LocalDateTime when disableLosslessIntegers=true', done => {
+    if (neo4jDoesNotSupportTemporalTypes(done)) {
+      return;
+    }
+    session = driverWithNativeNumbers.session();
+
+    testSendReceiveTemporalValue(new neo4j.LocalDateTime(2045, 9, 1, 11, 25, 25, 911), done);
+  });
+
   it('should send and receive random LocalDateTime', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
@@ -303,6 +356,15 @@ describe('temporal-types', () => {
     testSendReceiveTemporalValue(minDateTime, done);
   });
 
+  it('should send and receive DateTimeWithZoneOffset when disableLosslessIntegers=true', done => {
+    if (neo4jDoesNotSupportTemporalTypes(done)) {
+      return;
+    }
+    session = driverWithNativeNumbers.session();
+
+    testSendReceiveTemporalValue(new neo4j.DateTimeWithZoneOffset(2022, 2, 7, 17, 15, 59, 12399, MAX_TIME_ZONE_OFFSET), done);
+  });
+
   it('should send and receive random DateTimeWithZoneOffset', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
@@ -344,6 +406,15 @@ describe('temporal-types', () => {
 
     const minDateTime = dateTimeWithZoneId(MIN_YEAR, 1, 1, 0, 0, 0, 0, MIN_ZONE_ID);
     testSendReceiveTemporalValue(minDateTime, done);
+  });
+
+  it('should send and receive DateTimeWithZoneId when disableLosslessIntegers=true', done => {
+    if (neo4jDoesNotSupportTemporalTypes(done)) {
+      return;
+    }
+    session = driverWithNativeNumbers.session();
+
+    testSendReceiveTemporalValue(new neo4j.DateTimeWithZoneId(2011, 11, 25, 23, 59, 59, 192378, 'Europe/Stockholm'), done);
   });
 
   it('should send and receive random DateTimeWithZoneId', done => {
@@ -475,9 +546,6 @@ describe('temporal-types', () => {
   function testSendAndReceiveArrayOfRandomTemporalValues(valueGenerator, done) {
     const arrayLength = _.random(MIN_TEMPORAL_ARRAY_LENGTH, MAX_TEMPORAL_ARRAY_LENGTH);
     const values = _.range(arrayLength).map(() => valueGenerator());
-
-    console.log('Generated: ' + values);
-
     testSendReceiveTemporalValue(values, done);
   }
 


### PR DESCRIPTION
By default, driver exposes integer values as instances of `Integer` class. This class can represent integer values larger than `Number.MAX_SAFE_INTEGER` without loss of precision. Driver can be forced to return native numbers using `disableLosslessIntegers` config option.

This PR makes spatial and temporal types support `disableLosslessIntegers`. All exposed integer properties will be of type `number` when this config option is set to `true`. Internal conversions for temporal types still use `Integer` to not lose precision.