### PR TITLE
Represent Cypher DateTime with a single type

### DIFF
--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -30,22 +30,7 @@ import {assertString, isEmptyObjectOrNull} from './internal/util';
 import urlUtil from './internal/url-util';
 import HttpDriver from './internal/http/http-driver';
 import {isPoint, Point} from './spatial-types';
-import {
-  Date,
-  DateTimeWithZoneId,
-  DateTimeWithZoneOffset,
-  Duration,
-  isDate,
-  isDateTimeWithZoneId,
-  isDateTimeWithZoneOffset,
-  isDuration,
-  isLocalDateTime,
-  isLocalTime,
-  isTime,
-  LocalDateTime,
-  LocalTime,
-  Time
-} from './temporal-types';
+import {Date, DateTime, Duration, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime, LocalDateTime, LocalTime, Time} from './temporal-types';
 
 /**
  * @property {function(username: string, password: string, realm: ?string)} basic the function to create a
@@ -225,8 +210,7 @@ const types = {
   Record,
   Point,
   Date,
-  DateTimeWithZoneId,
-  DateTimeWithZoneOffset,
+  DateTime,
   Duration,
   LocalDateTime,
   LocalTime,
@@ -275,8 +259,7 @@ const forExport = {
   Point,
   isPoint,
   Date,
-  DateTimeWithZoneId,
-  DateTimeWithZoneOffset,
+  DateTime,
   Duration,
   LocalDateTime,
   LocalTime,
@@ -286,8 +269,7 @@ const forExport = {
   isTime,
   isDate,
   isLocalDateTime,
-  isDateTimeWithZoneOffset,
-  isDateTimeWithZoneId
+  isDateTime
 };
 
 export {
@@ -303,8 +285,7 @@ export {
   Point,
   isPoint,
   Date,
-  DateTimeWithZoneId,
-  DateTimeWithZoneOffset,
+  DateTime,
   Duration,
   LocalDateTime,
   LocalTime,
@@ -314,7 +295,6 @@ export {
   isTime,
   isDate,
   isLocalDateTime,
-  isDateTimeWithZoneOffset,
-  isDateTimeWithZoneId
+  isDateTime
 };
 export default forExport;

--- a/test/types/v1/temporal-types.test.ts
+++ b/test/types/v1/temporal-types.test.ts
@@ -19,12 +19,10 @@
 
 import {
   Date,
-  DateTimeWithZoneId,
-  DateTimeWithZoneOffset,
+  DateTime,
   Duration,
   isDate,
-  isDateTimeWithZoneId,
-  isDateTimeWithZoneOffset,
+  isDateTime,
   isDuration,
   isLocalDateTime,
   isLocalTime,
@@ -60,14 +58,14 @@ const localTime2Second1: number = localTime2.second;
 const localTime2Nanosecond1: number = localTime2.nanosecond;
 
 const time1: Time = new Time(int(1), int(1), int(1), int(1), int(1));
-const offset1: Integer = time1.offsetSeconds;
+const offset1: Integer = time1.timeZoneOffsetSeconds;
 const hour1: Integer = time1.hour;
 const minute1: Integer = time1.minute;
 const second1: Integer = time1.second;
 const nanosecond1: Integer = time1.nanosecond;
 
 const time2: Time<number> = new Time(1, 1, 1, 1, 1);
-const offset2: number = time2.offsetSeconds;
+const offset2: number = time2.timeZoneOffsetSeconds;
 const hour2: number = time2.hour;
 const minute2: number = time2.minute;
 const second2: number = time2.second;
@@ -101,8 +99,9 @@ const minute4: number = localDateTime2.minute;
 const second4: number = localDateTime2.second;
 const nanosecond4: number = localDateTime2.nanosecond;
 
-const dateTime1: DateTimeWithZoneOffset = new DateTimeWithZoneOffset(int(1), int(1), int(1), int(1), int(1), int(1), int(1), int(1));
-const offset3: Integer = dateTime1.offsetSeconds;
+const dateTime1: DateTime = new DateTime(int(1), int(1), int(1), int(1), int(1), int(1), int(1), int(1), undefined);
+const zoneId1: string | undefined = dateTime1.timeZoneId;
+const offset3: Integer | undefined = dateTime1.timeZoneOffsetSeconds;
 const year3: Integer = dateTime1.year;
 const month3: Integer = dateTime1.month;
 const day3: Integer = dateTime1.day;
@@ -111,8 +110,9 @@ const minute5: Integer = dateTime1.minute;
 const second5: Integer = dateTime1.second;
 const nanosecond5: Integer = dateTime1.nanosecond;
 
-const dateTime2: DateTimeWithZoneOffset<number> = new DateTimeWithZoneOffset(1, 1, 1, 1, 1, 1, 1, 1);
-const offset4: number = dateTime2.offsetSeconds;
+const dateTime2: DateTime<number> = new DateTime(1, 1, 1, 1, 1, 1, 1, 1, undefined);
+const zoneId2: string | undefined = dateTime2.timeZoneId;
+const offset4: number | undefined = dateTime2.timeZoneOffsetSeconds;
 const year4: number = dateTime2.year;
 const month4: number = dateTime2.month;
 const day4: number = dateTime2.day;
@@ -121,8 +121,9 @@ const minute6: number = dateTime2.minute;
 const second6: number = dateTime2.second;
 const nanosecond6: number = dateTime2.nanosecond;
 
-const dateTime3: DateTimeWithZoneId = new DateTimeWithZoneId(int(1), int(1), int(1), int(1), int(1), int(1), int(1), "UTC");
-const zoneId1: string = dateTime3.zoneId;
+const dateTime3: DateTime = new DateTime(int(1), int(1), int(1), int(1), int(1), int(1), int(1), undefined, "UTC");
+const zoneId3: string | undefined = dateTime3.timeZoneId;
+const offset5: Integer | undefined = dateTime3.timeZoneOffsetSeconds;
 const year5: Integer = dateTime3.year;
 const month5: Integer = dateTime3.month;
 const day5: Integer = dateTime3.day;
@@ -131,8 +132,9 @@ const minute7: Integer = dateTime3.minute;
 const second7: Integer = dateTime3.second;
 const nanosecond7: Integer = dateTime3.nanosecond;
 
-const dateTime4: DateTimeWithZoneId<number> = new DateTimeWithZoneId(1, 1, 1, 1, 1, 1, 1, "UTC");
-const zoneId2: string = dateTime4.zoneId;
+const dateTime4: DateTime<number> = new DateTime(1, 1, 1, 1, 1, 1, 1, undefined, "UTC");
+const zoneId4: string | undefined = dateTime4.timeZoneId;
+const offset6: number | undefined = dateTime4.timeZoneOffsetSeconds;
 const year6: number = dateTime4.year;
 const month6: number = dateTime4.month;
 const day6: number = dateTime4.day;
@@ -146,5 +148,4 @@ const isLocalTimeValue: boolean = isLocalTime(localTime1);
 const isTimeValue: boolean = isTime(time1);
 const isDateValue: boolean = isDate(date1);
 const isLocalDateTimeValue: boolean = isLocalDateTime(localDateTime1);
-const isDateTimeWithZoneOffsetValue: boolean = isDateTimeWithZoneOffset(dateTime1);
-const isDateTimeWithZoneIdValue: boolean = isDateTimeWithZoneId(dateTime3);
+const isDateTimeValue: boolean = isDateTime(dateTime1);

--- a/test/v1/temporal-types.test.js
+++ b/test/v1/temporal-types.test.js
@@ -329,7 +329,7 @@ describe('temporal-types', () => {
     testSendAndReceiveArrayOfRandomTemporalValues(() => randomLocalDateTime(), done);
   });
 
-  it('should receive DateTimeWithZoneOffset', done => {
+  it('should receive DateTime with time zone offset', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -338,7 +338,7 @@ describe('temporal-types', () => {
     testReceiveTemporalValue('RETURN datetime({year: 1992, month: 11, day: 24, hour: 9, minute: 55, second: 42, nanosecond: 999, timezone: "+05:00"})', expectedValue, done);
   });
 
-  it('should send and receive max DateTimeWithZoneOffset', done => {
+  it('should send and receive max DateTime with zone offset', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -347,7 +347,7 @@ describe('temporal-types', () => {
     testSendReceiveTemporalValue(maxDateTime, done);
   });
 
-  it('should send and receive min DateTimeWithZoneOffset', done => {
+  it('should send and receive min DateTime with zone offset', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -356,16 +356,16 @@ describe('temporal-types', () => {
     testSendReceiveTemporalValue(minDateTime, done);
   });
 
-  it('should send and receive DateTimeWithZoneOffset when disableLosslessIntegers=true', done => {
+  it('should send and receive DateTime with zone offset when disableLosslessIntegers=true', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.DateTimeWithZoneOffset(2022, 2, 7, 17, 15, 59, 12399, MAX_TIME_ZONE_OFFSET), done);
+    testSendReceiveTemporalValue(new neo4j.DateTime(2022, 2, 7, 17, 15, 59, 12399, MAX_TIME_ZONE_OFFSET, null), done);
   });
 
-  it('should send and receive random DateTimeWithZoneOffset', done => {
+  it('should send and receive random DateTime with zone offset', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -373,7 +373,7 @@ describe('temporal-types', () => {
     testSendAndReceiveRandomTemporalValues(() => randomDateTimeWithZoneOffset(), done);
   });
 
-  it('should send and receive array of DateTimeWithZoneOffset', done => {
+  it('should send and receive array of DateTime with zone offset', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -381,7 +381,7 @@ describe('temporal-types', () => {
     testSendAndReceiveArrayOfRandomTemporalValues(() => randomDateTimeWithZoneOffset(), done);
   });
 
-  it('should receive DateTimeWithZoneId', done => {
+  it('should receive DateTime with zone id', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -390,7 +390,7 @@ describe('temporal-types', () => {
     testReceiveTemporalValue('RETURN datetime({year: 1992, month: 11, day: 24, hour: 9, minute: 55, second: 42, nanosecond: 999, timezone: "Europe/Stockholm"})', expectedValue, done);
   });
 
-  it('should send and receive max DateTimeWithZoneId', done => {
+  it('should send and receive max DateTime with zone id', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -399,7 +399,7 @@ describe('temporal-types', () => {
     testSendReceiveTemporalValue(maxDateTime, done);
   });
 
-  it('should send and receive min DateTimeWithZoneId', done => {
+  it('should send and receive min DateTime with zone id', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -408,16 +408,16 @@ describe('temporal-types', () => {
     testSendReceiveTemporalValue(minDateTime, done);
   });
 
-  it('should send and receive DateTimeWithZoneId when disableLosslessIntegers=true', done => {
+  it('should send and receive DateTime with zone id when disableLosslessIntegers=true', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.DateTimeWithZoneId(2011, 11, 25, 23, 59, 59, 192378, 'Europe/Stockholm'), done);
+    testSendReceiveTemporalValue(new neo4j.DateTime(2011, 11, 25, 23, 59, 59, 192378, null, 'Europe/Stockholm'), done);
   });
 
-  it('should send and receive random DateTimeWithZoneId', done => {
+  it('should send and receive random DateTime with zone id', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -425,7 +425,7 @@ describe('temporal-types', () => {
     testSendAndReceiveRandomTemporalValues(() => randomDateTimeWithZoneId(), done);
   });
 
-  it('should send and receive array of DateTimeWithZoneId', done => {
+  it('should send and receive array of DateTime with zone id', done => {
     if (neo4jDoesNotSupportTemporalTypes(done)) {
       return;
     }
@@ -599,14 +599,14 @@ describe('temporal-types', () => {
 
   function randomDateTimeWithZoneOffset() {
     const dateTime = randomDstSafeLocalDateTime();
-    return new neo4j.DateTimeWithZoneOffset(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond,
-      randomZoneOffsetSeconds());
+    return new neo4j.DateTime(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond,
+      randomZoneOffsetSeconds(), null);
   }
 
   function randomDateTimeWithZoneId() {
     const dateTime = randomDstSafeLocalDateTime();
-    return new neo4j.DateTimeWithZoneId(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond,
-      randomZoneId());
+    return new neo4j.DateTime(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond,
+      null, randomZoneId());
   }
 
   function randomDstSafeLocalDateTime() {
@@ -683,13 +683,13 @@ describe('temporal-types', () => {
   }
 
   function dateTimeWithZoneOffset(year, month, day, hour, minute, second, nanosecond, offsetSeconds) {
-    return new neo4j.DateTimeWithZoneOffset(neo4j.int(year), neo4j.int(month), neo4j.int(day),
-      neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond), neo4j.int(offsetSeconds));
+    return new neo4j.DateTime(neo4j.int(year), neo4j.int(month), neo4j.int(day),
+      neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond), neo4j.int(offsetSeconds), null);
   }
 
   function dateTimeWithZoneId(year, month, day, hour, minute, second, nanosecond, zoneId) {
-    return new neo4j.DateTimeWithZoneId(neo4j.int(year), neo4j.int(month), neo4j.int(day),
-      neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond), zoneId);
+    return new neo4j.DateTime(neo4j.int(year), neo4j.int(month), neo4j.int(day),
+      neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond), null, zoneId);
   }
 
   function randomInt(lower, upper) {

--- a/types/v1/index.d.ts
+++ b/types/v1/index.d.ts
@@ -20,22 +20,7 @@
 import Integer, {inSafeRange, int, isInt, toNumber, toString} from "./integer";
 import {Node, Path, PathSegment, Relationship, UnboundRelationship} from "./graph-types";
 import {isPoint, Point} from "./spatial-types";
-import {
-  Date,
-  DateTimeWithZoneId,
-  DateTimeWithZoneOffset,
-  Duration,
-  isDate,
-  isDateTimeWithZoneId,
-  isDateTimeWithZoneOffset,
-  isDuration,
-  isLocalDateTime,
-  isLocalTime,
-  isTime,
-  LocalDateTime,
-  LocalTime,
-  Time
-} from "./temporal-types";
+import {Date, DateTime, Duration, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime, LocalDateTime, LocalTime, Time} from "./temporal-types";
 import {Neo4jError, PROTOCOL_ERROR, SERVICE_UNAVAILABLE, SESSION_EXPIRED} from "./error";
 import Result, {Observer, StatementResult} from "./result";
 import ResultSummary, {Notification, NotificationPosition, Plan, ProfiledPlan, ServerInfo, StatementStatistic} from "./result-summary";
@@ -78,8 +63,7 @@ declare const types: {
   Time: Time;
   Date: Date;
   LocalDateTime: LocalDateTime;
-  DateTimeWithZoneOffset: DateTimeWithZoneOffset;
-  DateTimeWithZoneId: DateTimeWithZoneId;
+  DateTime: DateTime;
 };
 
 declare const session: {
@@ -150,15 +134,13 @@ declare const forExport: {
   Time: Time;
   Date: Date;
   LocalDateTime: LocalDateTime;
-  DateTimeWithZoneOffset: DateTimeWithZoneOffset;
-  DateTimeWithZoneId: DateTimeWithZoneId;
+  DateTime: DateTime;
   isDuration: typeof isDuration;
   isLocalTime: typeof isLocalTime;
   isTime: typeof isTime;
   isDate: typeof isDate;
   isLocalDateTime: typeof isLocalDateTime;
-  isDateTimeWithZoneOffset: typeof isDateTimeWithZoneOffset;
-  isDateTimeWithZoneId: typeof isDateTimeWithZoneId;
+  isDateTime: typeof isDateTime;
 };
 
 export {
@@ -203,15 +185,13 @@ export {
   Time,
   Date,
   LocalDateTime,
-  DateTimeWithZoneOffset,
-  DateTimeWithZoneId,
+  DateTime,
   isDuration,
   isLocalTime,
   isTime,
   isDate,
   isLocalDateTime,
-  isDateTimeWithZoneOffset,
-  isDateTimeWithZoneId
+  isDateTime
 }
 
 export default forExport;

--- a/types/v1/temporal-types.d.ts
+++ b/types/v1/temporal-types.d.ts
@@ -46,9 +46,9 @@ declare class Time<T extends NumberOrInteger = Integer> {
   readonly minute: T;
   readonly second: T;
   readonly nanosecond: T;
-  readonly offsetSeconds: T;
+  readonly timeZoneOffsetSeconds: T;
 
-  constructor(hour: T, minute: T, second: T, nanosecond: T, offsetSeconds: T);
+  constructor(hour: T, minute: T, second: T, nanosecond: T, timeZoneOffsetSeconds: T);
 }
 
 declare class Date<T extends NumberOrInteger = Integer> {
@@ -73,7 +73,7 @@ declare class LocalDateTime<T extends NumberOrInteger = Integer> {
   constructor(year: T, month: T, day: T, hour: T, minute: T, second: T, nanosecond: T);
 }
 
-declare class DateTimeWithZoneOffset<T extends NumberOrInteger = Integer> {
+declare class DateTime<T extends NumberOrInteger = Integer> {
 
   readonly year: T;
   readonly month: T;
@@ -82,23 +82,10 @@ declare class DateTimeWithZoneOffset<T extends NumberOrInteger = Integer> {
   readonly minute: T;
   readonly second: T;
   readonly nanosecond: T;
-  readonly offsetSeconds: T;
+  readonly timeZoneOffsetSeconds?: T;
+  readonly timeZoneId?: string;
 
-  constructor(year: T, month: T, day: T, hour: T, minute: T, second: T, nanosecond: T, offsetSeconds: T);
-}
-
-declare class DateTimeWithZoneId<T extends NumberOrInteger = Integer> {
-
-  readonly year: T;
-  readonly month: T;
-  readonly day: T;
-  readonly hour: T;
-  readonly minute: T;
-  readonly second: T;
-  readonly nanosecond: T;
-  readonly zoneId: string;
-
-  constructor(year: T, month: T, day: T, hour: T, minute: T, second: T, nanosecond: T, zoneId: string);
+  constructor(year: T, month: T, day: T, hour: T, minute: T, second: T, nanosecond: T, timeZoneOffsetSeconds?: T, timeZoneId?: string);
 }
 
 declare function isDuration(obj: object): boolean;
@@ -111,9 +98,7 @@ declare function isDate(obj: object): boolean;
 
 declare function isLocalDateTime(obj: object): boolean;
 
-declare function isDateTimeWithZoneOffset(obj: object): boolean;
-
-declare function isDateTimeWithZoneId(obj: object): boolean;
+declare function isDateTime(obj: object): boolean;
 
 export {
   Duration,
@@ -121,13 +106,11 @@ export {
   Time,
   Date,
   LocalDateTime,
-  DateTimeWithZoneOffset,
-  DateTimeWithZoneId,
+  DateTime,
   isDuration,
   isLocalTime,
   isTime,
   isDate,
   isLocalDateTime,
-  isDateTimeWithZoneOffset,
-  isDateTimeWithZoneId
+  isDateTime
 }


### PR DESCRIPTION
DateTime contains time zone information. It might either be an offset in seconds (that corresponds to ±HH:MM) or the time zone id (like 'Europe/London'). Previously driver exposed DateTime as two different types: `DateTimeWithZoneOffset` and `DateTimeWithZoneId`.

This PR combines them into a single type:

```
class DateTime {
  year: Integer|number,
  month: Integer|number,
  day: Integer|number,
  hour: Integer|number,
  minute: Integer|number,
  second: Integer|number,
  nanosecond: Integer|number,
  timeZoneOffsetSeconds: Integer|number,
  timeZoneId: string
}
```

where either `timeZoneOffsetSeconds` or `timeZoneId` is defined. Such single type better corresponds to the Cypher DateTime type and feels more idiomatic to JavaScript. Shape of objects (set of their properties) feels more important than the class/type.

Also renamed `Time.offsetSeconds` to `Time.timeZoneOffsetSeconds` to better represent the meaning of the property.