### PR TITLE
Do not try to send GOODBYE message when connection is broken

### DIFF
--- a/src/v1/internal/connection.js
+++ b/src/v1/internal/connection.js
@@ -387,9 +387,9 @@ export default class Connection {
       this._log.debug(`${this} closing`);
     }
 
-    if (this._protocol) {
-      // protocol has been initialized
-      // use it to notify the database about the upcoming close of the connection
+    if (this._protocol && this.isOpen()) {
+      // protocol has been initialized and this connection is healthy
+      // notify the database about the upcoming close of the connection
       this._protocol.prepareToClose(NO_OP_OBSERVER);
     }
 

--- a/test/internal/connection.test.js
+++ b/test/internal/connection.test.js
@@ -367,6 +367,27 @@ describe('Connection', () => {
       }).catch(done.fail);
   });
 
+  it('should not prepare broken connection to close', done => {
+    connection = createConnection('bolt://localhost');
+
+    connection.connect('my-connection/9.9.9', basicAuthToken())
+      .then(() => {
+        expect(connection._protocol).toBeDefined();
+        expect(connection._protocol).not.toBeNull();
+
+        // make connection seem broken
+        connection._isBroken = true;
+        expect(connection.isOpen()).toBeFalsy();
+
+        connection._protocol.prepareToClose = () => {
+          throw new Error('Not supposed to be called');
+        };
+
+        connection.close(() => done());
+      })
+      .catch(error => done.fail(error));
+  });
+
   function packedHandshakeMessage() {
     const result = alloc(4);
     result.putInt32(0, 1);

--- a/test/internal/shared-neo4j.js
+++ b/test/internal/shared-neo4j.js
@@ -111,7 +111,10 @@ const additionalConfig = {
   'dbms.transaction.bookmark_ready_timeout': '5s',
 
   // enable GC logging
-  'dbms.logs.gc.enabled': true
+  'dbms.logs.gc.enabled': true,
+
+  // enable query logging
+  'dbms.logs.query.enabled': true
 };
 
 const neoCtrlVersionParam = '-e';

--- a/test/internal/shared-neo4j.js
+++ b/test/internal/shared-neo4j.js
@@ -108,7 +108,10 @@ const additionalConfig = {
   'dbms.connector.http.listen_address': 'localhost:7474',
 
   // shorten the default time to wait for the bookmark from 30 to 5 seconds
-  'dbms.transaction.bookmark_ready_timeout': '5s'
+  'dbms.transaction.bookmark_ready_timeout': '5s',
+
+  // enable GC logging
+  'dbms.logs.gc.enabled': true
 };
 
 const neoCtrlVersionParam = '-e';


### PR DESCRIPTION
To avoid unnecessary "write after end" errors when connection has been closed because of an error.