### PR TITLE
Allow rollback transaction after failure

### DIFF
--- a/src/v1/internal/stream-observer.js
+++ b/src/v1/internal/stream-observer.js
@@ -114,6 +114,14 @@ class StreamObserver {
   }
 
   /**
+   * Mark this observer as if it has completed with no metadata.
+   */
+  markCompleted() {
+    this._fieldKeys = [];
+    this._tail = {};
+  }
+
+  /**
    * Will be called on errors.
    * If user-provided observer is present, pass the error
    * to it's onError method, otherwise set instance variable _error.

--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -177,9 +177,7 @@ let _states = {
       return {result: _newDummyResult(observer, "COMMIT", {}), state: _states.FAILED};
     },
     rollback: (connectionHolder, observer) => {
-      observer.onError({error:
-      "Cannot rollback transaction, because previous statements in the " +
-      "transaction has failed and the transaction has already been rolled back."});
+      observer.markCompleted();
       return {result: _newDummyResult(observer, "ROLLBACK", {}), state: _states.FAILED};
     },
     run: (connectionHolder, observer, statement, parameters) => {

--- a/test/internal/stream-observer.test.js
+++ b/test/internal/stream-observer.test.js
@@ -172,6 +172,18 @@ describe('StreamObserver', () => {
     streamObserver.onCompleted({key: 42});
   });
 
+  it('should mark as completed', done => {
+    const streamObserver = new StreamObserver();
+    streamObserver.markCompleted();
+
+    streamObserver.subscribe({
+      onCompleted: metadata => {
+        expect(metadata).toEqual({});
+        done();
+      }
+    });
+  });
+
 });
 
 function newStreamObserver() {

--- a/test/v1/session.test.js
+++ b/test/v1/session.test.js
@@ -114,7 +114,7 @@ describe('session', () => {
     const session = driver.session();
     const tx = session.beginTransaction();
     tx.run('INVALID QUERY').catch(() => {
-      tx.rollback().catch(() => {
+      tx.rollback().then(() => {
         session.close(() => {
           driver.close();
           done();

--- a/test/v1/transaction.test.js
+++ b/test/v1/transaction.test.js
@@ -527,6 +527,19 @@ describe('transaction', () => {
     tx.rollback().then(() => done());
   });
 
+  it('should allow rollback after failure', done => {
+    const tx = session.beginTransaction();
+    tx.run('WRONG QUERY')
+      .then(() => done.fail('Expected to fail'))
+      .catch(error => {
+        expectSyntaxError(error);
+
+        tx.rollback()
+          .catch(error => done.fail(error))
+          .then(() => done());
+      });
+  });
+
   function expectSyntaxError(error) {
     expect(error.code).toBe('Neo.ClientError.Statement.SyntaxError');
   }


### PR DESCRIPTION
Previously, it was not possible to rollback transaction after failure. Doing this resulted in an error. This PR turns it into a no-op. Transaction is automatically rolled back after failure in the database because failure is acknowledged by sending a RESET message. So this is just a driver API level change.