### PR TITLE
Fix conversion from standard Date to Time & DateTime

### DIFF
--- a/src/v1/internal/temporal-util.js
+++ b/src/v1/internal/temporal-util.js
@@ -311,11 +311,22 @@ export function totalNanoseconds(standardDate, nanoseconds) {
 
 /**
  * Get the time zone offset in seconds from the given standard JavaScript date.
+ *
+ * <b>Implementation note:</b>
+ * Time zone offset returned by the standard JavaScript date is the difference, in minutes, from local time to UTC.
+ * So positive value means offset is behind UTC and negative value means it is ahead.
+ * For Neo4j temporal types, like `Time` or `DateTime` offset is in seconds and represents difference from UTC to local time.
+ * This is different from standard JavaScript dates and that's why implementation negates the returned value.
+ *
  * @param {global.Date} standardDate the standard JavaScript date.
  * @return {number} the time zone offset in seconds.
  */
 export function timeZoneOffsetInSeconds(standardDate) {
-  return standardDate.getTimezoneOffset() * SECONDS_PER_MINUTE;
+  let offsetInMinutes = standardDate.getTimezoneOffset();
+  if (offsetInMinutes === 0) {
+    return 0;
+  }
+  return -1 * offsetInMinutes * SECONDS_PER_MINUTE;
 }
 
 /**

--- a/src/v1/temporal-types.js
+++ b/src/v1/temporal-types.js
@@ -139,7 +139,8 @@ export class Time {
    * @param {Integer|number} minute the minute for the new local time.
    * @param {Integer|number} second the second for the new local time.
    * @param {Integer|number} nanosecond the nanosecond for the new local time.
-   * @param {Integer|number} timeZoneOffsetSeconds the time zone offset in seconds.
+   * @param {Integer|number} timeZoneOffsetSeconds the time zone offset in seconds. Value represents the difference, in seconds, from UTC to local time.
+   * This is different from standard JavaScript `Date.getTimezoneOffset()` which is the difference, in minutes, from local time to UTC.
    */
   constructor(hour, minute, second, nanosecond, timeZoneOffsetSeconds) {
     this.hour = util.assertValidHour(hour);
@@ -312,7 +313,9 @@ export class DateTime {
    * @param {Integer|number} minute the minute for the new date-time.
    * @param {Integer|number} second the second for the new date-time.
    * @param {Integer|number} nanosecond the nanosecond for the new date-time.
-   * @param {Integer|number|null} timeZoneOffsetSeconds the total time zone offset in seconds for the new date-time. Either this argument or `timeZoneId` should be defined.
+   * @param {Integer|number} timeZoneOffsetSeconds the time zone offset in seconds. Either this argument or `timeZoneId` should be defined.
+   * Value represents the difference, in seconds, from UTC to local time.
+   * This is different from standard JavaScript `Date.getTimezoneOffset()` which is the difference, in minutes, from local time to UTC.
    * @param {string|null} timeZoneId the time zone id for the new date-time. Either this argument or `timeZoneOffsetSeconds` should be defined.
    */
   constructor(year, month, day, hour, minute, second, nanosecond, timeZoneOffsetSeconds, timeZoneId) {

--- a/test/internal/temporal-util.test.js
+++ b/test/internal/temporal-util.test.js
@@ -20,6 +20,7 @@
 import {int} from '../../src/v1/integer';
 import * as util from '../../src/v1/internal/temporal-util';
 import {types} from '../../src/v1';
+import testUtils from './test-utils';
 
 describe('temporal-util', () => {
 
@@ -189,10 +190,12 @@ describe('temporal-util', () => {
   });
 
   it('should get timezone offset in seconds from standard date', () => {
-    expect(util.timeZoneOffsetInSeconds(fakeStandardDateWithOffset(0))).toEqual(0);
-    expect(util.timeZoneOffsetInSeconds(fakeStandardDateWithOffset(2))).toEqual(120);
-    expect(util.timeZoneOffsetInSeconds(fakeStandardDateWithOffset(10))).toEqual(600);
-    expect(util.timeZoneOffsetInSeconds(fakeStandardDateWithOffset(101))).toEqual(6060);
+    expect(util.timeZoneOffsetInSeconds(testUtils.fakeStandardDateWithOffset(0))).toBe(0);
+    expect(util.timeZoneOffsetInSeconds(testUtils.fakeStandardDateWithOffset(2))).toBe(-120);
+    expect(util.timeZoneOffsetInSeconds(testUtils.fakeStandardDateWithOffset(10))).toBe(-600);
+    expect(util.timeZoneOffsetInSeconds(testUtils.fakeStandardDateWithOffset(101))).toBe(-6060);
+    expect(util.timeZoneOffsetInSeconds(testUtils.fakeStandardDateWithOffset(-180))).toBe(10800);
+    expect(util.timeZoneOffsetInSeconds(testUtils.fakeStandardDateWithOffset(-600))).toBe(36000);
   });
 
   it('should verify year', () => {
@@ -329,10 +332,4 @@ function localTime(hour, minute, second, nanosecond) {
 
 function localDateTime(year, month, day, hour, minute, second, nanosecond) {
   return new types.LocalDateTime(int(year), int(month), int(day), int(hour), int(minute), int(second), int(nanosecond));
-}
-
-function fakeStandardDateWithOffset(offsetMinutes) {
-  const date = new Date();
-  date.getTimezoneOffset = () => offsetMinutes;
-  return date;
 }

--- a/test/internal/test-utils.js
+++ b/test/internal/test-utils.js
@@ -24,7 +24,14 @@ function isServer() {
   return !isClient();
 }
 
+function fakeStandardDateWithOffset(offsetMinutes) {
+  const date = new Date();
+  date.getTimezoneOffset = () => offsetMinutes;
+  return date;
+}
+
 export default {
   isClient,
   isServer,
+  fakeStandardDateWithOffset
 };


### PR DESCRIPTION
Time zone offset was not converted correctly. Offset exposed by the standard JavaScript `Date` is the difference, in minutes, from local time to UTC. So positive offset means local time is behind UTC and negative means it's ahead. This is different from Neo4j temporal types that support time zone offsets - `Time` and `DateTime`. They define offset as the difference, in seconds, from UTC to local time. Previous code converted offset in minutes to offset in seconds but did not change the sign of the value.

Fixes #427 