### PR TITLE
Add support for simple integer-like numbers

### DIFF
--- a/src/v1/internal/packstream-v1.js
+++ b/src/v1/internal/packstream-v1.js
@@ -112,6 +112,8 @@ class Packer {
       return () => this._ch.writeUInt8( TRUE );
     } else if (x === false) {
       return () => this._ch.writeUInt8( FALSE );
+    } else if (Number.isInteger(x)) {
+      return () => this.packInteger(Integer.fromInt(x))
     } else if (typeof(x) == "number") {
       return () => this.packFloat(x);
     } else if (typeof(x) == "string") {


### PR DESCRIPTION
Currently it is possible to pass integers to queries using the [`Integer` type](https://github.com/neo4j/neo4j-javascript-driver/blob/0d259a1611c628aa62a916f6040e5015f2e4f844/src/v1/integer.js). Normal numbers are interpreted as `float` by this driver. This can happen unintentionally.

This happened for a query parameter where a normal number was passed, expecting it to be interpreted as an ID and thus integer. In the query the parameter was compared with an ID from the database and the equality always ended up being `false`. This was because this driver interpreted the value as being `float` and thus the query would check equality of an float with an actual integer, always resulting in false.

This PR adds another case for the packer to check whether a Javascript number can be interpreted as an integer and if so, pack it as an integer. In other cases the number will still be packed as a float.