### PR TITLE
Omit zero nanoseconds in `toString()` for temporal types

### DIFF
--- a/src/v1/internal/temporal-util.js
+++ b/src/v1/internal/temporal-util.js
@@ -189,8 +189,8 @@ export function durationToIsoString(months, days, seconds, nanoseconds) {
   const monthsString = formatNumber(months);
   const daysString = formatNumber(days);
   const secondsString = formatNumber(seconds);
-  const nanosecondsString = formatNumber(nanoseconds, 9);
-  return `P${monthsString}M${daysString}DT${secondsString}.${nanosecondsString}S`;
+  const nanosecondsString = formatNanoseconds(nanoseconds);
+  return `P${monthsString}M${daysString}DT${secondsString}${nanosecondsString}S`;
 }
 
 /**
@@ -205,8 +205,8 @@ export function timeToIsoString(hour, minute, second, nanosecond) {
   const hourString = formatNumber(hour, 2);
   const minuteString = formatNumber(minute, 2);
   const secondString = formatNumber(second, 2);
-  const nanosecondString = formatNumber(nanosecond, 9);
-  return `${hourString}:${minuteString}:${secondString}.${nanosecondString}`;
+  const nanosecondString = formatNanoseconds(nanosecond);
+  return `${hourString}:${minuteString}:${secondString}${nanosecondString}`;
 }
 
 /**
@@ -319,6 +319,15 @@ function floorMod(x, y) {
   y = int(y);
 
   return x.subtract(floorDiv(x, y).multiply(y));
+}
+
+/**
+ * @param {Integer|number|string} value the number of nanoseconds to format.
+ * @return {string} formatted and possibly left-padded nanoseconds part as string.
+ */
+function formatNanoseconds(value) {
+  value = int(value);
+  return value.equals(0) ? '' : '.' + formatNumber(value, 9);
 }
 
 /**

--- a/test/internal/temporal-util.test.js
+++ b/test/internal/temporal-util.test.js
@@ -52,7 +52,8 @@ describe('temporal-util', () => {
   });
 
   it('should convert time to ISO string', () => {
-    expect(util.timeToIsoString(8, 9, 1, 0)).toEqual('08:09:01.000000000');
+    expect(util.timeToIsoString(8, 9, 1, 0)).toEqual('08:09:01');
+    expect(util.timeToIsoString(1, 23, 45, 600000000)).toEqual('01:23:45.600000000');
     expect(util.timeToIsoString(int(2), int(4), int(6), int(7))).toEqual('02:04:06.000000007');
     expect(util.timeToIsoString(22, 19, 7, 999)).toEqual('22:19:07.000000999');
     expect(util.timeToIsoString(int(17), int(2), int(59), int(909090))).toEqual('17:02:59.000909090');
@@ -61,7 +62,7 @@ describe('temporal-util', () => {
   });
 
   it('should convert duration to ISO string', () => {
-    expect(util.durationToIsoString(0, 0, 0, 0)).toEqual('P0M0DT0.000000000S');
+    expect(util.durationToIsoString(0, 0, 0, 0)).toEqual('P0M0DT0S');
     expect(util.durationToIsoString(0, 0, 0, 123)).toEqual('P0M0DT0.000000123S');
     expect(util.durationToIsoString(11, 99, 100, 99901)).toEqual('P11M99DT100.000099901S');
     expect(util.durationToIsoString(int(3), int(9191), int(17), int(123456789))).toEqual('P3M9191DT17.123456789S');

--- a/test/v1/temporal-types.test.js
+++ b/test/v1/temporal-types.test.js
@@ -435,20 +435,20 @@ describe('temporal-types', () => {
 
   it('should convert Duration to ISO string', () => {
     expect(duration(13, 62, 3, 999111999).toString()).toEqual('P13M62DT3.999111999S');
-    expect(duration(0, 0, 0, 0).toString()).toEqual('P0M0DT0.000000000S');
+    expect(duration(0, 0, 0, 0).toString()).toEqual('P0M0DT0S');
     expect(duration(-1, -2, 10, 10).toString()).toEqual('P-1M-2DT10.000000010S');
   });
 
   it('should convert LocalTime to ISO string', () => {
     expect(localTime(12, 19, 39, 111222333).toString()).toEqual('12:19:39.111222333');
     expect(localTime(3, 59, 2, 17).toString()).toEqual('03:59:02.000000017');
-    expect(localTime(0, 0, 0, 0).toString()).toEqual('00:00:00.000000000');
+    expect(localTime(0, 0, 0, 0).toString()).toEqual('00:00:00');
   });
 
   it('should convert Time to ISO string', () => {
     expect(time(11, 45, 22, 333222111, 9015).toString()).toEqual('11:45:22.333222111+02:30:15');
     expect(time(23, 2, 1, 10, 0).toString()).toEqual('23:02:01.000000010Z');
-    expect(time(0, 12, 59, 0, -40500).toString()).toEqual('00:12:59.000000000-11:15');
+    expect(time(0, 12, 59, 0, -40500).toString()).toEqual('00:12:59-11:15');
     expect(time(21, 59, 0, 123, -25200).toString()).toEqual('21:59:00.000000123-07:00');
   });
 


### PR DESCRIPTION
This changes implementations of `toString()` function for `Duration`, `Time`, `LocalTime`, `LocalDateTime` and `DateTime`. Returned strings still remain valid ISO strings and represent same temporal values.