### PR TITLE
More validation for query parameters

### DIFF
--- a/src/v1/internal/packstream-v1.js
+++ b/src/v1/internal/packstream-v1.js
@@ -129,6 +129,12 @@ class Packer {
       }
     } else if (isIterable(x)) {
       return this.packableIterable(x, onError);
+    } else if (x instanceof Node) {
+      return this._nonPackableValue(`It is not allowed to pass nodes in query parameters, given: ${x}`, onError);
+    } else if (x instanceof Relationship) {
+      return this._nonPackableValue(`It is not allowed to pass relationships in query parameters, given: ${x}`, onError);
+    } else if (x instanceof Path) {
+      return this._nonPackableValue(`It is not allowed to pass paths in query parameters, given: ${x}`, onError);
     } else if (x instanceof Structure) {
       var packableFields = [];
       for (var i = 0; i < x.fields.length; i++) {
@@ -155,10 +161,7 @@ class Packer {
         }
       };
     } else {
-      if (onError) {
-        onError(newError("Cannot pack this value: " + x));
-      }
-      return () => undefined;
+      return this._nonPackableValue(`Unable to pack the given value: ${x}`, onError);
     }
   }
 
@@ -333,6 +336,13 @@ class Packer {
 
   disableByteArrays() {
     this._byteArraysSupported = false;
+  }
+
+  _nonPackableValue(message, onError) {
+    if (onError) {
+      onError(newError(message, PROTOCOL_ERROR));
+    }
+    return () => undefined;
   }
 }
 

--- a/src/v1/internal/util.js
+++ b/src/v1/internal/util.js
@@ -39,7 +39,7 @@ function isEmptyObjectOrNull(obj) {
 }
 
 function isObject(obj) {
-  return typeof obj === 'object' && !Array.isArray(obj) && Boolean(obj);
+  return typeof obj === 'object' && !Array.isArray(obj) && obj !== null;
 }
 
 /**
@@ -79,7 +79,7 @@ function assertCypherStatement(obj) {
 }
 
 function assertQueryParameters(obj) {
-  if (!isObject(obj) && Boolean(obj)) {
+  if (!isObject(obj)) {
     // objects created with `Object.create(null)` do not have a constructor property
     const constructor = obj.constructor ? ' ' + obj.constructor.name : '';
     throw new TypeError(`Query parameters are expected to either be undefined/null or an object, given:${constructor} ${obj}`);

--- a/src/v1/internal/util.js
+++ b/src/v1/internal/util.js
@@ -39,8 +39,29 @@ function isEmptyObjectOrNull(obj) {
 }
 
 function isObject(obj) {
-  const type = typeof obj;
-  return type === 'function' || type === 'object' && Boolean(obj);
+  return typeof obj === 'object' && !Array.isArray(obj) && Boolean(obj);
+}
+
+/**
+ * Check and normalize given statement and parameters.
+ * @param {string|{text: string, parameters: object}} statement the statement to check.
+ * @param {object} parameters
+ * @return {{query: string, params: object}} the normalized query with parameters.
+ * @throws TypeError when either given query or parameters are invalid.
+ */
+function validateStatementAndParameters(statement, parameters) {
+  let query = statement;
+  let params = parameters || {};
+
+  if (typeof statement === 'object' && statement.text) {
+    query = statement.text;
+    params = statement.parameters || {};
+  }
+
+  assertCypherStatement(query);
+  assertQueryParameters(params);
+
+  return {query, params};
 }
 
 function assertString(obj, objName) {
@@ -52,10 +73,17 @@ function assertString(obj, objName) {
 
 function assertCypherStatement(obj) {
   assertString(obj, 'Cypher statement');
-  if (obj.trim().length == 0) {
+  if (obj.trim().length === 0) {
     throw new TypeError('Cypher statement is expected to be a non-empty string.');
   }
-  return obj;
+}
+
+function assertQueryParameters(obj) {
+  if (!isObject(obj) && Boolean(obj)) {
+    // objects created with `Object.create(null)` do not have a constructor property
+    const constructor = obj.constructor ? ' ' + obj.constructor.name : '';
+    throw new TypeError(`Query parameters are expected to either be undefined/null or an object, given:${constructor} ${obj}`);
+  }
 }
 
 function isString(str) {
@@ -66,7 +94,7 @@ export {
   isEmptyObjectOrNull,
   isString,
   assertString,
-  assertCypherStatement,
+  validateStatementAndParameters,
   ENCRYPTION_ON,
   ENCRYPTION_OFF
 }

--- a/src/v1/session.js
+++ b/src/v1/session.js
@@ -20,7 +20,7 @@ import StreamObserver from './internal/stream-observer';
 import Result from './result';
 import Transaction from './transaction';
 import {newError} from './error';
-import {assertCypherStatement} from './internal/util';
+import {validateStatementAndParameters} from './internal/util';
 import ConnectionHolder from './internal/connection-holder';
 import Driver, {READ, WRITE} from './driver';
 import TransactionExecutor from './internal/transaction-executor';
@@ -60,14 +60,10 @@ class Session {
    * @return {Result} - New Result
    */
   run(statement, parameters = {}) {
-    if (typeof statement === 'object' && statement.text) {
-      parameters = statement.parameters || {};
-      statement = statement.text;
-    }
-    assertCypherStatement(statement);
+    const {query, params} = validateStatementAndParameters(statement, parameters);
 
-    return this._run(statement, parameters, (connection, streamObserver) =>
-      connection.run(statement, parameters, streamObserver)
+    return this._run(query, params, (connection, streamObserver) =>
+      connection.run(query, params, streamObserver)
     );
   }
 

--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -18,7 +18,7 @@
  */
 import StreamObserver from './internal/stream-observer';
 import Result from './result';
-import {assertCypherStatement} from './internal/util';
+import {validateStatementAndParameters} from './internal/util';
 import {EMPTY_CONNECTION_HOLDER} from './internal/connection-holder';
 import Bookmark from './internal/bookmark';
 
@@ -60,13 +60,9 @@ class Transaction {
    * @return {Result} New Result
    */
   run(statement, parameters) {
-    if(typeof statement === 'object' && statement.text) {
-      parameters = statement.parameters || {};
-      statement = statement.text;
-    }
-    assertCypherStatement(statement);
+    const {query, params} = validateStatementAndParameters(statement, parameters);
 
-    return this._state.run(this._connectionHolder,  new _TransactionStreamObserver(this), statement, parameters);
+    return this._state.run(this._connectionHolder, new _TransactionStreamObserver(this), query, params);
   }
 
   /**

--- a/test/internal/http/http-session.test.js
+++ b/test/internal/http/http-session.test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import sharedNeo4j from '../../internal/shared-neo4j';
+import urlUtil from '../../../src/v1/internal/url-util';
+import testUtil from '../test-utils';
+import HttpSession from '../../../src/v1/internal/http/http-session';
+import HttpSessionTracker from '../../../src/v1/internal/http/http-session-tracker';
+
+describe('http session', () => {
+
+  it('should fail for invalid query parameters', done => {
+    if (testUtil.isServer()) {
+      done();
+      return;
+    }
+
+    const session = new HttpSession(urlUtil.parseDatabaseUrl('http://localhost:7474'), sharedNeo4j.authToken, {}, new HttpSessionTracker());
+
+    expect(() => session.run('RETURN $value', [1, 2, 3])).toThrowError(TypeError);
+    expect(() => session.run('RETURN $value', '123')).toThrowError(TypeError);
+    expect(() => session.run('RETURN $value', () => [123])).toThrowError(TypeError);
+
+    session.close(() => done());
+  });
+
+});

--- a/test/internal/util.test.js
+++ b/test/internal/util.test.js
@@ -24,13 +24,12 @@ describe('util', () => {
   it('should check empty objects', () => {
     expect(util.isEmptyObjectOrNull(null)).toBeTruthy();
     expect(util.isEmptyObjectOrNull({})).toBeTruthy();
-    expect(util.isEmptyObjectOrNull([])).toBeTruthy();
+
+    expect(util.isEmptyObjectOrNull([])).toBeFalsy();
 
     const func = () => {
       return 42;
     };
-    expect(util.isEmptyObjectOrNull(func)).toBeTruthy();
-    func.foo = 'bar';
     expect(util.isEmptyObjectOrNull(func)).toBeFalsy();
 
     expect(util.isEmptyObjectOrNull()).toBeFalsy();
@@ -74,6 +73,26 @@ describe('util', () => {
     verifyInvalidCypherStatement(console.log);
   });
 
+  it('should check valid query parameters', () => {
+    verifyValidQueryParameters(null);
+    verifyValidQueryParameters(undefined);
+    verifyValidQueryParameters({});
+    verifyValidQueryParameters({a: 1, b: 2, c: 3});
+    verifyValidQueryParameters({foo: 'bar', baz: 'qux'});
+  });
+
+  it('should check invalid query parameters', () => {
+    verifyInvalidQueryParameters('parameter');
+    verifyInvalidQueryParameters(123);
+    verifyInvalidQueryParameters([]);
+    verifyInvalidQueryParameters([1, 2, 3]);
+    verifyInvalidQueryParameters([null]);
+    verifyInvalidQueryParameters(['1', '2', '3']);
+    verifyInvalidQueryParameters(() => [1, 2, 3]);
+    verifyInvalidQueryParameters(() => '');
+    verifyInvalidQueryParameters(() => null);
+  });
+
   function verifyValidString(str) {
     expect(util.assertString(str, 'Test string')).toBe(str);
   }
@@ -83,7 +102,15 @@ describe('util', () => {
   }
 
   function verifyInvalidCypherStatement(str) {
-    expect(() => util.assertCypherStatement(str)).toThrowError(TypeError);
+    expect(() => util.validateStatementAndParameters(str, {})).toThrowError(TypeError);
+  }
+
+  function verifyValidQueryParameters(obj) {
+    expect(() => util.validateStatementAndParameters('RETURN 1', obj)).not.toThrow();
+  }
+
+  function verifyInvalidQueryParameters(obj) {
+    expect(() => util.validateStatementAndParameters('RETURN 1', obj)).toThrowError(TypeError);
   }
 
 });

--- a/test/v1/transaction.test.js
+++ b/test/v1/transaction.test.js
@@ -509,6 +509,16 @@ describe('transaction', () => {
     testConnectionTimeout(true, done);
   });
 
+  it('should fail for invalid query parameters', done => {
+    const tx = session.beginTransaction();
+
+    expect(() => tx.run('RETURN $value', 'Hello')).toThrowError(TypeError);
+    expect(() => tx.run('RETURN $value', 12345)).toThrowError(TypeError);
+    expect(() => tx.run('RETURN $value', () => 'Hello')).toThrowError(TypeError);
+
+    tx.rollback().then(() => done());
+  });
+
   function expectSyntaxError(error) {
     expect(error.code).toBe('Neo.ClientError.Statement.SyntaxError');
   }


### PR DESCRIPTION
Driver expects query parameters to either be undefined/null or an object. This was previously not enforced and illegal parameters, like strings or arrays, were sent to the database. This resulted in a protocol violation and database closed the connection. Users were only able to see the actual error/stacktrace in the database logs. Driver received a `ServiceUnavailable` or `SessionExpired` error.

This PR adds validation of query parameters. It also prohibits nodes, relationships, and paths from being used as query parameters in the driver.

Resolves https://github.com/neo4j/neo4j-javascript-driver/issues/340