### PR TITLE
Keep bookmark returned after auto-commit tx

### DIFF
--- a/src/v1/session.js
+++ b/src/v1/session.js
@@ -89,7 +89,7 @@ class Session {
   }
 
   _run(statement, parameters, statementRunner) {
-    const streamObserver = new StreamObserver();
+    const streamObserver = new SessionStreamObserver(this);
     const connectionHolder = this._connectionHolderWithMode(this._mode);
     if (!this._hasTx) {
       connectionHolder.initializeConnection();
@@ -209,7 +209,6 @@ class Session {
   /**
    * Update value of the last bookmark.
    * @param {Bookmark} newBookmark the new bookmark.
-   * @private
    */
   _updateBookmark(newBookmark) {
     if (newBookmark && !newBookmark.isEmpty()) {
@@ -244,6 +243,23 @@ class Session {
     } else {
       throw newError('Unknown access mode: ' + mode);
     }
+  }
+}
+
+/**
+ * @private
+ */
+class SessionStreamObserver extends StreamObserver {
+
+  constructor(session) {
+    super();
+    this._session = session;
+  }
+
+  onCompleted(meta) {
+    super.onCompleted(meta);
+    const bookmark = new Bookmark(meta.bookmark);
+    this._session._updateBookmark(bookmark);
   }
 }
 

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -583,7 +583,9 @@ describe('session', () => {
       return;
     }
 
-    const bookmarkBefore = session.lastBookmark();
+    // new session without initial bookmark
+    session = driver.session();
+    expect(session.lastBookmark()).toBeNull();
 
     const tx = session.beginTransaction();
     tx.run('RETURN 42 as answer').then(result => {
@@ -592,11 +594,7 @@ describe('session', () => {
       expect(records[0].get('answer').toNumber()).toEqual(42);
 
       tx.commit().then(() => {
-        const bookmarkAfter = session.lastBookmark();
-        expect(bookmarkAfter).toBeDefined();
-        expect(bookmarkAfter).not.toBeNull();
-        expect(bookmarkAfter).not.toEqual(bookmarkBefore);
-
+        verifyBookmark(session.lastBookmark());
         done();
       });
     });
@@ -631,12 +629,10 @@ describe('session', () => {
     tx.run('CREATE ()').then(() => {
       tx.commit().then(() => {
         const bookmarkBefore = session.lastBookmark();
-        expect(bookmarkBefore).toBeDefined();
-        expect(bookmarkBefore).not.toBeNull();
+        verifyBookmark(bookmarkBefore);
 
         session.run('CREATE ()').then(() => {
-          const bookmarkAfter = session.lastBookmark();
-          expect(bookmarkAfter).toEqual(bookmarkBefore);
+          verifyBookmark(session.lastBookmark());
           done();
         });
       });
@@ -648,17 +644,16 @@ describe('session', () => {
       return;
     }
 
-    const bookmarkBefore = session.lastBookmark();
+    // new session without initial bookmark
+    session = driver.session();
+    expect(session.lastBookmark()).toBeNull();
+
     const resultPromise = session.readTransaction(tx => tx.run('RETURN 42 AS answer'));
 
     resultPromise.then(result => {
       expect(result.records.length).toEqual(1);
       expect(result.records[0].get('answer').toNumber()).toEqual(42);
-
-      const bookmarkAfter = session.lastBookmark();
-      verifyBookmark(bookmarkAfter);
-      expect(bookmarkAfter).not.toEqual(bookmarkBefore);
-
+      verifyBookmark(session.lastBookmark());
       done();
     });
   });

--- a/test/v1/transaction.test.js
+++ b/test/v1/transaction.test.js
@@ -233,8 +233,11 @@ describe('transaction', () => {
       return;
     }
 
-    const tx = session.beginTransaction();
+    // new session without initial bookmark
+    session = driver.session();
     expect(session.lastBookmark()).toBeNull();
+
+    const tx = session.beginTransaction();
     tx.run("CREATE (:TXNode1)").then(() => {
       tx.run("CREATE (:TXNode2)").then(() => {
         tx.commit().then(() => {
@@ -250,9 +253,11 @@ describe('transaction', () => {
       return;
     }
 
+    // new session without initial bookmark
+    session = driver.session();
     expect(session.lastBookmark()).toBeNull();
-    const tx1 = session.beginTransaction();
 
+    const tx1 = session.beginTransaction();
     tx1.run('CREATE ()').then(() => {
       tx1.commit().then(() => {
         expectValidLastBookmark(session);
@@ -283,7 +288,10 @@ describe('transaction', () => {
       return;
     }
 
+    // new session without initial bookmark
+    session = driver.session();
     expect(session.lastBookmark()).toBeNull();
+
     const tx1 = session.beginTransaction();
 
     tx1.run('CREATE ()').then(() => {


### PR DESCRIPTION
Auto-commit transactions return bookmarks in Bolt V3. They were previously unused. This PR makes driver extract such bookmarks and expose them via Session#lastBookmark(). It then possible for explicit and auto-commit transactions within the same session to be chained with bookmarks.