### PR TITLE
Fix TTL parsing when driver configured to use JS numbers

### DIFF
--- a/src/v1/internal/routing-util.js
+++ b/src/v1/internal/routing-util.js
@@ -61,7 +61,7 @@ export default class RoutingUtil {
   parseTtl(record, routerAddress) {
     try {
       const now = int(Date.now());
-      const expires = record.get('ttl').multiply(1000).add(now);
+      const expires = int(record.get('ttl')).multiply(1000).add(now);
       // if the server uses a really big expire time like Long.MAX_VALUE this may have overflowed
       if (expires.lessThan(now)) {
         return Integer.MAX_VALUE;
@@ -69,7 +69,7 @@ export default class RoutingUtil {
       return expires;
     } catch (error) {
       throw newError(
-        'Unable to parse TTL entry from router ' + routerAddress + ' from record:\n' + JSON.stringify(record),
+        `Unable to parse TTL entry from router ${routerAddress} from record:\n${JSON.stringify(record)}\nError message: ${error.message}`,
         PROTOCOL_ERROR);
     }
   }
@@ -102,9 +102,9 @@ export default class RoutingUtil {
         readers: readers,
         writers: writers
       }
-    } catch (ignore) {
+    } catch (error) {
       throw newError(
-        'Unable to parse servers entry from router ' + routerAddress + ' from record:\n' + JSON.stringify(record),
+        `Unable to parse servers entry from router ${routerAddress} from record:\n${JSON.stringify(record)}\nError message: ${error.message}`,
         PROTOCOL_ERROR);
     }
   }

--- a/test/internal/node/routing.driver.boltkit.test.js
+++ b/test/internal/node/routing.driver.boltkit.test.js
@@ -1999,31 +1999,11 @@ describe('routing driver with stub server', () => {
   });
 
   it('should rediscover using older getServers procedure when server is old', done => {
-    if (!boltStub.supported) {
-      done();
-      return;
-    }
+    testDiscoveryAndReadQueryInAutoCommitTx('./test/resources/boltstub/acquire_endpoints_old_routing_procedure.script', {}, done);
+  });
 
-    const router = boltStub.start('./test/resources/boltstub/acquire_endpoints_old_routing_procedure.script', 9001);
-    const reader = boltStub.start('./test/resources/boltstub/read_server.script', 9005);
-
-    boltStub.run(() => {
-      const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001');
-
-      const session = driver.session(READ);
-      session.run('MATCH (n) RETURN n.name').then(result => {
-        expect(result.records.map(record => record.get(0))).toEqual(['Bob', 'Alice', 'Tina']);
-        session.close();
-        driver.close();
-        router.exit(code1 => {
-          reader.exit(code2 => {
-            expect(code1).toEqual(0);
-            expect(code2).toEqual(0);
-            done();
-          });
-        });
-      }).catch(done.fail);
-    });
+  it('should connect to cluster when disableLosslessIntegers is on', done => {
+    testDiscoveryAndReadQueryInAutoCommitTx('./test/resources/boltstub/acquire_endpoints.script', {disableLosslessIntegers: true}, done);
   });
 
   function testAddressPurgeOnDatabaseError(query, accessMode, done) {
@@ -2111,6 +2091,34 @@ describe('routing driver with stub server', () => {
           });
         });
       });
+    });
+  }
+
+  function testDiscoveryAndReadQueryInAutoCommitTx(routerScript, driverConfig, done) {
+    if (!boltStub.supported) {
+      done();
+      return;
+    }
+
+    const router = boltStub.start(routerScript, 9001);
+    const reader = boltStub.start('./test/resources/boltstub/read_server.script', 9005);
+
+    boltStub.run(() => {
+      const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001', driverConfig);
+
+      const session = driver.session(READ);
+      session.run('MATCH (n) RETURN n.name').then(result => {
+        expect(result.records.map(record => record.get(0))).toEqual(['Bob', 'Alice', 'Tina']);
+        session.close();
+        driver.close();
+        router.exit(code1 => {
+          reader.exit(code2 => {
+            expect(code1).toEqual(0);
+            expect(code2).toEqual(0);
+            done();
+          });
+        });
+      }).catch(done.fail);
     });
   }
 

--- a/test/internal/routing-util.test.js
+++ b/test/internal/routing-util.test.js
@@ -238,12 +238,18 @@ describe('RoutingUtil', () => {
   });
 
   function testValidTtlParsing(currentTime, ttlSeconds) {
-    const record = newRecord({ttl: int(ttlSeconds)});
     clock.setSystemTime(currentTime);
+    const expectedExpirationTime = currentTime + ttlSeconds * 1000;
 
-    const expirationTime = parseTtl(record).toNumber();
+    // verify parsing when TTL is an Integer
+    const record1 = newRecord({ttl: int(ttlSeconds)});
+    const expirationTime1 = parseTtl(record1).toNumber();
+    expect(expirationTime1).toEqual(expectedExpirationTime);
 
-    expect(expirationTime).toEqual(currentTime + ttlSeconds * 1000);
+    // verify parsing when TTL is a JavaScript Number, this can happen when driver is configured with {disableLosslessIntegers: true}
+    const record2 = newRecord({ttl: ttlSeconds});
+    const expirationTime2 = parseTtl(record2).toNumber();
+    expect(expirationTime2).toEqual(expectedExpirationTime);
   }
 
   function testValidServersParsing(routerAddresses, readerAddresses, writerAddresses) {


### PR DESCRIPTION
Driver can be created with `{disableLosslessIntegers: true}` config. Then all integer numbers returned in query results will be `Number` instead of `neo4j.Integer`.

Routing table response parsing code did not expect `Number`s and failed to parse the TTL entry. This PR fixes parsing by always wrapping returned value of TTL in a `neo4j.Integer`.

Also improved error messages around routing response parsing to include the original error message.

Fixes #424 