### PR TITLE
Configurable server address resolver

### DIFF
--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -202,6 +202,20 @@ const logging = {
  *         level: 'info',
  *         logger: (level, message) => console.log(level + ' ' + message)
  *       },
+ *
+ *       // Specify a custom server address resolver function used by the routing driver to resolve the initial address used to create the driver.
+ *       // Such resolution happens:
+ *       //  * during the very first rediscovery when driver is created
+ *       //  * when all the known routers from the current routing table have failed and driver needs to fallback to the initial address
+ *       //
+ *       // In NodeJS environment driver defaults to performing a DNS resolution of the initial address using 'dns' module.
+ *       // In browser environment driver uses the initial address as-is.
+ *       // Value should be a function that takes a single string argument - the initial address. It should return an array of new addresses.
+ *       // Address is a string of shape '<host>:<port>'. Provided function can return either a Promise resolved with an array of addresses
+ *       // or array of addresses directly.
+ *       resolver: function(address) {
+ *         return ['127.0.0.1:8888', 'fallback.db.com:7687'];
+ *       },
  *     }
  *
  * @param {string} url The URL for the Neo4j database, for instance "bolt://localhost"

--- a/src/v1/internal/host-name-resolvers.js
+++ b/src/v1/internal/host-name-resolvers.js
@@ -33,6 +33,25 @@ export class DummyHostNameResolver extends HostNameResolver {
   }
 }
 
+export class ConfiguredHostNameResolver extends HostNameResolver {
+
+  constructor(resolverFunction) {
+    super();
+    this._resolverFunction = resolverFunction;
+  }
+
+  resolve(seedRouter) {
+    return new Promise(resolve => resolve(this._resolverFunction(seedRouter)))
+      .then(resolved => {
+        if (!Array.isArray(resolved)) {
+          throw new TypeError(`Configured resolver function should either return an array of addresses or a Promise resolved with an array of addresses.` +
+            `Each address is '<host>:<port>'. Got: ${resolved}`);
+        }
+        return resolved;
+      });
+  }
+}
+
 export class DnsHostNameResolver extends HostNameResolver {
 
   constructor() {

--- a/test/internal/bolt-stub.js
+++ b/test/internal/bolt-stub.js
@@ -111,12 +111,10 @@ class StubServer {
   }
 }
 
-function newDriver(url) {
+function newDriver(url, config = {}) {
   // boltstub currently does not support encryption, create driver with encryption turned off
-  const config = {
-    encrypted: 'ENCRYPTION_OFF'
-  };
-  return neo4j.driver(url, sharedNeo4j.authToken, config);
+  const newConfig = Object.assign({encrypted: 'ENCRYPTION_OFF'}, config);
+  return neo4j.driver(url, sharedNeo4j.authToken, newConfig);
 }
 
 const supportedStub = SupportedBoltStub.create();

--- a/test/internal/connection-providers.test.js
+++ b/test/internal/connection-providers.test.js
@@ -25,6 +25,7 @@ import {DirectConnectionProvider, LoadBalancer} from '../../src/v1/internal/conn
 import Pool from '../../src/v1/internal/pool';
 import LeastConnectedLoadBalancingStrategy from '../../src/v1/internal/least-connected-load-balancing-strategy';
 import Logger from '../../src/v1/internal/logger';
+import {DummyHostNameResolver} from '../../src/v1/internal/host-name-resolvers';
 
 const NO_OP_DRIVER_CALLBACK = () => {
 };
@@ -138,7 +139,8 @@ describe('LoadBalancer', () => {
   it('initializes routing table with the given router', () => {
     const connectionPool = newPool();
     const loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy(connectionPool);
-    const loadBalancer = new LoadBalancer('server-ABC', {}, connectionPool, loadBalancingStrategy, NO_OP_DRIVER_CALLBACK, Logger.noOp());
+    const loadBalancer = new LoadBalancer('server-ABC', {}, connectionPool, loadBalancingStrategy, new DummyHostNameResolver(),
+      NO_OP_DRIVER_CALLBACK, Logger.noOp());
 
     expectRoutingTable(loadBalancer,
       ['server-ABC'],
@@ -1074,7 +1076,8 @@ function newLoadBalancerWithSeedRouter(seedRouter, seedRouterResolved,
                                        connectionPool = null) {
   const pool = connectionPool || newPool();
   const loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy(pool);
-  const loadBalancer = new LoadBalancer(seedRouter, {}, pool, loadBalancingStrategy, NO_OP_DRIVER_CALLBACK, Logger.noOp());
+  const loadBalancer = new LoadBalancer(seedRouter, {}, pool, loadBalancingStrategy, new DummyHostNameResolver(),
+    NO_OP_DRIVER_CALLBACK, Logger.noOp());
   loadBalancer._routingTable = new RoutingTable(routers, readers, writers, expirationTime);
   loadBalancer._rediscovery = new FakeRediscovery(routerToRoutingTable);
   loadBalancer._hostNameResolver = new FakeDnsResolver(seedRouterResolved);

--- a/test/resources/boltstub/get_routing_table.script
+++ b/test/resources/boltstub/get_routing_table.script
@@ -15,3 +15,4 @@ S: SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]
    RECORD ["Eve"]
    SUCCESS {}
+S: <EXIT>

--- a/test/v1/routing-driver.test.js
+++ b/test/v1/routing-driver.test.js
@@ -21,6 +21,7 @@ import RoundRobinLoadBalancingStrategy from '../../src/v1/internal/round-robin-l
 import LeastConnectedLoadBalancingStrategy from '../../src/v1/internal/least-connected-load-balancing-strategy';
 import RoutingDriver from '../../src/v1/routing-driver';
 import Pool from '../../src/v1/internal/pool';
+import neo4j from '../../src/v1';
 
 describe('RoutingDriver', () => {
 
@@ -41,6 +42,12 @@ describe('RoutingDriver', () => {
 
   it('should fail when unknown strategy is configured', () => {
     expect(() => createStrategy({loadBalancingStrategy: 'wrong'})).toThrow();
+  });
+
+  it('should fail when configured resolver is of illegal type', () => {
+    expect(() => neo4j.driver('bolt+routing://localhost', {}, {resolver: 'string instead of a function'})).toThrowError(TypeError);
+    expect(() => neo4j.driver('bolt+routing://localhost', {}, {resolver: []})).toThrowError(TypeError);
+    expect(() => neo4j.driver('bolt+routing://localhost', {}, {resolver: {}})).toThrowError(TypeError);
   });
 
 });


### PR DESCRIPTION
This PR makes it possible to configure a resolver function used by the routing driver. Such function is used during the initial discovery and when all known routers have failed. Driver already had an internal facility like this which performed a DNS lookup in NodeJS environment for the hostname of the initial address. This remains the default. In browser environment no resolution is performed and address is used as-is. Users are now able to provide a custom resolver in the config.

Example:

```javascript
var auth = neo4j.auth.basic('neo4j', 'neo4j');
var config = {
  resolver: function(address) {
    return ['fallback1.db.com:8987', 'fallback2.db.org:7687'];
  }
};
var driver = neo4j.driver('bolt+routing://db.com', auth, config);
```