### PR TITLE
Remove deprecation from Integer class

### DIFF
--- a/src/v1/integer.js
+++ b/src/v1/integer.js
@@ -35,8 +35,6 @@ import {newError} from './error';
  * @param {number} low The low (signed) 32 bits of the long
  * @param {number} high The high (signed) 32 bits of the long
  * @constructor
- *
- * @deprecated This class will be removed or made internal in a future version of the driver.
  */
 class Integer {
   constructor(low, high) {


### PR DESCRIPTION
Driver still does not export `Integer` type from the top module. Users are expected to use functions defined in `neo4j.integer` to convert to and from `Integer` objects. Class remains in JSDoc but will not have a "this class was deprecated" header.