### PR TITLE
Pass AccessMode in BEGIN and RUN messages

### DIFF
--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -28,6 +28,7 @@ import ConnectivityVerifier from './internal/connectivity-verifier';
 import PoolConfig, {DEFAULT_ACQUISITION_TIMEOUT, DEFAULT_MAX_SIZE} from './internal/pool-config';
 import Logger from './internal/logger';
 import ConnectionErrorHandler from './internal/connection-error-handler';
+import {ACCESS_MODE_READ, ACCESS_MODE_WRITE} from './internal/constants';
 
 const DEFAULT_MAX_CONNECTION_LIFETIME = 60 * 60 * 1000; // 1 hour
 
@@ -36,14 +37,14 @@ const DEFAULT_MAX_CONNECTION_LIFETIME = 60 * 60 * 1000; // 1 hour
  * Should be used like this: `driver.session(neo4j.session.READ)`.
  * @type {string}
  */
-const READ = 'READ';
+const READ = ACCESS_MODE_READ;
 
 /**
  * Constant that represents write session access mode.
  * Should be used like this: `driver.session(neo4j.session.WRITE)`.
  * @type {string}
  */
-const WRITE = 'WRITE';
+const WRITE = ACCESS_MODE_WRITE;
 
 let idGenerator = 0;
 
@@ -198,7 +199,7 @@ class Driver {
 
   static _validateSessionMode(rawMode) {
     const mode = rawMode || WRITE;
-    if (mode !== READ && mode !== WRITE) {
+    if (mode !== ACCESS_MODE_READ && mode !== ACCESS_MODE_WRITE) {
       throw newError('Illegal session mode ' + mode);
     }
     return mode;

--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -175,15 +175,15 @@ class Driver {
   }
 
   /**
-   * Acquire a session to communicate with the database. The driver maintains
-   * a pool of sessions, so calling this method is normally cheap because you
-   * will be pulling a session out of the common pool.
+   * Acquire a session to communicate with the database. The session will
+   * borrow connections from the underlying connection pool as required and
+   * should be considered lightweight and disposable.
    *
    * This comes with some responsibility - make sure you always call
    * {@link close} when you are done using a session, and likewise,
    * make sure you don't close your session before you are done using it. Once
-   * it is returned to the pool, the session will be reset to a clean state and
-   * made available for others to use.
+   * it is closed, the underlying connection will be released to the connection
+   * pool and made available for others to use.
    *
    * @param {string} [mode=WRITE] the access mode of this session, allowed values are {@link READ} and {@link WRITE}.
    * @param {string|string[]} [bookmarkOrBookmarks=null] the initial reference or references to some previous

--- a/src/v1/internal/bolt-protocol-v1.js
+++ b/src/v1/internal/bolt-protocol-v1.js
@@ -21,6 +21,7 @@ import * as v1 from './packstream-v1';
 import {newError} from '../error';
 import Bookmark from './bookmark';
 import TxConfig from './tx-config';
+import {ACCESS_MODE_WRITE} from "./constants";
 
 export default class BoltProtocol {
 
@@ -80,9 +81,10 @@ export default class BoltProtocol {
    * Begin an explicit transaction.
    * @param {Bookmark} bookmark the bookmark.
    * @param {TxConfig} txConfig the configuration.
+   * @param {string} mode the access mode.
    * @param {StreamObserver} observer the response observer.
    */
-  beginTransaction(bookmark, txConfig, observer) {
+  beginTransaction(bookmark, txConfig, mode, observer) {
     assertTxConfigIsEmpty(txConfig, this._connection, observer);
 
     const runMessage = RequestMessage.run('BEGIN', bookmark.asBeginTransactionParameters());
@@ -97,7 +99,9 @@ export default class BoltProtocol {
    * @param {StreamObserver} observer the response observer.
    */
   commitTransaction(observer) {
-    this.run('COMMIT', {}, Bookmark.empty(), TxConfig.empty(), observer);
+    // WRITE access mode is used as a place holder here, it has
+    // no effect on behaviour for Bolt V1 & V2
+    this.run('COMMIT', {}, Bookmark.empty(), TxConfig.empty(), ACCESS_MODE_WRITE, observer);
   }
 
   /**
@@ -105,7 +109,9 @@ export default class BoltProtocol {
    * @param {StreamObserver} observer the response observer.
    */
   rollbackTransaction(observer) {
-    this.run('ROLLBACK', {}, Bookmark.empty(), TxConfig.empty(), observer);
+    // WRITE access mode is used as a place holder here, it has
+    // no effect on behaviour for Bolt V1 & V2
+    this.run('ROLLBACK', {}, Bookmark.empty(), TxConfig.empty(), ACCESS_MODE_WRITE, observer);
   }
 
   /**
@@ -114,10 +120,11 @@ export default class BoltProtocol {
    * @param {object} parameters the statement parameters.
    * @param {Bookmark} bookmark the bookmark.
    * @param {TxConfig} txConfig the auto-commit transaction configuration.
+   * @param {string} mode the access mode.
    * @param {StreamObserver} observer the response observer.
    */
-  run(statement, parameters, bookmark, txConfig, observer) {
-    // bookmark is ignored in this version of the protocol
+  run(statement, parameters, bookmark, txConfig, mode, observer) {
+    // bookmark and mode are ignored in this versioon of the protocol
     assertTxConfigIsEmpty(txConfig, this._connection, observer);
 
     const runMessage = RequestMessage.run(statement, parameters);

--- a/src/v1/internal/bolt-protocol-v3.js
+++ b/src/v1/internal/bolt-protocol-v3.js
@@ -52,9 +52,9 @@ export default class BoltProtocol extends BoltProtocolV2 {
     this._connection.write(message, observer, true);
   }
 
-  beginTransaction(bookmark, txConfig, observer) {
+  beginTransaction(bookmark, txConfig, mode, observer) {
     prepareToHandleSingleResponse(observer);
-    const message = RequestMessage.begin(bookmark, txConfig);
+    const message = RequestMessage.begin(bookmark, txConfig, mode);
     this._connection.write(message, observer, true);
   }
 
@@ -70,8 +70,8 @@ export default class BoltProtocol extends BoltProtocolV2 {
     this._connection.write(message, observer, true);
   }
 
-  run(statement, parameters, bookmark, txConfig, observer) {
-    const runMessage = RequestMessage.runWithMetadata(statement, parameters, bookmark, txConfig);
+  run(statement, parameters, bookmark, txConfig, mode, observer) {
+    const runMessage = RequestMessage.runWithMetadata(statement, parameters, bookmark, txConfig, mode);
     const pullAllMessage = RequestMessage.pullAll();
 
     this._connection.write(runMessage, observer, false);

--- a/src/v1/internal/connection-holder.js
+++ b/src/v1/internal/connection-holder.js
@@ -37,6 +37,14 @@ export default class ConnectionHolder {
   }
 
   /**
+   * Returns the assigned access mode.
+   * @returns {string} access mode
+   */
+  mode() {
+    return this._mode;
+  }
+
+  /**
    * Make this holder initialize new connection if none exists already.
    * @return {undefined}
    */

--- a/src/v1/internal/constants.js
+++ b/src/v1/internal/constants.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ACCESS_MODE_READ = 'READ';
+const ACCESS_MODE_WRITE = 'WRITE';
+
+export {
+  ACCESS_MODE_READ,
+  ACCESS_MODE_WRITE
+}

--- a/src/v1/internal/routing-util.js
+++ b/src/v1/internal/routing-util.js
@@ -22,6 +22,7 @@ import Integer, {int} from '../integer';
 import {ServerVersion, VERSION_3_2_0} from './server-version';
 import Bookmark from './bookmark';
 import TxConfig from './tx-config';
+import {ACCESS_MODE_WRITE} from "./constants";
 
 const CALL_GET_SERVERS = 'CALL dbms.cluster.routing.getServers';
 const CALL_GET_ROUTING_TABLE = 'CALL dbms.cluster.routing.getRoutingTable($context)';
@@ -125,7 +126,7 @@ export default class RoutingUtil {
         params = {};
       }
 
-      connection.protocol().run(query, params, Bookmark.empty(), TxConfig.empty(), streamObserver);
+      connection.protocol().run(query, params, Bookmark.empty(), TxConfig.empty(), ACCESS_MODE_WRITE, streamObserver);
     });
   }
 }

--- a/src/v1/transaction.js
+++ b/src/v1/transaction.js
@@ -46,7 +46,7 @@ class Transaction {
     const streamObserver = new _TransactionStreamObserver(this);
 
     this._connectionHolder.getConnection(streamObserver)
-      .then(conn => conn.protocol().beginTransaction(bookmark, txConfig, streamObserver))
+      .then(conn => conn.protocol().beginTransaction(bookmark, txConfig, this._connectionHolder.mode(), streamObserver))
       .catch(error => streamObserver.onError(error));
   }
 
@@ -158,7 +158,7 @@ let _states = {
       const txConfig = TxConfig.empty();
 
       connectionHolder.getConnection(observer)
-        .then(conn => conn.protocol().run(statement, parameters, bookmark, txConfig, observer))
+        .then(conn => conn.protocol().run(statement, parameters, bookmark, txConfig, connectionHolder.mode(), observer))
         .catch(error => observer.onError(error));
 
       return _newRunResult(observer, statement, parameters, () => observer.serverMetadata());

--- a/test/internal/bolt-protocol-v1.test.js
+++ b/test/internal/bolt-protocol-v1.test.js
@@ -21,6 +21,7 @@ import BoltProtocolV1 from '../../src/v1/internal/bolt-protocol-v1';
 import RequestMessage from '../../src/v1/internal/request-message';
 import Bookmark from '../../src/v1/internal/bookmark';
 import TxConfig from '../../src/v1/internal/tx-config';
+import {WRITE} from "../../src/v1/driver";
 
 class MessageRecorder {
 
@@ -78,7 +79,7 @@ describe('BoltProtocolV1', () => {
     const parameters = {x: 'x', y: 'y'};
     const observer = {};
 
-    protocol.run(statement, parameters, Bookmark.empty(), TxConfig.empty(), observer);
+    protocol.run(statement, parameters, Bookmark.empty(), TxConfig.empty(), WRITE, observer);
 
     recorder.verifyMessageCount(2);
 
@@ -110,7 +111,7 @@ describe('BoltProtocolV1', () => {
     const bookmark = new Bookmark('neo4j:bookmark:v1:tx42');
     const observer = {};
 
-    protocol.beginTransaction(bookmark, TxConfig.empty(), observer);
+    protocol.beginTransaction(bookmark, TxConfig.empty(), WRITE, observer);
 
     recorder.verifyMessageCount(2);
 

--- a/test/internal/connection.test.js
+++ b/test/internal/connection.test.js
@@ -32,6 +32,7 @@ import ConnectionErrorHandler from '../../src/v1/internal/connection-error-handl
 import testUtils from '../internal/test-utils';
 import Bookmark from '../../src/v1/internal/bookmark';
 import TxConfig from '../../src/v1/internal/tx-config';
+import {WRITE} from "../../src/v1/driver";
 
 const ILLEGAL_MESSAGE = {signature: 42, fields: []};
 const SUCCESS_MESSAGE = {signature: 0x70, fields: [{}]};
@@ -98,7 +99,7 @@ describe('Connection', () => {
 
     connection.connect('mydriver/0.0.0', basicAuthToken())
       .then(() => {
-        connection.protocol().run('RETURN 1.0', {}, Bookmark.empty(), TxConfig.empty(), streamObserver);
+        connection.protocol().run('RETURN 1.0', {}, Bookmark.empty(), TxConfig.empty(), WRITE, streamObserver);
       });
   });
 

--- a/test/resources/boltstub/acquire_endpoints_v3.script
+++ b/test/resources/boltstub/acquire_endpoints_v3.script
@@ -1,0 +1,10 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "basic", "principal": "neo4j", "credentials": "password", "user_agent": "neo4j-javascript/0.0.0-dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}

--- a/test/resources/boltstub/hello_run_exit_read.script
+++ b/test/resources/boltstub/hello_run_exit_read.script
@@ -1,0 +1,12 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"credentials": "password", "scheme": "basic", "user_agent": "neo4j-javascript/0.0.0-dev", "principal": "neo4j"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Foo"]
+   RECORD ["Bar"]
+   SUCCESS {}
+S: <EXIT>

--- a/test/resources/boltstub/read_server_v3_read.script
+++ b/test/resources/boltstub/read_server_v3_read.script
@@ -1,0 +1,12 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "basic", "principal": "neo4j", "credentials": "password", "user_agent": "neo4j-javascript/0.0.0-dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   RECORD ["Tina"]
+   SUCCESS {}

--- a/test/resources/boltstub/read_server_v3_read_tx.script
+++ b/test/resources/boltstub/read_server_v3_read_tx.script
@@ -1,0 +1,16 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "basic", "principal": "neo4j", "credentials": "password", "user_agent": "neo4j-javascript/0.0.0-dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: BEGIN {"mode": "r"}
+S: SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   RECORD ["Tina"]
+   SUCCESS {}
+C: COMMIT
+S: SUCCESS {"bookmark": "ABookmark"}

--- a/test/resources/boltstub/write_server_v3_write.script
+++ b/test/resources/boltstub/write_server_v3_write.script
@@ -1,0 +1,9 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "basic", "principal": "neo4j", "credentials": "password", "user_agent": "neo4j-javascript/0.0.0-dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}

--- a/test/resources/boltstub/write_server_v3_write_tx.script
+++ b/test/resources/boltstub/write_server_v3_write_tx.script
@@ -1,0 +1,13 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "basic", "principal": "neo4j", "credentials": "password", "user_agent": "neo4j-javascript/0.0.0-dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: BEGIN {}
+S: SUCCESS {}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: COMMIT
+S: SUCCESS { "bookmark": "ABookmark" }


### PR DESCRIPTION
This PR makes the `AccessMode` set on client side available on messages BEGIN and RUN in Bolt V3.

No `mode` parameter in statement metadata means that the access mode set by client is `WRITE`, whereas a value of `r` means it is set as `READ`.

It also addresses an issue about API docs where it mentioned session pools instead of connection pools.