### PR TITLE
Automatically use secure WebSocket on HTTPS pages

### DIFF
--- a/src/v1/internal/ch-config.js
+++ b/src/v1/internal/ch-config.js
@@ -42,9 +42,12 @@ export default class ChannelConfig {
 
 function extractEncrypted(driverConfig) {
   // check if encryption was configured by the user, use explicit null check because we permit boolean value
-  const encryptionConfigured = driverConfig.encrypted == null;
+  const encryptionNotConfigured = driverConfig.encrypted == null;
   // default to using encryption if trust-all-certificates is available
-  return encryptionConfigured ? hasFeature('trust_all_certificates') : driverConfig.encrypted;
+  if (encryptionNotConfigured && hasFeature('trust_all_certificates')) {
+    return true;
+  }
+  return driverConfig.encrypted;
 }
 
 function extractTrust(driverConfig) {

--- a/src/v1/internal/ch-node.js
+++ b/src/v1/internal/ch-node.js
@@ -297,7 +297,6 @@ class NodeChannel {
     this._handleConnectionTerminated = this._handleConnectionTerminated.bind(this);
     this._connectionErrorCode = config.connectionErrorCode;
 
-    this._encrypted = config.encrypted;
     this._conn = connect(config, () => {
       if(!self._open) {
         return;
@@ -360,10 +359,6 @@ class NodeChannel {
 
       socket.setTimeout(timeout);
     }
-  }
-
-  isEncrypted() {
-    return this._encrypted;
   }
 
   /**

--- a/src/v1/internal/connector.js
+++ b/src/v1/internal/connector.js
@@ -397,10 +397,6 @@ class Connection {
     return !this._isBroken && this._ch._open;
   }
 
-  isEncrypted() {
-    return this._ch.isEncrypted();
-  }
-
   /**
    * Call close on the channel.
    * @param {function} cb - Function to call on close.

--- a/test/internal/ch-config.test.js
+++ b/test/internal/ch-config.test.js
@@ -76,7 +76,11 @@ describe('ChannelConfig', () => {
   it('should use encryption if available but not configured', () => {
     const config = new ChannelConfig(null, {}, '');
 
-    expect(config.encrypted).toEqual(hasFeature('trust_all_certificates'));
+    if (hasFeature('trust_all_certificates')) {
+      expect(config.encrypted).toBeTruthy();
+    } else {
+      expect(config.encrypted).toBeFalsy();
+    }
   });
 
   it('should use available trust conf when nothing configured', () => {

--- a/test/internal/ch-websocket.test.js
+++ b/test/internal/ch-websocket.test.js
@@ -19,8 +19,9 @@
 import wsChannel from '../../src/v1/internal/ch-websocket';
 import ChannelConfig from '../../src/v1/internal/ch-config';
 import urlUtil from '../../src/v1/internal/url-util';
-import {SERVICE_UNAVAILABLE} from '../../src/v1/error';
+import {Neo4jError, SERVICE_UNAVAILABLE} from '../../src/v1/error';
 import {setTimeoutMock} from './timers-util';
+import {ENCRYPTION_OFF, ENCRYPTION_ON} from '../../src/v1/internal/util';
 
 describe('WebSocketChannel', () => {
 
@@ -94,6 +95,54 @@ describe('WebSocketChannel', () => {
     }
   });
 
+  it('should select wss when running on https page', () => {
+    testWebSocketScheme('https:', {}, 'wss');
+  });
+
+  it('should select ws when running on http page', () => {
+    testWebSocketScheme('http:', {}, 'ws');
+  });
+
+  it('should select ws when running on https page but encryption turned off with boolean', () => {
+    testWebSocketScheme('https:', {encrypted: false}, 'ws');
+  });
+
+  it('should select ws when running on https page but encryption turned off with string', () => {
+    testWebSocketScheme('https:', {encrypted: ENCRYPTION_OFF}, 'ws');
+  });
+
+  it('should select wss when running on http page but encryption configured with boolean', () => {
+    testWebSocketScheme('http:', {encrypted: true}, 'wss');
+  });
+
+  it('should select wss when running on http page but encryption configured with string', () => {
+    testWebSocketScheme('http:', {encrypted: ENCRYPTION_ON}, 'wss');
+  });
+
+  it('should fail when encryption configured with unsupported trust strategy', () => {
+    if (!webSocketChannelAvailable) {
+      return;
+    }
+
+    const protocolSupplier = () => 'http:';
+
+    WebSocket = () => {
+      return {
+        close: () => {
+        }
+      };
+    };
+
+    const url = urlUtil.parseDatabaseUrl('bolt://localhost:8989');
+    const driverConfig = {encrypted: true, trust: 'TRUST_ON_FIRST_USE'};
+    const channelConfig = new ChannelConfig(url, driverConfig, SERVICE_UNAVAILABLE);
+
+    const channel = new WebSocketChannel(channelConfig, protocolSupplier);
+
+    expect(channel._error).toBeDefined();
+    expect(channel._error.name).toEqual('Neo4jError');
+  });
+
   function testFallbackToLiteralIPv6(boltAddress, expectedWsAddress) {
     if (!webSocketChannelAvailable) {
       return;
@@ -119,6 +168,29 @@ describe('WebSocketChannel', () => {
     webSocketChannel = new WebSocketChannel(channelConfig);
 
     expect(webSocketChannel._ws.url).toEqual(expectedWsAddress);
+  }
+
+  function testWebSocketScheme(windowLocationProtocol, driverConfig, expectedScheme) {
+    if (!webSocketChannelAvailable) {
+      return;
+    }
+
+    const protocolSupplier = () => windowLocationProtocol;
+
+    // replace real WebSocket with a function that memorizes the url
+    WebSocket = url => {
+      return {
+        url: url,
+        close: () => {
+        }
+      };
+    };
+
+    const url = urlUtil.parseDatabaseUrl('bolt://localhost:8989');
+    const channelConfig = new ChannelConfig(url, driverConfig, SERVICE_UNAVAILABLE);
+    const channel = new WebSocketChannel(channelConfig, protocolSupplier);
+
+    expect(channel._ws.url).toEqual(expectedScheme + '://localhost:8989');
   }
 
 });


### PR DESCRIPTION
Previously, driver used in browser used secure WebSocket with 'wss' scheme only when encryption was explicitly turned on in the driver config. On HTTP web pages it is perfectly fine to use either plane or secure WebSocket ('ws' and 'wss' respectively). On HTTPS web pages only 'wss' is allowed. So explicit `{encrypted: true}` configuration was always required for drivers used on HTTPS web pages.

This PR makes driver automatically use secure WebSocket when driver is used on a HTTPS web page.

Resolves #255