### PR TITLE
Bolt V3 support & transaction configuration

### DIFF
--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -192,7 +192,7 @@ class Driver {
   session(mode, bookmarkOrBookmarks) {
     const sessionMode = Driver._validateSessionMode(mode);
     const connectionProvider = this._getOrCreateConnectionProvider();
-    const bookmark = new Bookmark(bookmarkOrBookmarks);
+    const bookmark = bookmarkOrBookmarks ? new Bookmark(bookmarkOrBookmarks) : Bookmark.empty();
     return new Session(sessionMode, connectionProvider, bookmark, this._config);
   }
 

--- a/src/v1/internal/bolt-protocol-v1.js
+++ b/src/v1/internal/bolt-protocol-v1.js
@@ -50,6 +50,15 @@ export default class BoltProtocol {
   }
 
   /**
+   * Transform metadata received in SUCCESS message before it is passed to the handler.
+   * @param {object} metadata the received metadata.
+   * @return {object} transformed metadata.
+   */
+  transformMetadata(metadata) {
+    return metadata;
+  }
+
+  /**
    * Perform initialization and authentication of the underlying connection.
    * @param {string} clientName the client name.
    * @param {object} authToken the authentication token.

--- a/src/v1/internal/bolt-protocol-v1.js
+++ b/src/v1/internal/bolt-protocol-v1.js
@@ -18,6 +18,9 @@
  */
 import RequestMessage from './request-message';
 import * as v1 from './packstream-v1';
+import {newError} from '../error';
+import Bookmark from './bookmark';
+import TxConfig from './tx-config';
 
 export default class BoltProtocol {
 
@@ -72,9 +75,12 @@ export default class BoltProtocol {
   /**
    * Begin an explicit transaction.
    * @param {Bookmark} bookmark the bookmark.
+   * @param {TxConfig} txConfig the configuration.
    * @param {StreamObserver} observer the response observer.
    */
-  beginTransaction(bookmark, observer) {
+  beginTransaction(bookmark, txConfig, observer) {
+    assertTxConfigIsEmpty(txConfig, this._connection, observer);
+
     const runMessage = RequestMessage.run('BEGIN', bookmark.asBeginTransactionParameters());
     const pullAllMessage = RequestMessage.pullAll();
 
@@ -87,7 +93,7 @@ export default class BoltProtocol {
    * @param {StreamObserver} observer the response observer.
    */
   commitTransaction(observer) {
-    this.run('COMMIT', {}, observer);
+    this.run('COMMIT', {}, Bookmark.empty(), TxConfig.empty(), observer);
   }
 
   /**
@@ -95,16 +101,21 @@ export default class BoltProtocol {
    * @param {StreamObserver} observer the response observer.
    */
   rollbackTransaction(observer) {
-    this.run('ROLLBACK', {}, observer);
+    this.run('ROLLBACK', {}, Bookmark.empty(), TxConfig.empty(), observer);
   }
 
   /**
    * Send a Cypher statement through the underlying connection.
    * @param {string} statement the cypher statement.
    * @param {object} parameters the statement parameters.
+   * @param {Bookmark} bookmark the bookmark.
+   * @param {TxConfig} txConfig the auto-commit transaction configuration.
    * @param {StreamObserver} observer the response observer.
    */
-  run(statement, parameters, observer) {
+  run(statement, parameters, bookmark, txConfig, observer) {
+    // bookmark is ignored in this version of the protocol
+    assertTxConfigIsEmpty(txConfig, this._connection, observer);
+
     const runMessage = RequestMessage.run(statement, parameters);
     const pullAllMessage = RequestMessage.pullAll();
 
@@ -127,5 +138,22 @@ export default class BoltProtocol {
 
   _createUnpacker(disableLosslessIntegers) {
     return new v1.Unpacker(disableLosslessIntegers);
+  }
+}
+
+/**
+ * @param {TxConfig} txConfig the auto-commit transaction configuration.
+ * @param {Connection} connection the connection.
+ * @param {StreamObserver} observer the response observer.
+ */
+function assertTxConfigIsEmpty(txConfig, connection, observer) {
+  if (!txConfig.isEmpty()) {
+    const error = newError('Driver is connected to the database that does not support transaction configuration. ' +
+      'Please upgrade to neo4j 3.5.0 or later in order to use this functionality');
+
+    // unsupported API was used, consider this a fatal error for the current connection
+    connection._handleFatalError(error);
+    observer.onError(error);
+    throw error;
   }
 }

--- a/src/v1/internal/bolt-protocol-v3.js
+++ b/src/v1/internal/bolt-protocol-v3.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import BoltProtocolV2 from './bolt-protocol-v2';
+import RequestMessage from './request-message';
+
+export default class BoltProtocol extends BoltProtocolV2 {
+
+  constructor(connection, chunker, disableLosslessIntegers) {
+    super(connection, chunker, disableLosslessIntegers);
+  }
+
+  transformMetadata(metadata) {
+    if (metadata.t_first) {
+      // Bolt V3 uses shorter key 't_first' to represent 'result_available_after'
+      // adjust the key to be the same as in Bolt V1 so that ResultSummary can retrieve the value
+      metadata.result_available_after = metadata.t_first;
+      delete metadata.t_first;
+    }
+    if (metadata.t_last) {
+      // Bolt V3 uses shorter key 't_last' to represent 'result_consumed_after'
+      // adjust the key to be the same as in Bolt V1 so that ResultSummary can retrieve the value
+      metadata.result_consumed_after = metadata.t_last;
+      delete metadata.t_last;
+    }
+    return metadata;
+  }
+
+  initialize(userAgent, authToken, observer) {
+    prepareToHandleSingleResponse(observer);
+    const message = RequestMessage.hello(userAgent, authToken);
+    this._connection.write(message, observer, true);
+  }
+
+  beginTransaction(bookmark, observer) {
+    prepareToHandleSingleResponse(observer);
+    const message = RequestMessage.begin(bookmark);
+    this._connection.write(message, observer, true);
+  }
+
+  commitTransaction(observer) {
+    prepareToHandleSingleResponse(observer);
+    const message = RequestMessage.commit();
+    this._connection.write(message, observer, true);
+  }
+
+  rollbackTransaction(observer) {
+    prepareToHandleSingleResponse(observer);
+    const message = RequestMessage.rollback();
+    this._connection.write(message, observer, true);
+  }
+
+  run(statement, parameters, observer) {
+    const metadata = {};
+    const runMessage = RequestMessage.runWithMetadata(statement, parameters, metadata);
+    const pullAllMessage = RequestMessage.pullAll();
+
+    this._connection.write(runMessage, observer, false);
+    this._connection.write(pullAllMessage, observer, true);
+  }
+}
+
+function prepareToHandleSingleResponse(observer) {
+  if (observer && typeof observer.prepareToHandleSingleResponse === 'function') {
+    observer.prepareToHandleSingleResponse();
+  }
+}

--- a/src/v1/internal/bolt-protocol-v3.js
+++ b/src/v1/internal/bolt-protocol-v3.js
@@ -47,9 +47,9 @@ export default class BoltProtocol extends BoltProtocolV2 {
     this._connection.write(message, observer, true);
   }
 
-  beginTransaction(bookmark, observer) {
+  beginTransaction(bookmark, txConfig, observer) {
     prepareToHandleSingleResponse(observer);
-    const message = RequestMessage.begin(bookmark);
+    const message = RequestMessage.begin(bookmark, txConfig);
     this._connection.write(message, observer, true);
   }
 
@@ -65,9 +65,8 @@ export default class BoltProtocol extends BoltProtocolV2 {
     this._connection.write(message, observer, true);
   }
 
-  run(statement, parameters, observer) {
-    const metadata = {};
-    const runMessage = RequestMessage.runWithMetadata(statement, parameters, metadata);
+  run(statement, parameters, bookmark, txConfig, observer) {
+    const runMessage = RequestMessage.runWithMetadata(statement, parameters, bookmark, txConfig);
     const pullAllMessage = RequestMessage.pullAll();
 
     this._connection.write(runMessage, observer, false);

--- a/src/v1/internal/bookmark.js
+++ b/src/v1/internal/bookmark.js
@@ -53,6 +53,14 @@ export default class Bookmark {
   }
 
   /**
+   * Get all bookmark values as an array.
+   * @return {string[]} all values.
+   */
+  values() {
+    return this._values;
+  }
+
+  /**
    * Get this bookmark as an object for begin transaction call.
    * @return {object} the value of this bookmark as object.
    */

--- a/src/v1/internal/bookmark.js
+++ b/src/v1/internal/bookmark.js
@@ -36,6 +36,10 @@ export default class Bookmark {
     this._maxValue = maxBookmark(this._values);
   }
 
+  static empty() {
+    return EMPTY_BOOKMARK;
+  }
+
   /**
    * Check if the given bookmark is meaningful and can be send to the database.
    * @return {boolean} returns <code>true</code> bookmark has a value, <code>false</code> otherwise.
@@ -79,6 +83,8 @@ export default class Bookmark {
     };
   }
 }
+
+const EMPTY_BOOKMARK = new Bookmark(null);
 
 /**
  * Converts given value to an array.

--- a/src/v1/internal/connection.js
+++ b/src/v1/internal/connection.js
@@ -267,7 +267,8 @@ export default class Connection {
           this._log.debug(`${this} S: SUCCESS ${JSON.stringify(msg)}`);
         }
         try {
-          this._currentObserver.onCompleted( payload );
+          const metadata = this._protocol.transformMetadata(payload);
+          this._currentObserver.onCompleted(metadata);
         } finally {
           this._updateCurrentObserver();
         }

--- a/src/v1/internal/connection.js
+++ b/src/v1/internal/connection.js
@@ -225,7 +225,6 @@ export default class Connection {
    * failing, and the connection getting ejected from the session pool.
    *
    * @param error an error object, forwarded to all current and future subscribers
-   * @protected
    */
   _handleFatalError(error) {
     this._isBroken = true;

--- a/src/v1/internal/request-message.js
+++ b/src/v1/internal/request-message.js
@@ -88,10 +88,11 @@ export default class RequestMessage {
   /**
    * Create a new BEGIN message.
    * @param {Bookmark} bookmark the bookmark.
+   * @param {TxConfig} txConfig the configuration.
    * @return {RequestMessage} new BEGIN message.
    */
-  static begin(bookmark) {
-    const metadata = {bookmarks: bookmark.values()};
+  static begin(bookmark, txConfig) {
+    const metadata = buildTxMetadata(bookmark, txConfig);
     return new RequestMessage(BEGIN, [metadata], () => `BEGIN ${JSON.stringify(metadata)}`);
   }
 
@@ -115,13 +116,35 @@ export default class RequestMessage {
    * Create a new RUN message with additional metadata.
    * @param {string} statement the cypher statement.
    * @param {object} parameters the statement parameters.
-   * @param {object} metadata the additional metadata.
+   * @param {Bookmark} bookmark the bookmark.
+   * @param {TxConfig} txConfig the configuration.
    * @return {RequestMessage} new RUN message with additional metadata.
    */
-  static runWithMetadata(statement, parameters, metadata) {
+  static runWithMetadata(statement, parameters, bookmark, txConfig) {
+    const metadata = buildTxMetadata(bookmark, txConfig);
     return new RequestMessage(RUN, [statement, parameters, metadata],
       () => `RUN ${statement} ${JSON.stringify(parameters)} ${JSON.stringify(metadata)}`);
   }
+}
+
+/**
+ * Create an object that represent transaction metadata.
+ * @param {Bookmark} bookmark the bookmark.
+ * @param {TxConfig} txConfig the configuration.
+ * @return {object} a metadata object.
+ */
+function buildTxMetadata(bookmark, txConfig) {
+  const metadata = {};
+  if (!bookmark.isEmpty()) {
+    metadata['bookmarks'] = bookmark.values();
+  }
+  if (txConfig.timeout) {
+    metadata['tx_timeout'] = txConfig.timeout;
+  }
+  if (txConfig.metadata) {
+    metadata['tx_metadata'] = txConfig.metadata;
+  }
+  return metadata;
 }
 
 // constants for messages that never change

--- a/src/v1/internal/routing-util.js
+++ b/src/v1/internal/routing-util.js
@@ -20,6 +20,8 @@
 import {newError, PROTOCOL_ERROR, SERVICE_UNAVAILABLE} from '../error';
 import Integer, {int} from '../integer';
 import {ServerVersion, VERSION_3_2_0} from './server-version';
+import Bookmark from './bookmark';
+import TxConfig from './tx-config';
 
 const CALL_GET_SERVERS = 'CALL dbms.cluster.routing.getServers';
 const CALL_GET_ROUTING_TABLE = 'CALL dbms.cluster.routing.getRoutingTable($context)';
@@ -123,7 +125,7 @@ export default class RoutingUtil {
         params = {};
       }
 
-      connection.protocol().run(query, params, streamObserver);
+      connection.protocol().run(query, params, Bookmark.empty(), TxConfig.empty(), streamObserver);
     });
   }
 }

--- a/src/v1/internal/server-version.js
+++ b/src/v1/internal/server-version.js
@@ -112,6 +112,7 @@ function compareInts(x, y) {
 const VERSION_3_1_0 = new ServerVersion(3, 1, 0);
 const VERSION_3_2_0 = new ServerVersion(3, 2, 0);
 const VERSION_3_4_0 = new ServerVersion(3, 4, 0);
+const VERSION_3_5_0 = new ServerVersion(3, 5, 0);
 const maxVer = Number.MAX_SAFE_INTEGER;
 const VERSION_IN_DEV = new ServerVersion(maxVer, maxVer, maxVer);
 
@@ -120,6 +121,7 @@ export {
   VERSION_3_1_0,
   VERSION_3_2_0,
   VERSION_3_4_0,
+  VERSION_3_5_0,
   VERSION_IN_DEV
 };
 

--- a/src/v1/internal/stream-observer.js
+++ b/src/v1/internal/stream-observer.js
@@ -100,6 +100,20 @@ class StreamObserver {
   }
 
   /**
+   * Stream observer defaults to handling responses for two messages: RUN + PULL_ALL or RUN + DISCARD_ALL.
+   * Response for RUN initializes statement keys. Response for PULL_ALL / DISCARD_ALL exposes the result stream.
+   *
+   * However, some operations can be represented as a single message which receives full metadata in a single response.
+   * For example, operations to begin, commit and rollback an explicit transaction use two messages in Bolt V1 but a single message in Bolt V3.
+   * Messages are `RUN "BEGIN" {}` + `PULL_ALL` in Bolt V1 and `BEGIN` in Bolt V3.
+   *
+   * This function prepares the observer to only handle a single response message.
+   */
+  prepareToHandleSingleResponse() {
+    this._fieldKeys = [];
+  }
+
+  /**
    * Will be called on errors.
    * If user-provided observer is present, pass the error
    * to it's onError method, otherwise set instance variable _error.

--- a/src/v1/internal/tx-config.js
+++ b/src/v1/internal/tx-config.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as util from './util';
+import {int} from '../integer';
+import {newError} from '../error';
+
+/**
+ * Internal holder of the transaction configuration.
+ * It performs input validation and value conversion for further serialization by the Bolt protocol layer.
+ * Users of the driver provide transaction configuration as regular objects `{timeout: 10, metadata: {key: 'value'}}`.
+ * Driver converts such objects to {@link TxConfig} immediately and uses converted values everywhere.
+ */
+export default class TxConfig {
+
+  /**
+   * @constructor
+   * @param {object} config the raw configuration object.
+   */
+  constructor(config) {
+    assertValidConfig(config);
+    this.timeout = extractTimeout(config);
+    this.metadata = extractMetadata(config);
+  }
+
+  /**
+   * Get an empty config object.
+   * @return {TxConfig} an empty config.
+   */
+  static empty() {
+    return EMPTY_CONFIG;
+  }
+
+  /**
+   * Check if this config object is empty. I.e. has no configuration values specified.
+   * @return {boolean} `true` if this object is empty, `false` otherwise.
+   */
+  isEmpty() {
+    return Object.values(this).every(value => value == null);
+  }
+}
+
+const EMPTY_CONFIG = new TxConfig({});
+
+/**
+ * @return {Integer|null}
+ */
+function extractTimeout(config) {
+  if (util.isObject(config) && (config.timeout || config.timeout === 0)) {
+    util.assertNumberOrInteger(config.timeout, 'Transaction timeout');
+    const timeout = int(config.timeout);
+    if (timeout.isZero()) {
+      throw newError('Transaction timeout should not be zero');
+    }
+    if (timeout.isNegative()) {
+      throw newError('Transaction timeout should not be negative');
+    }
+    return timeout;
+  }
+  return null;
+}
+
+/**
+ * @return {object|null}
+ */
+function extractMetadata(config) {
+  if (util.isObject(config) && config.metadata) {
+    const metadata = config.metadata;
+    util.assertObject(metadata);
+    if (Object.keys(metadata).length !== 0) {
+      // not an empty object
+      return metadata;
+    }
+  }
+  return null;
+}
+
+function assertValidConfig(config) {
+  if (config) {
+    util.assertObject(config, 'Transaction config');
+  }
+}

--- a/src/v1/internal/util.js
+++ b/src/v1/internal/util.js
@@ -66,6 +66,13 @@ function validateStatementAndParameters(statement, parameters) {
   return {query, params};
 }
 
+function assertObject(obj, objName) {
+  if (!isObject(obj)) {
+    throw new TypeError(objName + ' expected to be an object but was: ' + JSON.stringify(obj));
+  }
+  return obj;
+}
+
 function assertString(obj, objName) {
   if (!isString(obj)) {
     throw new TypeError(objName + ' expected to be string but was: ' + JSON.stringify(obj));
@@ -118,7 +125,9 @@ function isString(str) {
 
 export {
   isEmptyObjectOrNull,
+  isObject,
   isString,
+  assertObject,
   assertString,
   assertNumber,
   assertNumberOrInteger,

--- a/src/v1/session.js
+++ b/src/v1/session.js
@@ -110,8 +110,13 @@ class Session {
     connectionHolder.initializeConnection();
     this._hasTx = true;
 
-    const onTxClose = () => this._hasTx = false;
-    return new Transaction(connectionHolder, onTxClose.bind(this), this._lastBookmark, this._updateBookmark.bind(this));
+    const tx = new Transaction(connectionHolder, this._transactionClosed.bind(this), this._updateBookmark.bind(this));
+    tx._begin(this._lastBookmark);
+    return tx;
+  }
+
+  _transactionClosed() {
+    this._hasTx = false;
   }
 
   /**

--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -32,20 +32,21 @@ class Transaction {
    * @constructor
    * @param {ConnectionHolder} connectionHolder - the connection holder to get connection from.
    * @param {function()} onClose - Function to be called when transaction is committed or rolled back.
-   * @param {Bookmark} bookmark bookmark for transaction begin.
    * @param {function(bookmark: Bookmark)} onBookmark callback invoked when new bookmark is produced.
    */
-  constructor(connectionHolder, onClose, bookmark, onBookmark) {
+  constructor(connectionHolder, onClose, onBookmark) {
     this._connectionHolder = connectionHolder;
+    this._state = _states.ACTIVE;
+    this._onClose = onClose;
+    this._onBookmark = onBookmark;
+  }
+
+  _begin(bookmark) {
     const streamObserver = new _TransactionStreamObserver(this);
 
     this._connectionHolder.getConnection(streamObserver)
       .then(conn => conn.protocol().beginTransaction(bookmark, streamObserver))
       .catch(error => streamObserver.onError(error));
-
-    this._state = _states.ACTIVE;
-    this._onClose = onClose;
-    this._onBookmark = onBookmark;
   }
 
   /**

--- a/test/internal/bolt-protocol-v1.test.js
+++ b/test/internal/bolt-protocol-v1.test.js
@@ -44,6 +44,15 @@ class MessageRecorder {
 
 describe('BoltProtocolV1', () => {
 
+  it('should not change metadata', () => {
+    const metadata = {result_available_after: 1, result_consumed_after: 2, t_first: 3, t_last: 4};
+    const protocol = new BoltProtocolV1(new MessageRecorder(), null, false);
+
+    const transformedMetadata = protocol.transformMetadata(metadata);
+
+    expect(transformedMetadata).toEqual({result_available_after: 1, result_consumed_after: 2, t_first: 3, t_last: 4});
+  });
+
   it('should initialize the connection', () => {
     const recorder = new MessageRecorder();
     const protocol = new BoltProtocolV1(recorder, null, false);

--- a/test/internal/bolt-protocol-v1.test.js
+++ b/test/internal/bolt-protocol-v1.test.js
@@ -20,6 +20,7 @@
 import BoltProtocolV1 from '../../src/v1/internal/bolt-protocol-v1';
 import RequestMessage from '../../src/v1/internal/request-message';
 import Bookmark from '../../src/v1/internal/bookmark';
+import TxConfig from '../../src/v1/internal/tx-config';
 
 class MessageRecorder {
 
@@ -77,7 +78,7 @@ describe('BoltProtocolV1', () => {
     const parameters = {x: 'x', y: 'y'};
     const observer = {};
 
-    protocol.run(statement, parameters, observer);
+    protocol.run(statement, parameters, Bookmark.empty(), TxConfig.empty(), observer);
 
     recorder.verifyMessageCount(2);
 
@@ -109,7 +110,7 @@ describe('BoltProtocolV1', () => {
     const bookmark = new Bookmark('neo4j:bookmark:v1:tx42');
     const observer = {};
 
-    protocol.beginTransaction(bookmark, observer);
+    protocol.beginTransaction(bookmark, TxConfig.empty(), observer);
 
     recorder.verifyMessageCount(2);
 

--- a/test/internal/bolt-protocol-v3.test.js
+++ b/test/internal/bolt-protocol-v3.test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BoltProtocolV3 from '../../src/v1/internal/bolt-protocol-v3';
+
+describe('BoltProtocolV3', () => {
+
+  it('should update metadata', () => {
+    const metadata = {t_first: 1, t_last: 2, db_hits: 3, some_other_key: 4};
+    const protocol = new BoltProtocolV3(null, null, false);
+
+    const transformedMetadata = protocol.transformMetadata(metadata);
+
+    expect(transformedMetadata).toEqual({result_available_after: 1, result_consumed_after: 2, db_hits: 3, some_other_key: 4});
+  });
+
+});

--- a/test/internal/bookmark.test.js
+++ b/test/internal/bookmark.test.js
@@ -129,4 +129,10 @@ describe('Bookmark', () => {
     expect(new Bookmark(bookmarkStrings).values()).toEqual(bookmarkStrings);
   });
 
+  it('should expose empty bookmark value', () => {
+    const bookmark = Bookmark.empty();
+    expect(bookmark).toBeDefined();
+    expect(bookmark.isEmpty()).toBeTruthy();
+  });
+
 });

--- a/test/internal/bookmark.test.js
+++ b/test/internal/bookmark.test.js
@@ -118,4 +118,15 @@ describe('Bookmark', () => {
     });
   });
 
+  it('should expose bookmark values', () => {
+    expect(new Bookmark(undefined).values()).toEqual([]);
+    expect(new Bookmark(null).values()).toEqual([]);
+
+    const bookmarkString = 'neo4j:bookmark:v1:tx123';
+    expect(new Bookmark(bookmarkString).values()).toEqual([bookmarkString]);
+
+    const bookmarkStrings = ['neo4j:bookmark:v1:tx1', 'neo4j:bookmark:v1:tx2', 'neo4j:bookmark:v1:tx3'];
+    expect(new Bookmark(bookmarkStrings).values()).toEqual(bookmarkStrings);
+  });
+
 });

--- a/test/internal/connection.test.js
+++ b/test/internal/connection.test.js
@@ -30,6 +30,8 @@ import Logger from '../../src/v1/internal/logger';
 import StreamObserver from '../../src/v1/internal/stream-observer';
 import ConnectionErrorHandler from '../../src/v1/internal/connection-error-handler';
 import testUtils from '../internal/test-utils';
+import Bookmark from '../../src/v1/internal/bookmark';
+import TxConfig from '../../src/v1/internal/tx-config';
 
 const ILLEGAL_MESSAGE = {signature: 42, fields: []};
 const SUCCESS_MESSAGE = {signature: 0x70, fields: [{}]};
@@ -96,7 +98,7 @@ describe('Connection', () => {
 
     connection.connect('mydriver/0.0.0', basicAuthToken())
       .then(() => {
-        connection.protocol().run('RETURN 1.0', {}, streamObserver);
+        connection.protocol().run('RETURN 1.0', {}, Bookmark.empty(), TxConfig.empty(), streamObserver);
       });
   });
 
@@ -219,7 +221,8 @@ describe('Connection', () => {
   });
 
   it('should not queue RUN observer when broken', done => {
-    testQueueingOfObserversWithBrokenConnection(connection => connection.protocol().run('RETURN 1', {}, {}), done);
+    testQueueingOfObserversWithBrokenConnection(connection =>
+      connection.protocol().run('RETURN 1', {}, Bookmark.empty(), TxConfig.empty(), {}), done);
   });
 
   it('should not queue RESET observer when broken', done => {

--- a/test/internal/protocol-handshaker.test.js
+++ b/test/internal/protocol-handshaker.test.js
@@ -37,11 +37,12 @@ describe('ProtocolHandshaker', () => {
     expect(writtenBuffers.length).toEqual(1);
 
     const boltMagicPreamble = '60 60 b0 17';
+    const protocolVersion3 = '00 00 00 03';
     const protocolVersion2 = '00 00 00 02';
     const protocolVersion1 = '00 00 00 01';
     const noProtocolVersion = '00 00 00 00';
 
-    expect(writtenBuffers[0].toHex()).toEqual(`${boltMagicPreamble} ${protocolVersion2} ${protocolVersion1} ${noProtocolVersion} ${noProtocolVersion} `);
+    expect(writtenBuffers[0].toHex()).toEqual(`${boltMagicPreamble} ${protocolVersion3} ${protocolVersion2} ${protocolVersion1} ${noProtocolVersion} `);
   });
 
   it('should create protocol with valid version', () => {

--- a/test/internal/stream-observer.test.js
+++ b/test/internal/stream-observer.test.js
@@ -158,6 +158,20 @@ describe('StreamObserver', () => {
     expect(errors).toEqual([error1]);
   });
 
+  it('should be able to handle a single response', done => {
+    const streamObserver = new StreamObserver();
+    streamObserver.prepareToHandleSingleResponse();
+
+    streamObserver.subscribe({
+      onCompleted: metadata => {
+        expect(metadata.key).toEqual(42);
+        done();
+      }
+    });
+
+    streamObserver.onCompleted({key: 42});
+  });
+
 });
 
 function newStreamObserver() {

--- a/test/internal/tx-config.test.js
+++ b/test/internal/tx-config.test.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import TxConfig from '../../src/v1/internal/tx-config';
+import {int} from '../../src/v1';
+
+describe('TxConfig', () => {
+
+  it('should be possible to construct from null', () => {
+    testEmptyConfigCreation(null);
+  });
+
+  it('should be possible to construct from undefined', () => {
+    testEmptyConfigCreation(undefined);
+  });
+
+  it('should be possible to construct from empty object', () => {
+    testEmptyConfigCreation({});
+  });
+
+  it('should fail to construct from array', () => {
+    expect(() => new TxConfig([])).toThrowError(TypeError);
+  });
+
+  it('should fail to construct from function', () => {
+    const func = () => {
+    };
+    expect(() => new TxConfig(func)).toThrowError(TypeError);
+  });
+
+  it('should expose empty config', () => {
+    const config = TxConfig.empty();
+    expect(config).toBeDefined();
+    expect(config.isEmpty()).toBeTruthy();
+  });
+
+  it('should fail to construct with invalid timeout', () => {
+    const invalidTimeoutValues = ['15s', [15], {}, 0, int(0), -42, int(-42)];
+
+    invalidTimeoutValues.forEach(invalidValue =>
+      expect(() => new TxConfig({timeout: invalidValue})).toThrow());
+  });
+
+  it('should construct with valid timeout', () => {
+    testConfigCreationWithTimeout(1);
+    testConfigCreationWithTimeout(42000);
+
+    testConfigCreationWithTimeout(int(1));
+    testConfigCreationWithTimeout(int(424242));
+  });
+
+  it('should fail to construct with invalid metadata', () => {
+    const invalidMetadataValues = ['hello', [1, 2, 3], () => 'Hello', 42];
+
+    invalidMetadataValues.forEach(invalidValue =>
+      expect(() => new TxConfig({metadata: invalidValue})).toThrow());
+  });
+
+  it('should construct with valid metadata', () => {
+    testEmptyConfigCreation({metadata: {}});
+
+    testConfigCreationWithMetadata({key: 'value'});
+    testConfigCreationWithMetadata({map: {key1: 1, key2: '2', key3: []}, array: [1, 2, 3, '4']});
+  });
+
+  function testEmptyConfigCreation(value) {
+    const config = new TxConfig(value);
+    expect(config).toBeDefined();
+    expect(config.isEmpty()).toBeTruthy();
+  }
+
+  function testConfigCreationWithTimeout(value) {
+    const config = new TxConfig({timeout: value});
+    expect(config).toBeDefined();
+    expect(config.isEmpty()).toBeFalsy();
+    expect(config.timeout).toEqual(int(value));
+  }
+
+  function testConfigCreationWithMetadata(value) {
+    const config = new TxConfig({metadata: value});
+    expect(config).toBeDefined();
+    expect(config.isEmpty()).toBeFalsy();
+    expect(config.metadata).toEqual(value);
+  }
+
+});

--- a/test/internal/util.test.js
+++ b/test/internal/util.test.js
@@ -152,6 +152,26 @@ describe('util', () => {
     verifyInvalidDate(2019);
   });
 
+  it('should check objects', () => {
+    expect(util.isObject(42)).toBeFalsy();
+    expect(util.isObject([])).toBeFalsy();
+    expect(util.isObject(() => 'Hello')).toBeFalsy();
+    expect(util.isObject('string')).toBeFalsy();
+
+    expect(util.isObject({})).toBeTruthy();
+    expect(util.isObject({key1: 1, key2: '2'})).toBeTruthy();
+  });
+
+  it('should assert on objects', () => {
+    expect(() => util.assertObject(42, '')).toThrowError(TypeError);
+    expect(() => util.assertObject([], '')).toThrowError(TypeError);
+    expect(() => util.assertObject(() => 'Hello', '')).toThrowError(TypeError);
+    expect(() => util.assertObject('string', '')).toThrowError(TypeError);
+
+    expect(() => util.assertObject({}, '')).not.toThrow();
+    expect(() => util.assertObject({key1: 1, key2: '2'}, '')).not.toThrow();
+  });
+
   function verifyValidString(str) {
     expect(util.assertString(str, 'Test string')).toBe(str);
   }

--- a/test/types/v1/session.test.ts
+++ b/test/types/v1/session.test.ts
@@ -17,17 +17,27 @@
  * limitations under the License.
  */
 
-import Session from "../../../types/v1/session";
+import Session, {TransactionConfig} from "../../../types/v1/session";
 import Transaction from "../../../types/v1/transaction";
 import Record from "../../../types/v1/record";
 import Result, {StatementResult} from "../../../types/v1/result";
 import ResultSummary from "../../../types/v1/result-summary";
+import Integer from "../../../types/v1/integer";
 
 const dummy: any = null;
+const intValue: Integer = Integer.fromInt(42);
 
 const session: Session = dummy;
 
-const tx: Transaction = session.beginTransaction();
+const txConfig1: TransactionConfig = {};
+const txConfig2: TransactionConfig = {timeout: 5000};
+const txConfig3: TransactionConfig = {timeout: intValue};
+const txConfig4: TransactionConfig = {metadata: {}};
+const txConfig5: TransactionConfig = {metadata: {key1: 'value1', key2: 5, key3: {a: 'a', b: 'b'}, key4: [1, 2, 3]}};
+const txConfig6: TransactionConfig = {timeout: 2000, metadata: {key1: 'value1', key2: 2}};
+const txConfig7: TransactionConfig = {timeout: intValue, metadata: {key1: 'value1', key2: 2}};
+
+const tx1: Transaction = session.beginTransaction();
 const bookmark: null | string = <null>session.lastBookmark();
 
 const promise1: Promise<number> = session.readTransaction((tx: Transaction) => {
@@ -101,7 +111,7 @@ result4.subscribe({
   onCompleted: (summary: ResultSummary) => console.log(summary)
 });
 
-const result5: Result = session.run({text: "RETURN 1"});
+const result5: Result = session.run("RETURN $value", {value: "42"}, txConfig1);
 result5.then((res: StatementResult) => {
   const records: Record[] = res.records;
   const summary: ResultSummary = res.summary;
@@ -111,7 +121,7 @@ result5.then((res: StatementResult) => {
   console.log(error);
 });
 
-const result6: Result = session.run({text: "RETURN 1"});
+const result6: Result = session.run("RETURN $value", {value: "42"}, txConfig2);
 result6.subscribe({});
 result6.subscribe({
   onNext: (record: Record) => console.log(record)
@@ -126,27 +136,6 @@ result6.subscribe({
   onCompleted: (summary: ResultSummary) => console.log(summary)
 });
 
-const result7: Result = session.run({text: "RETURN $value", parameters: {value: 42}});
-result7.then((res: StatementResult) => {
-  const records: Record[] = res.records;
-  const summary: ResultSummary = res.summary;
-  console.log(records);
-  console.log(summary);
-}).catch((error: Error) => {
-  console.log(error);
-});
-
-const result8: Result = session.run({text: "RETURN $value", parameters: {value: 42}});
-result8.subscribe({});
-result8.subscribe({
-  onNext: (record: Record) => console.log(record)
-});
-result8.subscribe({
-  onNext: (record: Record) => console.log(record),
-  onError: (error: Error) => console.log(error)
-});
-result8.subscribe({
-  onNext: (record: Record) => console.log(record),
-  onError: (error: Error) => console.log(error),
-  onCompleted: (summary: ResultSummary) => console.log(summary)
-});
+const tx2: Transaction = session.beginTransaction(txConfig2);
+const promise5: Promise<string> = session.readTransaction((tx: Transaction) => "", txConfig3);
+const promise6: Promise<number> = session.writeTransaction((tx: Transaction) => 42, txConfig4);

--- a/test/types/v1/transaction.test.ts
+++ b/test/types/v1/transaction.test.ts
@@ -79,56 +79,6 @@ result4.subscribe({
   onCompleted: (summary: ResultSummary) => console.log(summary)
 });
 
-const result5: Result = tx.run({text: "RETURN 1"});
-result5.then((res: StatementResult) => {
-  const records: Record[] = res.records;
-  const summary: ResultSummary = res.summary;
-  console.log(records);
-  console.log(summary);
-}).catch((error: Error) => {
-  console.log(error);
-});
-
-const result6: Result = tx.run({text: "RETURN 1"});
-result6.subscribe({});
-result6.subscribe({
-  onNext: (record: Record) => console.log(record)
-});
-result6.subscribe({
-  onNext: (record: Record) => console.log(record),
-  onError: (error: Error) => console.log(error)
-});
-result6.subscribe({
-  onNext: (record: Record) => console.log(record),
-  onError: (error: Error) => console.log(error),
-  onCompleted: (summary: ResultSummary) => console.log(summary)
-});
-
-const result7: Result = tx.run({text: "RETURN $value", parameters: {value: 42}});
-result7.then((res: StatementResult) => {
-  const records: Record[] = res.records;
-  const summary: ResultSummary = res.summary;
-  console.log(records);
-  console.log(summary);
-}).catch((error: Error) => {
-  console.log(error);
-});
-
-const result8: Result = tx.run({text: "RETURN $value", parameters: {value: 42}});
-result8.subscribe({});
-result8.subscribe({
-  onNext: (record: Record) => console.log(record)
-});
-result8.subscribe({
-  onNext: (record: Record) => console.log(record),
-  onError: (error: Error) => console.log(error)
-});
-result8.subscribe({
-  onNext: (record: Record) => console.log(record),
-  onError: (error: Error) => console.log(error),
-  onCompleted: (summary: ResultSummary) => console.log(summary)
-});
-
 tx.commit().then((res: StatementResult) => {
   console.log(res);
 }).catch((error: Error) => {

--- a/test/v1/bolt-v3.test.js
+++ b/test/v1/bolt-v3.test.js
@@ -1,0 +1,358 @@
+/**
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import neo4j from '../../src/v1';
+import sharedNeo4j from '../internal/shared-neo4j';
+import {ServerVersion, VERSION_3_5_0} from '../../src/v1/internal/server-version';
+
+const TX_CONFIG_WITH_METADATA = {metadata: {a: 1, b: 2}};
+const TX_CONFIG_WITH_TIMEOUT = {timeout: 42};
+
+const INVALID_TIMEOUT_VALUES = [0, -1, -42, '15 seconds', [1, 2, 3]];
+const INVALID_METADATA_VALUES = ['metadata', ['1', '2', '3'], () => 'hello world'];
+
+describe('Bolt V3 API', () => {
+
+  let driver;
+  let session;
+  let serverVersion;
+  let originalTimeout;
+
+  beforeEach(done => {
+    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken);
+    session = driver.session();
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+
+    session.run('MATCH (n) DETACH DELETE n').then(result => {
+      serverVersion = ServerVersion.fromString(result.summary.server.version);
+      done();
+    });
+  });
+
+  afterEach(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+    session.close();
+    driver.close();
+  });
+
+  it('should set transaction metadata for auto-commit transaction', done => {
+    if (!databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    const metadata = {
+      a: 'hello world',
+      b: 424242,
+      c: [true, false, true]
+    };
+
+    // call listTransactions procedure that should list itself with the specified metadata
+    session.run('CALL dbms.listTransactions()', {}, {metadata: metadata})
+      .then(result => {
+        const receivedMetadata = result.records[0].get('metaData');
+        expect(receivedMetadata).toEqual(metadata);
+        done();
+      })
+      .catch(error => {
+        done.fail(error);
+      });
+  });
+
+  it('should set transaction timeout for auto-commit transaction', done => {
+    if (!databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    session.run('CREATE (:Node)') // create a dummy node
+      .then(() => {
+        const otherSession = driver.session();
+        const tx = otherSession.beginTransaction();
+        tx.run('MATCH (n:Node) SET n.prop = 1') // lock dummy node but keep the transaction open
+          .then(() => {
+            // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
+            session.run('MATCH (n:Node) SET n.prop = $newValue', {newValue: 2}, {timeout: 1})
+              .then(() => done.fail('Failure expected'))
+              .catch(error => {
+                expect(error.code.indexOf('TransientError')).toBeGreaterThan(0);
+                expect(error.message.indexOf('transaction has been terminated')).toBeGreaterThan(0);
+
+                tx.rollback()
+                  .then(() => otherSession.close())
+                  .then(() => done())
+                  .catch(error => done.fail(error));
+              });
+          });
+      });
+  });
+
+  it('should set transaction metadata with read transaction function', done => {
+    testTransactionMetadataWithTransactionFunctions(true, done);
+  });
+
+  it('should set transaction metadata with write transaction function', done => {
+    testTransactionMetadataWithTransactionFunctions(false, done);
+  });
+
+  it('should fail auto-commit transaction with metadata when database does not support Bolt V3', done => {
+    testAutoCommitTransactionConfigWhenBoltV3NotSupported(TX_CONFIG_WITH_METADATA, done);
+  });
+
+  it('should fail auto-commit transaction with timeout when database does not support Bolt V3', done => {
+    testAutoCommitTransactionConfigWhenBoltV3NotSupported(TX_CONFIG_WITH_TIMEOUT, done);
+  });
+
+  it('should fail read transaction function with metadata when database does not support Bolt V3', done => {
+    testTransactionFunctionConfigWhenBoltV3NotSupported(true, TX_CONFIG_WITH_METADATA, done);
+  });
+
+  it('should fail read transaction function with timeout when database does not support Bolt V3', done => {
+    testTransactionFunctionConfigWhenBoltV3NotSupported(true, TX_CONFIG_WITH_TIMEOUT, done);
+  });
+
+  it('should fail write transaction function with metadata when database does not support Bolt V3', done => {
+    testTransactionFunctionConfigWhenBoltV3NotSupported(false, TX_CONFIG_WITH_METADATA, done);
+  });
+
+  it('should fail write transaction function with timeout when database does not support Bolt V3', done => {
+    testTransactionFunctionConfigWhenBoltV3NotSupported(false, TX_CONFIG_WITH_TIMEOUT, done);
+  });
+
+  it('should set transaction metadata for explicit transactions', done => {
+    if (!databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    const metadata = {
+      a: 12345,
+      b: 'string',
+      c: [1, 2, 3]
+    };
+
+    const tx = session.beginTransaction({metadata: metadata});
+    // call listTransactions procedure that should list itself with the specified metadata
+    tx.run('CALL dbms.listTransactions()')
+      .then(result => {
+        const receivedMetadata = result.records[0].get('metaData');
+        expect(receivedMetadata).toEqual(metadata);
+        tx.commit()
+          .then(() => done())
+          .catch(error => done.fail(error));
+      })
+      .catch(error => {
+        done.fail(error);
+      });
+  });
+
+  it('should set transaction timeout for explicit transactions', done => {
+    if (!databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    session.run('CREATE (:Node)') // create a dummy node
+      .then(() => {
+        const otherSession = driver.session();
+        const otherTx = otherSession.beginTransaction();
+        otherTx.run('MATCH (n:Node) SET n.prop = 1') // lock dummy node but keep the transaction open
+          .then(() => {
+            // run a query in an explicit transaction with timeout and try to update the locked dummy node
+            const tx = session.beginTransaction({timeout: 1});
+            tx.run('MATCH (n:Node) SET n.prop = $newValue', {newValue: 2})
+              .then(() => done.fail('Failure expected'))
+              .catch(error => {
+                expect(error.code.indexOf('TransientError')).toBeGreaterThan(0);
+                expect(error.message.indexOf('transaction has been terminated')).toBeGreaterThan(0);
+
+                otherTx.rollback()
+                  .then(() => otherSession.close())
+                  .then(() => done())
+                  .catch(error => done.fail(error));
+              });
+          });
+      });
+  });
+
+  it('should fail to run in explicit transaction with metadata when database does not support Bolt V3', done => {
+    testRunInExplicitTransactionWithConfigWhenBoltV3NotSupported(TX_CONFIG_WITH_METADATA, done);
+  });
+
+  it('should fail to run in explicit transaction with timeout when database does not support Bolt V3', done => {
+    testRunInExplicitTransactionWithConfigWhenBoltV3NotSupported(TX_CONFIG_WITH_TIMEOUT, done);
+  });
+
+  it('should fail to commit explicit transaction with metadata when database does not support Bolt V3', done => {
+    testCloseExplicitTransactionWithConfigWhenBoltV3NotSupported(true, TX_CONFIG_WITH_METADATA, done);
+  });
+
+  it('should fail to commit explicit transaction with timeout when database does not support Bolt V3', done => {
+    testCloseExplicitTransactionWithConfigWhenBoltV3NotSupported(true, TX_CONFIG_WITH_TIMEOUT, done);
+  });
+
+  it('should fail to rollback explicit transaction with metadata when database does not support Bolt V3', done => {
+    testCloseExplicitTransactionWithConfigWhenBoltV3NotSupported(false, TX_CONFIG_WITH_METADATA, done);
+  });
+
+  it('should fail to rollback explicit transaction with timeout when database does not support Bolt V3', done => {
+    testCloseExplicitTransactionWithConfigWhenBoltV3NotSupported(false, TX_CONFIG_WITH_TIMEOUT, done);
+  });
+
+  it('should fail to run auto-commit transaction with invalid timeout', () => {
+    INVALID_TIMEOUT_VALUES.forEach(invalidValue =>
+      expect(() => session.run('RETURN $x', {x: 42}, {timeout: invalidValue})).toThrow());
+  });
+
+  it('should fail to run auto-commit transaction with invalid metadata', () => {
+    INVALID_METADATA_VALUES.forEach(invalidValue =>
+      expect(() => session.run('RETURN $x', {x: 42}, {metadata: invalidValue})).toThrow());
+  });
+
+  it('should fail to begin explicit transaction with invalid timeout', () => {
+    INVALID_TIMEOUT_VALUES.forEach(invalidValue =>
+      expect(() => session.beginTransaction({timeout: invalidValue})).toThrow());
+  });
+
+  it('should fail to begin explicit transaction with invalid metadata', () => {
+    INVALID_METADATA_VALUES.forEach(invalidValue =>
+      expect(() => session.beginTransaction({metadata: invalidValue})).toThrow());
+  });
+
+  it('should fail to run read transaction function with invalid timeout', () => {
+    INVALID_TIMEOUT_VALUES.forEach(invalidValue =>
+      expect(() => session.readTransaction(tx => tx.run('RETURN 1'), {timeout: invalidValue})).toThrow());
+  });
+
+  it('should fail to run read transaction function with invalid metadata', () => {
+    INVALID_METADATA_VALUES.forEach(invalidValue =>
+      expect(() => session.readTransaction(tx => tx.run('RETURN 1'), {metadata: invalidValue})).toThrow());
+  });
+
+  it('should fail to run write transaction function with invalid timeout', () => {
+    INVALID_TIMEOUT_VALUES.forEach(invalidValue =>
+      expect(() => session.writeTransaction(tx => tx.run('RETURN 1'), {timeout: invalidValue})).toThrow());
+  });
+
+  it('should fail to run write transaction function with invalid metadata', () => {
+    INVALID_METADATA_VALUES.forEach(invalidValue =>
+      expect(() => session.writeTransaction(tx => tx.run('RETURN 1'), {metadata: invalidValue})).toThrow());
+  });
+
+  function testTransactionMetadataWithTransactionFunctions(read, done) {
+    if (!databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    const metadata = {
+      foo: 'bar',
+      baz: 42
+    };
+
+    const txFunctionWithMetadata = work => read
+      ? session.readTransaction(work, {metadata: metadata})
+      : session.writeTransaction(work, {metadata: metadata});
+
+    txFunctionWithMetadata(tx => tx.run('CALL dbms.listTransactions()'))
+      .then(result => {
+        const receivedMetadata = result.records[0].get('metaData');
+        expect(receivedMetadata).toEqual(metadata);
+        done();
+      })
+      .catch(error => {
+        done.fail(error);
+      });
+  }
+
+  function testAutoCommitTransactionConfigWhenBoltV3NotSupported(txConfig, done) {
+    if (databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    session.run('RETURN $x', {x: 42}, txConfig)
+      .then(() => done.fail('Failure expected'))
+      .catch(error => {
+        expectBoltV3NotSupportedError(error);
+        done();
+      });
+  }
+
+  function testTransactionFunctionConfigWhenBoltV3NotSupported(read, txConfig, done) {
+    if (databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    const txFunctionWithMetadata = work => read
+      ? session.readTransaction(work, txConfig)
+      : session.writeTransaction(work, txConfig);
+
+    txFunctionWithMetadata(tx => tx.run('RETURN 42'))
+      .then(() => done.fail('Failure expected'))
+      .catch(error => {
+        expectBoltV3NotSupportedError(error);
+        done();
+      });
+  }
+
+  function testRunInExplicitTransactionWithConfigWhenBoltV3NotSupported(txConfig, done) {
+    if (databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    const tx = session.beginTransaction(txConfig);
+    tx.run('RETURN 42')
+      .then(() => done.fail('Failure expected'))
+      .catch(error => {
+        expectBoltV3NotSupportedError(error);
+        session.close();
+        done();
+      });
+  }
+
+  function testCloseExplicitTransactionWithConfigWhenBoltV3NotSupported(commit, txConfig, done) {
+    if (databaseSupportsBoltV3()) {
+      done();
+      return;
+    }
+
+    const tx = session.beginTransaction(txConfig);
+    const promise = commit ? tx.commit() : tx.rollback();
+
+    promise.then(() => done.fail('Failure expected'))
+      .catch(error => {
+        expectBoltV3NotSupportedError(error);
+        session.close();
+        done();
+      });
+  }
+
+  function expectBoltV3NotSupportedError(error) {
+    expect(error.message.indexOf('Driver is connected to the database that does not support transaction configuration')).toBeGreaterThan(-1);
+  }
+
+  function databaseSupportsBoltV3() {
+    return serverVersion.compareTo(VERSION_3_5_0) >= 0;
+  }
+
+});

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -439,10 +439,10 @@ describe('session', () => {
   });
 
   it('should fail nicely for illegal bookmark', () => {
-    expect(() => session.beginTransaction({})).toThrowError(TypeError);
-    expect(() => session.beginTransaction({foo: 'bar'})).toThrowError(TypeError);
+    expect(() => session.beginTransaction(42)).toThrowError(TypeError);
     expect(() => session.beginTransaction(42)).toThrowError(TypeError);
     expect(() => session.beginTransaction([42.0, 42.0])).toThrowError(TypeError);
+    expect(() => session.beginTransaction(() => ['bookmark:1', 'bookmark:2', 'bookmark:3'])).toThrowError(TypeError);
   });
 
   it('should allow creation of a ' + neo4j.session.READ + ' session', done => {

--- a/types/v1/session.d.ts
+++ b/types/v1/session.d.ts
@@ -18,20 +18,33 @@
  */
 
 import Transaction from "./transaction";
-import StatementRunner from "./statement-runner";
+import StatementRunner, {Parameters} from "./statement-runner";
+import Result from "./result";
+import {NumberOrInteger} from "./graph-types";
 
 declare type TransactionWork<T> = (tx: Transaction) => T | Promise<T>;
 
+declare interface TransactionConfig {
+  timeout?: NumberOrInteger;
+  metadata?: object;
+}
+
 declare interface Session extends StatementRunner {
-  beginTransaction(): Transaction;
+  run(statement: string, parameters?: Parameters, config?: TransactionConfig): Result;
+
+  beginTransaction(config?: TransactionConfig): Transaction;
 
   lastBookmark(): string | null;
 
-  readTransaction<T>(work: TransactionWork<T>): Promise<T>;
+  readTransaction<T>(work: TransactionWork<T>, config?: TransactionConfig): Promise<T>;
 
-  writeTransaction<T>(work: TransactionWork<T>): Promise<T>;
+  writeTransaction<T>(work: TransactionWork<T>, config?: TransactionConfig): Promise<T>;
 
   close(callback?: () => void): void;
+}
+
+export {
+  TransactionConfig
 }
 
 export default Session;

--- a/types/v1/statement-runner.d.ts
+++ b/types/v1/statement-runner.d.ts
@@ -23,8 +23,6 @@ declare type Parameters = { [key: string]: any };
 
 declare interface StatementRunner {
   run(statement: string, parameters?: Parameters): Result;
-
-  run(statement: { text: string, parameters?: Parameters }): Result;
 }
 
 export {Parameters}


### PR DESCRIPTION
Bolt V3 allows additional metadata to be attached to BEGIN and RUN messages. This makes it possible to expose a couple new features in the API.

Auto-commit transactions executed via `Session#run()` now support bookmarks. In previous protocol versions, there was no good place in the RUN message to attach bookmarks. Auto-commit transactions will now use bookmarks given in `Driver#session(bookmarkOrBookmarks)` function and participate in causal chaining within a session.

Transactions functions, auto-commit, and explicit transactions now accept a configuration object with transaction timeout and metadata. Example of a configuration object:

```javascript
{
    timeout: 3000, // 3 seconds
    metadata: {key1: 42, key2: '42'}
}
```

where timeout is specified in milliseconds and metadata is an object containing valid Cypher types.

Transactions that execute longer than the configured timeout will be terminated by the database. This functionality allows limiting query/transaction execution time. Specified timeout overrides the default timeout configured in the database using `dbms.transaction.timeout` setting. Examples:

Specified transaction metadata will be attached to the executing transaction and visible in the output of `dbms.listQueries` and `dbms.listTransactions` procedures. It will also get logged to the `query.log`. This functionality makes it easier to tag transactions and is equivalent to `dbms.setTXMetaData` procedure.

Examples:

```javascript
var driver = neo4j.driver(...);
var session = driver.session();

var txConfig = {
  timeout: 5000, // 5 seconds
  metadata: {
    type: 'My Query',
    application: 'My App #1',
    sequence_number: 42
  }
};

// transaction configuration for auto-commit transaction
session.run('RETURN $x', {x: 42}, txConfig)
       .then(...)
       .catch(...)

// transaction configuration for explicit transaction
var tx = session.beginTransaction(txConfig);
tx.run(...);

// transaction configuration for read transaction function
session.readTransaction(tx => tx.run('RETURN $x', {x: 42}), txConfig)
       .then(...)
       .catch(...)

// transaction configuration for write transaction function
session.writeTransaction(tx => tx.run('RETURN $x', {x: 42}), txConfig)
       .then(...)
       .catch(...)
```