### PR TITLE
Use static factories to create NodeJS buffers

### DIFF
--- a/src/v1/internal/buf.js
+++ b/src/v1/internal/buf.js
@@ -511,7 +511,7 @@ class CombinedBuffer extends BaseBuffer {
  */
 class NodeBuffer extends BaseBuffer {
   constructor(arg) {
-    let buffer = arg instanceof _node.Buffer ? arg : new _node.Buffer(arg);
+    const buffer = arg instanceof _node.Buffer ? arg : newNodeJSBuffer(arg);
     super(buffer.length);
     this._buffer = buffer;
   }
@@ -556,6 +556,16 @@ class NodeBuffer extends BaseBuffer {
 
   getSlice ( start, length ) {
     return new NodeBuffer( this._buffer.slice( start, start + length ) );
+  }
+}
+
+function newNodeJSBuffer(arg) {
+  if (typeof arg === 'number' && typeof _node.Buffer.alloc === 'function') {
+    // use static factory function present in newer NodeJS versions to allocate new buffer with specified size
+    return _node.Buffer.alloc(arg);
+  } else {
+    // fallback to the old, potentially deprecated constructor
+    return new _node.Buffer(arg);
   }
 }
 

--- a/src/v1/internal/utf8.js
+++ b/src/v1/internal/utf8.js
@@ -20,21 +20,28 @@
 // This module defines a cross-platform UTF-8 encoder and decoder that works
 // with the Buffer API defined in buf.js
 
-import {alloc, NodeBuffer, HeapBuffer, CombinedBuffer} from "./buf";
+import {alloc, CombinedBuffer, HeapBuffer, NodeBuffer} from './buf';
 import {StringDecoder} from 'string_decoder';
 import {newError} from './../error';
+
 let platformObj = {};
 
 
 try {
   // This will throw an exception is 'buffer' is not available
   require.resolve("buffer");
-  let decoder = new StringDecoder('utf8');
-  let node = require("buffer");
+  const decoder = new StringDecoder('utf8');
+  const node = require('buffer');
+
+  // use static factory function present in newer NodeJS versions to create a buffer containing the given string
+  // or fallback to the old, potentially deprecated constructor
+  const newNodeJSBuffer = typeof node.Buffer.from === 'function'
+    ? str => node.Buffer.from(str, 'utf8')
+    : str => new node.Buffer(str, 'utf8');
 
   platformObj = {
     "encode": function (str) {
-      return new NodeBuffer(new node.Buffer(str, "UTF-8"));
+      return new NodeBuffer(newNodeJSBuffer(str));
     },
     "decode": function (buffer, length) {
       if (buffer instanceof NodeBuffer) {


### PR DESCRIPTION
Previously code always used constructor to create NodeJS buffers. Constructor is overloaded to create buffer from an array, another buffer, string or with specified size. It is deprecated in newer NodeJS versions in favor of static factories like `Buffer.alloc()` and `Buffer.from()`. First allocates a buffer of the specified size. Second creates buffer based on the given string, array or another buffer.

This PR makes code use static factories instead of the constructor, when available. This makes construction of buffers work in older NodeJS environments that only have the constructor and new environments, that potentially only have static factories.

Related to https://github.com/neo4j/neo4j-javascript-driver/issues/336