### PR TITLE
Improve exports of spatial and temporal types

### DIFF
--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -235,7 +235,7 @@ const error = {
 };
 
 /**
- * Object containing functions for work with {@link Integer} objects.
+ * Object containing functions to work with {@link Integer} objects.
  */
 const integer = {
   toNumber,
@@ -244,26 +244,16 @@ const integer = {
 };
 
 /**
- * @private
+ * Object containing functions to work with spatial types, like {@link Point}.
  */
-const forExport = {
-  driver,
-  int,
-  isInt,
-  integer,
-  Neo4jError,
-  auth,
-  types,
-  session,
-  error,
-  Point,
-  isPoint,
-  Date,
-  DateTime,
-  Duration,
-  LocalDateTime,
-  LocalTime,
-  Time,
+const spatial = {
+  isPoint
+};
+
+/**
+ * Object containing functions to work with temporal types, like {@link Time} or {@link Duration}.
+ */
+const temporal = {
   isDuration,
   isLocalTime,
   isTime,
@@ -272,29 +262,49 @@ const forExport = {
   isDateTime
 };
 
-export {
+
+/**
+ * @private
+ */
+const forExport = {
   driver,
   int,
   isInt,
+  isPoint,
+  isDuration,
+  isLocalTime,
+  isTime,
+  isDate,
+  isLocalDateTime,
+  isDateTime,
   integer,
   Neo4jError,
   auth,
   types,
   session,
   error,
-  Point,
+  spatial,
+  temporal
+};
+
+export {
+  driver,
+  int,
+  isInt,
   isPoint,
-  Date,
-  DateTime,
-  Duration,
-  LocalDateTime,
-  LocalTime,
-  Time,
   isDuration,
   isLocalTime,
   isTime,
   isDate,
   isLocalDateTime,
-  isDateTime
+  isDateTime,
+  integer,
+  Neo4jError,
+  auth,
+  types,
+  session,
+  error,
+  spatial,
+  temporal
 };
 export default forExport;

--- a/test/internal/temporal-util.test.js
+++ b/test/internal/temporal-util.test.js
@@ -19,8 +19,7 @@
 
 import {int} from '../../src/v1/integer';
 import * as util from '../../src/v1/internal/temporal-util';
-import {Date} from '../../src/v1/temporal-types';
-import {LocalDateTime, LocalTime} from '../../src/v1';
+import {types} from '../../src/v1';
 
 describe('temporal-util', () => {
 
@@ -120,13 +119,13 @@ describe('temporal-util', () => {
 });
 
 function date(year, month, day) {
-  return new Date(int(year), int(month), int(day));
+  return new types.Date(int(year), int(month), int(day));
 }
 
 function localTime(hour, minute, second, nanosecond) {
-  return new LocalTime(int(hour), int(minute), int(second), int(nanosecond));
+  return new types.LocalTime(int(hour), int(minute), int(second), int(nanosecond));
 }
 
 function localDateTime(year, month, day, hour, minute, second, nanosecond) {
-  return new LocalDateTime(int(year), int(month), int(day), int(hour), int(minute), int(second), int(nanosecond));
+  return new types.LocalDateTime(int(year), int(month), int(day), int(hour), int(minute), int(second), int(nanosecond));
 }

--- a/test/types/v1/index.test.ts
+++ b/test/types/v1/index.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import v1, {auth, AuthToken, Config, driver, error, session} from "../../../types/v1/index";
+import v1, {auth, AuthToken, Config, driver, error, session, spatial, temporal} from "../../../types/v1/index";
 
 import Driver from "../../../types/v1/driver";
 
@@ -63,3 +63,10 @@ const serviceUnavailable2: string = v1.error.SERVICE_UNAVAILABLE;
 const sessionExpired2: string = v1.error.SESSION_EXPIRED;
 const protocolError2: string = v1.error.PROTOCOL_ERROR;
 
+const isNeo4jPoint: boolean = spatial.isPoint({});
+const isNeo4jDate: boolean = temporal.isDate({});
+const isNeo4jDateTime: boolean = temporal.isDateTime({});
+const isNeo4jDuration: boolean = temporal.isDuration({});
+const isNeo4jLocalDateTime: boolean = temporal.isLocalDateTime({});
+const isNeo4jLocalTime: boolean = temporal.isLocalTime({});
+const isNeo4jTime: boolean = temporal.isTime({});

--- a/test/v1/temporal-types.test.js
+++ b/test/v1/temporal-types.test.js
@@ -110,7 +110,7 @@ describe('temporal-types', () => {
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.Duration(4, 15, 931, 99953), done);
+    testSendReceiveTemporalValue(new neo4j.types.Duration(4, 15, 931, 99953), done);
   });
 
   it('should send and receive array of Duration', done => {
@@ -154,7 +154,7 @@ describe('temporal-types', () => {
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.LocalTime(12, 32, 56, 12345), done);
+    testSendReceiveTemporalValue(new neo4j.types.LocalTime(12, 32, 56, 12345), done);
   });
 
   it('should send and receive random LocalTime', done => {
@@ -206,7 +206,7 @@ describe('temporal-types', () => {
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.Time(22, 19, 32, 18381, MAX_TIME_ZONE_OFFSET), done);
+    testSendReceiveTemporalValue(new neo4j.types.Time(22, 19, 32, 18381, MAX_TIME_ZONE_OFFSET), done);
   });
 
   it('should send and receive random Time', done => {
@@ -258,7 +258,7 @@ describe('temporal-types', () => {
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.Date(1923, 8, 14), done);
+    testSendReceiveTemporalValue(new neo4j.types.Date(1923, 8, 14), done);
   });
 
   it('should send and receive random Date', done => {
@@ -310,7 +310,7 @@ describe('temporal-types', () => {
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.LocalDateTime(2045, 9, 1, 11, 25, 25, 911), done);
+    testSendReceiveTemporalValue(new neo4j.types.LocalDateTime(2045, 9, 1, 11, 25, 25, 911), done);
   });
 
   it('should send and receive random LocalDateTime', done => {
@@ -362,7 +362,7 @@ describe('temporal-types', () => {
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.DateTime(2022, 2, 7, 17, 15, 59, 12399, MAX_TIME_ZONE_OFFSET, null), done);
+    testSendReceiveTemporalValue(new neo4j.types.DateTime(2022, 2, 7, 17, 15, 59, 12399, MAX_TIME_ZONE_OFFSET, null), done);
   });
 
   it('should send and receive random DateTime with zone offset', done => {
@@ -414,7 +414,7 @@ describe('temporal-types', () => {
     }
     session = driverWithNativeNumbers.session();
 
-    testSendReceiveTemporalValue(new neo4j.DateTime(2011, 11, 25, 23, 59, 59, 192378, null, 'Europe/Stockholm'), done);
+    testSendReceiveTemporalValue(new neo4j.types.DateTime(2011, 11, 25, 23, 59, 59, 192378, null, 'Europe/Stockholm'), done);
   });
 
   it('should send and receive random DateTime with zone id', done => {
@@ -599,30 +599,30 @@ describe('temporal-types', () => {
 
   function randomDateTimeWithZoneOffset() {
     const dateTime = randomDstSafeLocalDateTime();
-    return new neo4j.DateTime(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond,
+    return new neo4j.types.DateTime(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond,
       randomZoneOffsetSeconds(), null);
   }
 
   function randomDateTimeWithZoneId() {
     const dateTime = randomDstSafeLocalDateTime();
-    return new neo4j.DateTime(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond,
+    return new neo4j.types.DateTime(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond,
       null, randomZoneId());
   }
 
   function randomDstSafeLocalDateTime() {
     const date = randomDate();
     const time = randomDstSafeLocalTime();
-    return new neo4j.LocalDateTime(date.year, date.month, date.day, time.hour, time.minute, time.second, time.nanosecond);
+    return new neo4j.types.LocalDateTime(date.year, date.month, date.day, time.hour, time.minute, time.second, time.nanosecond);
   }
 
   function randomLocalDateTime() {
     const date = randomDate();
     const time = randomLocalTime();
-    return new neo4j.LocalDateTime(date.year, date.month, date.day, time.hour, time.minute, time.second, time.nanosecond);
+    return new neo4j.types.LocalDateTime(date.year, date.month, date.day, time.hour, time.minute, time.second, time.nanosecond);
   }
 
   function randomDate() {
-    return new neo4j.Date(
+    return new neo4j.types.Date(
       randomInt(MIN_YEAR, MAX_YEAR),
       randomInt(1, 12),
       randomInt(1, 28)
@@ -631,11 +631,11 @@ describe('temporal-types', () => {
 
   function randomTime() {
     const localTime = randomLocalTime();
-    return new neo4j.Time(localTime.hour, localTime.minute, localTime.second, localTime.nanosecond, randomZoneOffsetSeconds());
+    return new neo4j.types.Time(localTime.hour, localTime.minute, localTime.second, localTime.nanosecond, randomZoneOffsetSeconds());
   }
 
   function randomLocalTime() {
-    return new neo4j.LocalTime(
+    return new neo4j.types.LocalTime(
       randomInt(0, 23),
       randomInt(0, 59),
       randomInt(0, 59),
@@ -644,7 +644,7 @@ describe('temporal-types', () => {
   }
 
   function randomDstSafeLocalTime() {
-    return new neo4j.LocalTime(
+    return new neo4j.types.LocalTime(
       randomInt(4, 23), // do not generate hours in range where DST adjustment happens
       randomInt(0, 59),
       randomInt(0, 59),
@@ -662,33 +662,33 @@ describe('temporal-types', () => {
   }
 
   function duration(months, days, seconds, nanoseconds) {
-    return new neo4j.Duration(neo4j.int(months), neo4j.int(days), neo4j.int(seconds), neo4j.int(nanoseconds));
+    return new neo4j.types.Duration(neo4j.int(months), neo4j.int(days), neo4j.int(seconds), neo4j.int(nanoseconds));
   }
 
   function localTime(hour, minute, second, nanosecond) {
-    return new neo4j.LocalTime(neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond));
+    return new neo4j.types.LocalTime(neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond));
   }
 
   function time(hour, minute, second, nanosecond, offsetSeconds) {
-    return new neo4j.Time(neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond), neo4j.int(offsetSeconds));
+    return new neo4j.types.Time(neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond), neo4j.int(offsetSeconds));
   }
 
   function date(year, month, day) {
-    return new neo4j.Date(neo4j.int(year), neo4j.int(month), neo4j.int(day));
+    return new neo4j.types.Date(neo4j.int(year), neo4j.int(month), neo4j.int(day));
   }
 
   function localDateTime(year, month, day, hour, minute, second, nanosecond) {
-    return new neo4j.LocalDateTime(neo4j.int(year), neo4j.int(month), neo4j.int(day),
+    return new neo4j.types.LocalDateTime(neo4j.int(year), neo4j.int(month), neo4j.int(day),
       neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond));
   }
 
   function dateTimeWithZoneOffset(year, month, day, hour, minute, second, nanosecond, offsetSeconds) {
-    return new neo4j.DateTime(neo4j.int(year), neo4j.int(month), neo4j.int(day),
+    return new neo4j.types.DateTime(neo4j.int(year), neo4j.int(month), neo4j.int(day),
       neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond), neo4j.int(offsetSeconds), null);
   }
 
   function dateTimeWithZoneId(year, month, day, hour, minute, second, nanosecond, zoneId) {
-    return new neo4j.DateTime(neo4j.int(year), neo4j.int(month), neo4j.int(day),
+    return new neo4j.types.DateTime(neo4j.int(year), neo4j.int(month), neo4j.int(day),
       neo4j.int(hour), neo4j.int(minute), neo4j.int(second), neo4j.int(nanosecond), null, zoneId);
   }
 

--- a/types/v1/index.d.ts
+++ b/types/v1/index.d.ts
@@ -83,6 +83,19 @@ declare const integer: {
   inSafeRange: typeof inSafeRange;
 };
 
+declare const spatial: {
+  isPoint: typeof isPoint;
+};
+
+declare const temporal: {
+  isDuration: typeof isDuration;
+  isLocalTime: typeof isLocalTime;
+  isTime: typeof isTime;
+  isDate: typeof isDate;
+  isLocalDateTime: typeof isLocalDateTime;
+  isDateTime: typeof isDateTime;
+};
+
 /*
  Both default and non-default exports declare all visible types so that they can be used in client code like this:
 
@@ -101,6 +114,8 @@ declare const forExport: {
   types: typeof types;
   session: typeof session;
   error: typeof error;
+  spatial: typeof spatial;
+  temporal: typeof temporal;
   Driver: Driver;
   AuthToken: AuthToken;
   Config: Config;
@@ -152,6 +167,8 @@ export {
   types,
   session,
   error,
+  spatial,
+  temporal,
   Driver,
   AuthToken,
   Config,


### PR DESCRIPTION
Previously driver exported all spatial and temporal types and functions from both default and non-default export in v1 index.js file.

This PR makes it export all spatial and temporal types only from the `types` constant. Functions are still exported from both default and non-default exports to be consistent with existing `isInt`. Created two grouping constants `spatial` and `temporal` to export corresponding functions in a nicer, grouped way.