### PR TITLE
Add multi-database support

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -178,13 +178,18 @@ class Driver {
    * it is closed, the underlying connection will be released to the connection
    * pool and made available for others to use.
    *
-   * @param {string} [mode=WRITE] the access mode of this session, allowed values are {@link READ} and {@link WRITE}.
-   * @param {string|string[]} [bookmarkOrBookmarks=null] the initial reference or references to some previous
+   * @param {string} [defaultAccessMode=WRITE] the access mode of this session, allowed values are {@link READ} and {@link WRITE}.
+   * @param {string|string[]} [bookmarks=null] the initial reference or references to some previous
    * transactions. Value is optional and absence indicates that that the bookmarks do not exist or are unknown.
+   * @param {string} [db=''] the database this session will connect to.
    * @return {Session} new session.
    */
-  session (mode, bookmarkOrBookmarks) {
-    const sessionMode = Driver._validateSessionMode(mode)
+  session ({
+    defaultAccessMode = WRITE,
+    bookmarks: bookmarkOrBookmarks,
+    db = ''
+  } = {}) {
+    const sessionMode = Driver._validateSessionMode(defaultAccessMode)
     const connectionProvider = this._getOrCreateConnectionProvider()
     const bookmark = bookmarkOrBookmarks
       ? new Bookmark(bookmarkOrBookmarks)

--- a/src/driver.js
+++ b/src/driver.js
@@ -109,12 +109,13 @@ class Driver {
 
   /**
    * Verifies connectivity of this driver by trying to open a connection with the provided driver options.
+   * @param {string} [db=''] the target database to verify connectivity for.
    * @returns {Promise<object>} promise resolved with server info or rejected with error.
    */
-  verifyConnectivity () {
+  verifyConnectivity ({ db = '' } = {}) {
     const connectionProvider = this._getOrCreateConnectionProvider()
     const connectivityVerifier = new ConnectivityVerifier(connectionProvider)
-    return connectivityVerifier.verify()
+    return connectivityVerifier.verify({ db })
   }
 
   /**
@@ -194,7 +195,13 @@ class Driver {
     const bookmark = bookmarkOrBookmarks
       ? new Bookmark(bookmarkOrBookmarks)
       : Bookmark.empty()
-    return new Session(sessionMode, connectionProvider, bookmark, this._config)
+    return new Session({
+      mode: sessionMode,
+      db,
+      connectionProvider,
+      bookmark,
+      config: this._config
+    })
   }
 
   static _validateSessionMode (rawMode) {

--- a/src/internal/bolt-protocol-util.js
+++ b/src/internal/bolt-protocol-util.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { newError } from '../error'
+
+/**
+ * @param {TxConfig} txConfig the auto-commit transaction configuration.
+ * @param {Connection} connection the connection.
+ * @param {StreamObserver} observer the response observer.
+ */
+function assertTxConfigIsEmpty (txConfig, connection, observer) {
+  if (txConfig && !txConfig.isEmpty()) {
+    const error = newError(
+      'Driver is connected to the database that does not support transaction configuration. ' +
+        'Please upgrade to neo4j 3.5.0 or later in order to use this functionality'
+    )
+
+    // unsupported API was used, consider this a fatal error for the current connection
+    connection._handleFatalError(error)
+    observer.onError(error)
+    throw error
+  }
+}
+
+/**
+ * Asserts that the passed-in database name is empty.
+ * @param {string} db
+ * @param {Connection} connection
+ * @param {StreamObserver} observer
+ */
+function assertDbIsEmpty (db, connection, observer) {
+  if (db) {
+    const error = newError(
+      'Driver is connected to the database that does not support multiple databases. ' +
+        'Please upgrade to neo4j 4.0.0 or later in order to use this functionality'
+    )
+
+    // unsupported API was used, consider this a fatal error for the current connection
+    connection._handleFatalError(error)
+    observer.onError(error)
+    throw error
+  }
+}
+
+export { assertDbIsEmpty, assertTxConfigIsEmpty }

--- a/src/internal/bolt-protocol-v4.js
+++ b/src/internal/bolt-protocol-v4.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import BoltProtocolV3 from './bolt-protocol-v3'
+import RequestMessage from './request-message'
+
+export default class BoltProtocol extends BoltProtocolV3 {
+  beginTransaction (observer, { bookmark, txConfig, db, mode }) {
+    const message = RequestMessage.begin({ bookmark, txConfig, db, mode })
+    this._connection.write(message, observer, true)
+  }
+
+  run (statement, parameters, observer, { bookmark, txConfig, db, mode }) {
+    const runMessage = RequestMessage.runWithMetadata(statement, parameters, {
+      bookmark,
+      txConfig,
+      db,
+      mode
+    })
+    const pullMessage = RequestMessage.pull()
+
+    this._connection.write(runMessage, observer, false)
+    this._connection.write(pullMessage, observer, true)
+  }
+}

--- a/src/internal/connectivity-verifier.js
+++ b/src/internal/connectivity-verifier.js
@@ -37,8 +37,8 @@ export default class ConnectivityVerifier {
    * Try to obtain a working connection from the connection provider.
    * @returns {Promise<object>} promise resolved with server info or rejected with error.
    */
-  verify () {
-    return acquireAndReleaseDummyConnection(this._connectionProvider)
+  verify ({ db = '' } = {}) {
+    return acquireAndReleaseDummyConnection(this._connectionProvider, db)
   }
 }
 
@@ -47,8 +47,12 @@ export default class ConnectivityVerifier {
  * @param {ConnectionProvider} connectionProvider the provider to obtain connections from.
  * @return {Promise<object>} promise resolved with server info or rejected with error.
  */
-function acquireAndReleaseDummyConnection (connectionProvider) {
-  const connectionHolder = new ConnectionHolder(READ, connectionProvider)
+function acquireAndReleaseDummyConnection (connectionProvider, db) {
+  const connectionHolder = new ConnectionHolder({
+    mode: READ,
+    db,
+    connectionProvider
+  })
   connectionHolder.initializeConnection()
   const dummyObserver = new StreamObserver()
   const connectionPromise = connectionHolder.getConnection(dummyObserver)

--- a/src/internal/http/http-driver.js
+++ b/src/internal/http/http-driver.js
@@ -28,12 +28,12 @@ export default class HttpDriver extends Driver {
   }
 
   session () {
-    return new HttpSession(
-      this._hostPort,
-      this._authToken,
-      this._config,
-      this._sessionTracker
-    )
+    return new HttpSession({
+      url: this._hostPort,
+      authToken: this._authToken,
+      config: this._config,
+      sessionTracker: this._sessionTracker
+    })
   }
 
   close () {

--- a/src/internal/http/http-session.js
+++ b/src/internal/http/http-session.js
@@ -26,8 +26,8 @@ import { EMPTY_CONNECTION_HOLDER } from '../connection-holder'
 import Result from '../../result'
 
 export default class HttpSession extends Session {
-  constructor (url, authToken, config, sessionTracker) {
-    super(WRITE, null, null, config)
+  constructor ({ url, authToken, config, db = '', sessionTracker } = {}) {
+    super({ mode: WRITE, connectionProvider: null, bookmark: null, db, config })
     this._ongoingTransactionIds = []
     this._serverInfoSupplier = createServerInfoSupplier(url)
     this._requestRunner = new HttpRequestRunner(url, authToken)
@@ -35,7 +35,7 @@ export default class HttpSession extends Session {
     this._sessionTracker.sessionOpened(this)
   }
 
-  run (statement, parameters = {}) {
+  run (statement, parameters = {}, transactionConfig) {
     const { query, params } = validateStatementAndParameters(
       statement,
       parameters

--- a/src/internal/protocol-handshaker.js
+++ b/src/internal/protocol-handshaker.js
@@ -22,6 +22,7 @@ import { newError } from '../error'
 import BoltProtocolV1 from './bolt-protocol-v1'
 import BoltProtocolV2 from './bolt-protocol-v2'
 import BoltProtocolV3 from './bolt-protocol-v3'
+import BoltProtocolV4 from './bolt-protocol-v4'
 
 const HTTP_MAGIC_PREAMBLE = 1213486160 // == 0x48545450 == "HTTP"
 const BOLT_MAGIC_PREAMBLE = 0x6060b017
@@ -90,6 +91,12 @@ export default class ProtocolHandshaker {
           this._chunker,
           this._disableLosslessIntegers
         )
+      case 4:
+        return new BoltProtocolV4(
+          this._connection,
+          this._chunker,
+          this._disableLosslessIntegers
+        )
       case HTTP_MAGIC_PREAMBLE:
         throw newError(
           'Server responded HTTP. Make sure you are not trying to connect to the http endpoint ' +
@@ -112,10 +119,10 @@ function newHandshakeBuffer () {
   handshakeBuffer.writeInt32(BOLT_MAGIC_PREAMBLE)
 
   // proposed versions
+  handshakeBuffer.writeInt32(4)
   handshakeBuffer.writeInt32(3)
   handshakeBuffer.writeInt32(2)
   handshakeBuffer.writeInt32(1)
-  handshakeBuffer.writeInt32(0)
 
   // reset the reader position
   handshakeBuffer.reset()

--- a/src/internal/routing-util.js
+++ b/src/internal/routing-util.js
@@ -137,16 +137,11 @@ export default class RoutingUtil {
         params = {}
       }
 
-      connection
-        .protocol()
-        .run(
-          query,
-          params,
-          Bookmark.empty(),
-          TxConfig.empty(),
-          ACCESS_MODE_WRITE,
-          streamObserver
-        )
+      connection.protocol().run(query, params, streamObserver, {
+        bookmark: Bookmark.empty(),
+        txConfig: TxConfig.empty(),
+        mode: ACCESS_MODE_WRITE
+      })
     })
   }
 }

--- a/src/session.js
+++ b/src/session.js
@@ -97,16 +97,11 @@ class Session {
       : TxConfig.empty()
 
     return this._run(query, params, (connection, streamObserver) =>
-      connection
-        .protocol()
-        .run(
-          query,
-          params,
-          this._lastBookmark,
-          autoCommitTxConfig,
-          this._mode,
-          streamObserver
-        )
+      connection.protocol().run(query, params, streamObserver, {
+        bookmark: this._lastBookmark,
+        txConfig: autoCommitTxConfig,
+        mode: this._mode
+      })
     )
   }
 

--- a/src/session.js
+++ b/src/session.js
@@ -62,16 +62,19 @@ class Session {
    * @param {Bookmark} bookmark - the initial bookmark for this session.
    * @param {Object} [config={}] - this driver configuration.
    */
-  constructor (mode, connectionProvider, bookmark, config) {
+  constructor ({ mode, connectionProvider, bookmark, db, config }) {
     this._mode = mode
-    this._readConnectionHolder = new ConnectionHolder(
-      ACCESS_MODE_READ,
+    this._db = db
+    this._readConnectionHolder = new ConnectionHolder({
+      mode: ACCESS_MODE_READ,
+      db,
       connectionProvider
-    )
-    this._writeConnectionHolder = new ConnectionHolder(
-      ACCESS_MODE_WRITE,
+    })
+    this._writeConnectionHolder = new ConnectionHolder({
+      mode: ACCESS_MODE_WRITE,
+      db,
       connectionProvider
-    )
+    })
     this._open = true
     this._hasTx = false
     this._lastBookmark = bookmark
@@ -100,7 +103,8 @@ class Session {
       connection.protocol().run(query, params, streamObserver, {
         bookmark: this._lastBookmark,
         txConfig: autoCommitTxConfig,
-        mode: this._mode
+        mode: this._mode,
+        db: this._db
       })
     )
   }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -51,7 +51,8 @@ class Transaction {
         conn.protocol().beginTransaction(streamObserver, {
           bookmark: bookmark,
           txConfig: txConfig,
-          mode: this._connectionHolder.mode()
+          mode: this._connectionHolder.mode(),
+          db: this._connectionHolder.db()
         })
       )
       .catch(error => streamObserver.onError(error))
@@ -184,7 +185,8 @@ let _states = {
           conn.protocol().run(statement, parameters, observer, {
             bookmark: bookmark,
             txConfig: txConfig,
-            mode: connectionHolder.mode()
+            mode: connectionHolder.mode(),
+            db: connectionHolder.db()
           })
         )
         .catch(error => observer.onError(error))

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -48,14 +48,11 @@ class Transaction {
     this._connectionHolder
       .getConnection(streamObserver)
       .then(conn =>
-        conn
-          .protocol()
-          .beginTransaction(
-            bookmark,
-            txConfig,
-            this._connectionHolder.mode(),
-            streamObserver
-          )
+        conn.protocol().beginTransaction(streamObserver, {
+          bookmark: bookmark,
+          txConfig: txConfig,
+          mode: this._connectionHolder.mode()
+        })
       )
       .catch(error => streamObserver.onError(error))
   }
@@ -184,16 +181,11 @@ let _states = {
       connectionHolder
         .getConnection(observer)
         .then(conn =>
-          conn
-            .protocol()
-            .run(
-              statement,
-              parameters,
-              bookmark,
-              txConfig,
-              connectionHolder.mode(),
-              observer
-            )
+          conn.protocol().run(statement, parameters, observer, {
+            bookmark: bookmark,
+            txConfig: txConfig,
+            mode: connectionHolder.mode()
+          })
         )
         .catch(error => observer.onError(error))
 

--- a/test/bolt-v4.test.js
+++ b/test/bolt-v4.test.js
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import neo4j from '../src'
+import sharedNeo4j from './internal/shared-neo4j'
+import { ServerVersion, VERSION_4_0_0 } from '../src/internal/server-version'
+
+describe('Bolt V4 API', () => {
+  let driver
+  let session
+  let serverVersion
+  let originalTimeout
+
+  beforeEach(done => {
+    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    session = driver.session()
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
+
+    session.run('MATCH (n) DETACH DELETE n').then(result => {
+      serverVersion = ServerVersion.fromString(result.summary.server.version)
+      done()
+    })
+  })
+
+  afterEach(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
+    session.close()
+    driver.close()
+  })
+
+  describe('multi-database', () => {
+    describe('earlier versions', () => {
+      it('should fail run if not supported', done => {
+        if (databaseSupportsBoltV4()) {
+          done()
+          return
+        }
+
+        const session = driver.session({ db: 'adb' })
+
+        session
+          .run('RETURN 1')
+          .then(() => done.fail('Failure expected'))
+          .catch(error => {
+            expectBoltV4NotSupportedError(error)
+            session.close()
+            done()
+          })
+      })
+
+      it('should fail beginTransaction if not supported', done => {
+        if (databaseSupportsBoltV4()) {
+          done()
+          return
+        }
+
+        const session = driver.session({ db: 'adb' })
+        const tx = session.beginTransaction()
+
+        tx.run('RETURN 1')
+          .then(() => done.fail('Failure expected'))
+          .catch(error => {
+            expectBoltV4NotSupportedError(error)
+            session.close()
+            done()
+          })
+      })
+
+      it('should fail readTransaction if not supported', done => {
+        if (databaseSupportsBoltV4()) {
+          done()
+          return
+        }
+
+        const session = driver.session({ db: 'adb' })
+
+        session
+          .readTransaction(tx => tx.run('RETURN 1'))
+          .then(() => done.fail('Failure expected'))
+          .catch(error => {
+            expectBoltV4NotSupportedError(error)
+            session.close()
+            done()
+          })
+      })
+
+      it('should fail writeTransaction if not supported', done => {
+        if (databaseSupportsBoltV4()) {
+          done()
+          return
+        }
+
+        const session = driver.session({ db: 'adb' })
+
+        session
+          .writeTransaction(tx => tx.run('RETURN 1'))
+          .then(() => done.fail('Failure expected'))
+          .catch(error => {
+            expectBoltV4NotSupportedError(error)
+            session.close()
+            done()
+          })
+      })
+    })
+
+    it('should fail if connecting to a non-existing database', done => {
+      const neoSession = driver.session({ db: 'testdb' })
+
+      neoSession
+        .run('RETURN 1')
+        .then(result => {
+          done.fail('Failure expected')
+        })
+        .catch(error => {
+          expect(error.code).toContain('DatabaseNotFound')
+          done()
+        })
+        .finally(() => neoSession.close())
+    })
+
+    describe('neo4j database', () => {
+      it('should be able to create a node', done => {
+        if (!databaseSupportsBoltV4()) {
+          done()
+          return
+        }
+
+        const neoSession = driver.session({ db: 'neo4j' })
+
+        neoSession
+          .run('CREATE (n { db: $db }) RETURN n.db', { db: 'neo4j' })
+          .then(result => {
+            expect(result.records.length).toBe(1)
+            expect(result.records[0].get('n.db')).toBe('neo4j')
+            done()
+          })
+          .catch(error => {
+            done.fail(error)
+          })
+          .finally(() => neoSession.close())
+      })
+    })
+  })
+
+  function expectBoltV4NotSupportedError (error) {
+    expect(
+      error.message.indexOf(
+        'Driver is connected to the database that does not support multiple databases'
+      )
+    ).toBeGreaterThan(-1)
+  }
+
+  function databaseSupportsBoltV4 () {
+    return serverVersion.compareTo(VERSION_4_0_0) >= 0
+  }
+})

--- a/test/bolt-v4.test.js
+++ b/test/bolt-v4.test.js
@@ -121,6 +121,11 @@ describe('Bolt V4 API', () => {
     })
 
     it('should fail if connecting to a non-existing database', done => {
+      if (!databaseSupportsBoltV4()) {
+        done()
+        return
+      }
+
       const neoSession = driver.session({ db: 'testdb' })
 
       neoSession

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -193,7 +193,7 @@ describe('examples', () => {
         'b.acme.com:7676',
         'c.acme.com:8787'
       ])
-      const session = driver.session(neo4j.WRITE)
+      const session = driver.session({ defaultAccessMode: neo4j.WRITE })
 
       session
         .run('CREATE (n:Person { name: $name })', { name: name })
@@ -628,7 +628,7 @@ describe('examples', () => {
     const savedBookmarks = []
 
     // Create the first person and employment relationship.
-    const session1 = driver.session(neo4j.WRITE)
+    const session1 = driver.session({ defaultAccessMode: neo4j.WRITE })
     const first = session1
       .writeTransaction(tx => addCompany(tx, 'Wayne Enterprises'))
       .then(() => session1.writeTransaction(tx => addPerson(tx, 'Alice')))
@@ -644,7 +644,7 @@ describe('examples', () => {
       })
 
     // Create the second person and employment relationship.
-    const session2 = driver.session(neo4j.WRITE)
+    const session2 = driver.session({ defaultAccessMode: neo4j.WRITE })
     const second = session2
       .writeTransaction(tx => addCompany(tx, 'LexCorp'))
       .then(() => session2.writeTransaction(tx => addPerson(tx, 'Bob')))
@@ -659,7 +659,10 @@ describe('examples', () => {
 
     // Create a friendship between the two people created above.
     const last = Promise.all([first, second]).then(ignore => {
-      const session3 = driver.session(neo4j.WRITE, savedBookmarks)
+      const session3 = driver.session({
+        defaultAccessMode: neo4j.WRITE,
+        bookmarks: savedBookmarks
+      })
 
       return session3
         .writeTransaction(tx => makeFriends(tx, 'Alice', 'Bob'))

--- a/test/internal/bolt-protocol-v4.test.js
+++ b/test/internal/bolt-protocol-v4.test.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BoltProtocolV4 from '../../src/internal/bolt-protocol-v4'
+import RequestMessage from '../../src/internal/request-message'
+import utils from './test-utils'
+import Bookmark from '../../src/internal/bookmark'
+import TxConfig from '../../src/internal/tx-config'
+import { WRITE } from '../../src/driver'
+
+describe('BoltProtocolV4', () => {
+  beforeEach(() => {
+    jasmine.addMatchers(utils.matchers)
+  })
+
+  it('should run a statement', () => {
+    const db = 'testdb'
+    const bookmark = new Bookmark([
+      'neo4j:bookmark:v1:tx1',
+      'neo4j:bookmark:v1:tx2'
+    ])
+    const txConfig = new TxConfig({
+      timeout: 5000,
+      metadata: { x: 1, y: 'something' }
+    })
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4(recorder, null, false)
+
+    const statement = 'RETURN $x, $y'
+    const parameters = { x: 'x', y: 'y' }
+    const observer = {}
+
+    protocol.run(statement, parameters, observer, {
+      bookmark,
+      txConfig,
+      db,
+      mode: WRITE
+    })
+
+    recorder.verifyMessageCount(2)
+
+    expect(recorder.messages[0]).toBeMessage(
+      RequestMessage.runWithMetadata(statement, parameters, {
+        bookmark,
+        txConfig,
+        db,
+        mode: WRITE
+      })
+    )
+    expect(recorder.messages[1]).toBeMessage(RequestMessage.pull())
+    expect(recorder.observers).toEqual([observer, observer])
+    expect(recorder.flushes).toEqual([false, true])
+  })
+
+  it('should begin a transaction', () => {
+    const db = 'testdb'
+    const bookmark = new Bookmark([
+      'neo4j:bookmark:v1:tx1',
+      'neo4j:bookmark:v1:tx2'
+    ])
+    const txConfig = new TxConfig({
+      timeout: 5000,
+      metadata: { x: 1, y: 'something' }
+    })
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4(recorder, null, false)
+
+    const observer = {}
+
+    protocol.beginTransaction(observer, {
+      bookmark,
+      txConfig,
+      db,
+      mode: WRITE
+    })
+
+    recorder.verifyMessageCount(1)
+    expect(recorder.messages[0]).toBeMessage(
+      RequestMessage.begin({ bookmark, txConfig, db, mode: WRITE })
+    )
+    expect(recorder.observers).toEqual([observer])
+    expect(recorder.flushes).toEqual([true])
+  })
+})

--- a/test/internal/connection.test.js
+++ b/test/internal/connection.test.js
@@ -97,16 +97,11 @@ describe('Connection', () => {
     streamObserver.subscribe(pullAllObserver)
 
     connection.connect('mydriver/0.0.0', basicAuthToken()).then(() => {
-      connection
-        .protocol()
-        .run(
-          'RETURN 1.0',
-          {},
-          Bookmark.empty(),
-          TxConfig.empty(),
-          WRITE,
-          streamObserver
-        )
+      connection.protocol().run('RETURN 1.0', {}, streamObserver, {
+        bookmark: Bookmark.empty(),
+        txConfig: TxConfig.empty(),
+        mode: WRITE
+      })
     })
   })
 
@@ -122,12 +117,12 @@ describe('Connection', () => {
     connection._negotiateProtocol()
 
     const boltMagicPreamble = '60 60 b0 17'
+    const protocolVersion4 = '00 00 00 04'
     const protocolVersion3 = '00 00 00 03'
     const protocolVersion2 = '00 00 00 02'
     const protocolVersion1 = '00 00 00 01'
-    const noProtocolVersion = '00 00 00 00'
     expect(channel.toHex()).toBe(
-      `${boltMagicPreamble} ${protocolVersion3} ${protocolVersion2} ${protocolVersion1} ${noProtocolVersion}`
+      `${boltMagicPreamble} ${protocolVersion4} ${protocolVersion3} ${protocolVersion2} ${protocolVersion1}`
     )
   })
 
@@ -257,7 +252,12 @@ describe('Connection', () => {
       connection =>
         connection
           .protocol()
-          .run('RETURN 1', {}, Bookmark.empty(), TxConfig.empty(), {}),
+          .run(
+            'RETURN 1',
+            {},
+            {},
+            { bookmark: Bookmark.empty(), txConfig: TxConfig.empty() }
+          ),
       done
     )
   })

--- a/test/internal/http/http-session-tracker.test.js
+++ b/test/internal/http/http-session-tracker.test.js
@@ -69,12 +69,12 @@ describe('http session tracker', () => {
 
 class FakeHttpSession extends HttpSession {
   constructor (sessionTracker) {
-    super(
-      urlUtil.parseDatabaseUrl('http://localhost:7474'),
-      sharedNeo4j.authToken,
-      {},
-      sessionTracker
-    )
+    super({
+      url: urlUtil.parseDatabaseUrl('http://localhost:7474'),
+      authToken: sharedNeo4j.authToken,
+      config: {},
+      sessionTracker: sessionTracker
+    })
     this.timesClosed = 0
   }
 

--- a/test/internal/http/http-session.test.js
+++ b/test/internal/http/http-session.test.js
@@ -29,12 +29,12 @@ describe('http session', () => {
       return
     }
 
-    const session = new HttpSession(
-      urlUtil.parseDatabaseUrl('http://localhost:7474'),
-      sharedNeo4j.authToken,
-      {},
-      new HttpSessionTracker()
-    )
+    const session = new HttpSession({
+      url: urlUtil.parseDatabaseUrl('http://localhost:7474'),
+      authToken: sharedNeo4j.authToken,
+      config: {},
+      sessionTracker: new HttpSessionTracker()
+    })
 
     expect(() => session.run('RETURN $value', [1, 2, 3])).toThrowError(
       TypeError

--- a/test/internal/node/direct.driver.boltkit.test.js
+++ b/test/internal/node/direct.driver.boltkit.test.js
@@ -75,7 +75,10 @@ describe('direct driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
-      const session = driver.session(READ, 'neo4j:bookmark:v1:tx42')
+      const session = driver.session({
+        defaultAccessMode: READ,
+        bookmarks: ['neo4j:bookmark:v1:tx42']
+      })
       const tx = session.beginTransaction()
       tx.run('MATCH (n) RETURN n.name AS name').then(result => {
         const records = result.records
@@ -111,7 +114,10 @@ describe('direct driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
-      const session = driver.session(WRITE, 'neo4j:bookmark:v1:tx42')
+      const session = driver.session({
+        defaultAccessMode: WRITE,
+        bookmarks: ['neo4j:bookmark:v1:tx42']
+      })
       const tx = session.beginTransaction()
       tx.run("CREATE (n {name:'Bob'})").then(result => {
         const records = result.records
@@ -145,7 +151,10 @@ describe('direct driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
-      const session = driver.session(WRITE, 'neo4j:bookmark:v1:tx42')
+      const session = driver.session({
+        defaultAccessMode: WRITE,
+        bookmarks: ['neo4j:bookmark:v1:tx42']
+      })
       const writeTx = session.beginTransaction()
       writeTx.run("CREATE (n {name:'Bob'})").then(result => {
         const records = result.records
@@ -192,7 +201,10 @@ describe('direct driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
-      const session = driver.session(WRITE, 'neo4j:bookmark:v1:tx42')
+      const session = driver.session({
+        defaultAccessMode: WRITE,
+        bookmarks: ['neo4j:bookmark:v1:tx42']
+      })
       const writeTx = session.beginTransaction()
       writeTx.run("CREATE (n {name:'Bob'})").then(result => {
         const records = result.records
@@ -239,7 +251,10 @@ describe('direct driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
-      const session = driver.session(WRITE, 'neo4j:bookmark:v1:tx42')
+      const session = driver.session({
+        defaultAccessMode: WRITE,
+        bookmarks: ['neo4j:bookmark:v1:tx42']
+      })
       const writeTx = session.beginTransaction()
       writeTx.run("CREATE (n {name:'Bob'})").then(result => {
         const records = result.records

--- a/test/internal/node/routing.driver.boltkit.test.js
+++ b/test/internal/node/routing.driver.boltkit.test.js
@@ -88,7 +88,7 @@ describe('routing driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
-      const session = driver.session(READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').then(() => {
         expect(
           hasAddressInConnectionPool(driver, '127.0.0.1:9001')
@@ -130,7 +130,7 @@ describe('routing driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9042')
-      const session = driver.session(neo4j.session.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').then(() => {
         session.close()
 
@@ -236,7 +236,7 @@ describe('routing driver with stub server', () => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
 
       // When
-      const session = driver.session(neo4j.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session
         .run('MATCH (n) RETURN n.name')
         .catch(err => {
@@ -273,7 +273,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').then(res => {
         session.close()
 
@@ -325,7 +325,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9999')
       // When
-      const session1 = driver.session(neo4j.session.READ)
+      const session1 = driver.session({ defaultAccessMode: READ })
       session1.run('MATCH (n) RETURN n.name').then(res => {
         // Then
         expect(res.records[0].get('n.name')).toEqual('Bob')
@@ -333,7 +333,7 @@ describe('routing driver with stub server', () => {
         expect(res.records[2].get('n.name')).toEqual('Tina')
         session1.close()
 
-        const session2 = driver.session(neo4j.session.READ)
+        const session2 = driver.session({ defaultAccessMode: READ })
         session2.run('MATCH (n) RETURN n.name').then(res => {
           // Then
           expect(res.records[0].get('n.name')).toEqual('Bob')
@@ -381,14 +381,14 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session1 = driver.session(neo4j.session.READ)
+      const session1 = driver.session({ defaultAccessMode: READ })
       session1.run('MATCH (n) RETURN n.name').then(res => {
         // Then
         expect(res.records[0].get('n.name')).toEqual('Bob')
         expect(res.records[1].get('n.name')).toEqual('Alice')
         expect(res.records[2].get('n.name')).toEqual('Tina')
         session1.close()
-        const session2 = driver.session(neo4j.session.READ)
+        const session2 = driver.session({ defaultAccessMode: READ })
         session2.run('MATCH (n) RETURN n.name').then(res => {
           // Then
           expect(res.records[0].get('n.name')).toEqual('Bob')
@@ -430,7 +430,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').catch(err => {
         expect(err.code).toEqual(neo4j.error.SESSION_EXPIRED)
         driver.close()
@@ -463,7 +463,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.WRITE)
+      const session = driver.session({ defaultAccessMode: WRITE })
       session.run("CREATE (n {name:'Bob'})").then(() => {
         // Then
         driver.close()
@@ -500,9 +500,9 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session1 = driver.session(neo4j.session.WRITE)
+      const session1 = driver.session({ defaultAccessMode: WRITE })
       session1.run("CREATE (n {name:'Bob'})").then(() => {
-        const session2 = driver.session(neo4j.session.WRITE)
+        const session2 = driver.session({ defaultAccessMode: WRITE })
         session2.run("CREATE (n {name:'Bob'})").then(() => {
           // Then
           driver.close()
@@ -539,7 +539,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.WRITE)
+      const session = driver.session({ defaultAccessMode: WRITE })
       session.run('MATCH (n) RETURN n.name').catch(err => {
         expect(err.code).toEqual(neo4j.error.SESSION_EXPIRED)
         driver.close()
@@ -572,7 +572,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').then(() => {
         // Then
         assertHasRouters(driver, [
@@ -612,7 +612,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').catch(() => {
         session.close()
         // Then
@@ -653,7 +653,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').catch(() => {
         session.close()
         // Then
@@ -695,9 +695,9 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session1 = driver.session(neo4j.session.READ)
+      const session1 = driver.session({ defaultAccessMode: READ })
       session1.run('MATCH (n) RETURN n.name').catch(() => {
-        const session2 = driver.session(neo4j.session.READ)
+        const session2 = driver.session({ defaultAccessMode: READ })
         session2.run('MATCH (n) RETURN n.name').then(() => {
           driver.close()
           seedServer.exit(code1 => {
@@ -835,7 +835,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.WRITE)
+      const session = driver.session({ defaultAccessMode: WRITE })
       session.run('MATCH (n) RETURN n.name').catch(err => {
         expect(err.code).toEqual(neo4j.error.SESSION_EXPIRED)
         driver.close()
@@ -936,11 +936,11 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9002')
       // When
-      const session1 = driver.session(neo4j.session.WRITE)
+      const session1 = driver.session({ defaultAccessMode: WRITE })
       session1.run("CREATE (n {name:'Bob'})").then(() => {
         session1.close(() => {
           const openConnectionsCount = numberOfOpenConnections(driver)
-          const session2 = driver.session(neo4j.session.WRITE)
+          const session2 = driver.session({ defaultAccessMode: WRITE })
           session2.run('CREATE ()').then(() => {
             // driver should have same amount of open connections at this point;
             // no new connections should be created, existing connections should be reused
@@ -988,9 +988,9 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const readSession = driver.session(neo4j.session.READ)
+      const readSession = driver.session({ defaultAccessMode: READ })
       readSession.run('MATCH (n) RETURN n.name').then(readResult => {
-        const writeSession = driver.session(neo4j.session.WRITE)
+        const writeSession = driver.session({ defaultAccessMode: WRITE })
         writeSession.run("CREATE (n {name:'Bob'})").then(writeResult => {
           const readServerInfo = readResult.summary.server
           const writeServerInfo = writeResult.summary.server
@@ -1044,12 +1044,12 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const readSession = driver.session(neo4j.session.READ)
+      const readSession = driver.session({ defaultAccessMode: READ })
       readSession.run('MATCH (n) RETURN n.name').subscribe({
         onNext: () => {},
         onError: () => {},
         onCompleted: readSummary => {
-          const writeSession = driver.session(neo4j.session.WRITE)
+          const writeSession = driver.session({ defaultAccessMode: WRITE })
           writeSession.run("CREATE (n {name:'Bob'})").subscribe({
             onNext: () => {},
             onError: () => {},
@@ -1398,7 +1398,10 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
 
-      const session = driver.session(READ, 'neo4j:bookmark:v1:tx42')
+      const session = driver.session({
+        defaultAccessMode: READ,
+        bookmarks: ['neo4j:bookmark:v1:tx42']
+      })
       const tx = session.beginTransaction()
       tx.run('MATCH (n) RETURN n.name AS name').then(result => {
         const records = result.records
@@ -1442,7 +1445,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
 
-      const session = driver.session(null, 'neo4j:bookmark:v1:tx42')
+      const session = driver.session({ bookmarks: ['neo4j:bookmark:v1:tx42'] })
       const writeTx = session.beginTransaction()
       writeTx.run("CREATE (n {name:'Bob'})").then(() => {
         writeTx.commit().then(() => {
@@ -1836,7 +1839,7 @@ describe('routing driver with stub server', () => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9010')
 
       // run a dummy query to force routing table initialization
-      const session = driver.session(READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').then(result => {
         expect(result.records.length).toEqual(3)
         session.close(() => {
@@ -2041,7 +2044,7 @@ describe('routing driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9010')
-      const session = driver.session(READ)
+      const session = driver.session({ defaultAccessMode: READ })
 
       session.run('MATCH (n) RETURN n.name').then(result1 => {
         expect(result1.records.length).toEqual(3)
@@ -2087,7 +2090,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9010')
 
-      const session = driver.session(READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').then(result => {
         session.close(() => {
           expect(result.records.map(record => record.get(0))).toEqual([
@@ -2144,7 +2147,7 @@ describe('routing driver with stub server', () => {
               'Tina'
             ])
 
-            const writeSession = driver.session(WRITE)
+            const writeSession = driver.session({ defaultAccessMode: WRITE })
             writeSession.run("CREATE (n {name:'Bob'})").catch(error => {
               expect(error.code).toEqual(neo4j.error.SESSION_EXPIRED)
 
@@ -2209,7 +2212,7 @@ describe('routing driver with stub server', () => {
               9010
             )
             boltStub.run(() => {
-              const writeSession = driver.session(WRITE)
+              const writeSession = driver.session({ defaultAccessMode: WRITE })
               writeSession.run("CREATE (n {name:'Bob'})").then(result => {
                 writeSession.close(() => {
                   expect(result.records).toEqual([])
@@ -2263,7 +2266,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9010')
 
-      const readSession = driver.session(READ)
+      const readSession = driver.session({ defaultAccessMode: READ })
       readSession.run('MATCH (n) RETURN n.name').then(result => {
         readSession.close(() => {
           expect(result.records.map(record => record.get(0))).toEqual([
@@ -2276,7 +2279,7 @@ describe('routing driver with stub server', () => {
             '127.0.0.1:9020'
           ])
 
-          const writeSession = driver.session(WRITE)
+          const writeSession = driver.session({ defaultAccessMode: WRITE })
           writeSession.run("CREATE (n {name:'Bob'})").then(result => {
             writeSession.close(() => {
               expect(result.records).toEqual([])
@@ -2358,7 +2361,7 @@ describe('routing driver with stub server', () => {
         'neo4j:bookmark:v1:tx16',
         'neo4j:bookmark:v1:tx68'
       ]
-      const session = driver.session(WRITE, bookmarks)
+      const session = driver.session({ defaultAccessMode: WRITE, bookmarks })
       const tx = session.beginTransaction()
 
       tx.run(`CREATE (n {name:'Bob'})`).then(() => {
@@ -2466,7 +2469,7 @@ describe('routing driver with stub server', () => {
         resolver: resolverFunction
       })
 
-      const session = driver.session(READ)
+      const session = driver.session({ defaultAccessMode: READ })
       // run a query that should trigger discovery against 9001 and then read from it
       session
         .run('MATCH (n) RETURN n.name AS name')
@@ -2550,7 +2553,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session.run('MATCH (n) RETURN n.name').then(res => {
         session.close()
 
@@ -2588,7 +2591,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session
         .readTransaction(tx => tx.run('MATCH (n) RETURN n.name'))
         .then(res => {
@@ -2628,7 +2631,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.WRITE)
+      const session = driver.session({ defaultAccessMode: WRITE })
       session.run("CREATE (n {name:'Bob'})").then(res => {
         session.close()
         driver.close()
@@ -2661,7 +2664,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
-      const session = driver.session(neo4j.session.WRITE)
+      const session = driver.session({ defaultAccessMode: WRITE })
       session
         .writeTransaction(tx => tx.run("CREATE (n {name:'Bob'})"))
         .then(res => {
@@ -2702,7 +2705,7 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9010')
 
-      const session = driver.session(accessMode)
+      const session = driver.session({ defaultAccessMode: accessMode })
       session.run(query).catch(error => {
         expect(error.message).toEqual('Database is busy doing store copy')
         expect(error.code).toEqual(
@@ -2764,7 +2767,10 @@ describe('routing driver with stub server', () => {
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
 
-      const session = driver.session(accessMode, bookmark)
+      const session = driver.session({
+        defaultAccessMode: accessMode,
+        bookmarks: [bookmark]
+      })
       const tx = session.beginTransaction()
       tx.run("CREATE (n {name:'Bob'})").then(() => {
         tx.commit().then(() => {
@@ -2807,7 +2813,7 @@ describe('routing driver with stub server', () => {
         driverConfig
       )
 
-      const session = driver.session(READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session
         .run('MATCH (n) RETURN n.name')
         .then(result => {
@@ -3012,7 +3018,7 @@ describe('routing driver with stub server', () => {
         resolver: resolverFunction
       })
 
-      const session = driver.session(READ)
+      const session = driver.session({ defaultAccessMode: READ })
       session
         .run('MATCH (n) RETURN n.name')
         .then(result => {

--- a/test/internal/protocol-handshaker.test.js
+++ b/test/internal/protocol-handshaker.test.js
@@ -42,13 +42,13 @@ describe('ProtocolHandshaker', () => {
     expect(writtenBuffers.length).toEqual(1)
 
     const boltMagicPreamble = '60 60 b0 17'
+    const protocolVersion4 = '00 00 00 04'
     const protocolVersion3 = '00 00 00 03'
     const protocolVersion2 = '00 00 00 02'
     const protocolVersion1 = '00 00 00 01'
-    const noProtocolVersion = '00 00 00 00'
 
     expect(writtenBuffers[0].toHex()).toEqual(
-      `${boltMagicPreamble} ${protocolVersion3} ${protocolVersion2} ${protocolVersion1} ${noProtocolVersion}`
+      `${boltMagicPreamble} ${protocolVersion4} ${protocolVersion3} ${protocolVersion2} ${protocolVersion1}`
     )
   })
 

--- a/test/internal/test-utils.js
+++ b/test/internal/test-utils.js
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 function isClient () {
   return typeof window !== 'undefined' && window.document
 }
@@ -49,6 +50,65 @@ const matchers = {
         return result
       }
     }
+  },
+  toBeMessage: function (util, customEqualityTesters) {
+    return {
+      compare: function (actual, expected) {
+        if (expected === undefined) {
+          expected = {}
+        }
+
+        let result = {}
+        let failures = []
+
+        if (!util.equals(expected.signature, actual.signature)) {
+          failures.push(
+            `signature '${actual.signature}' to match '${expected.signature}'`
+          )
+        }
+
+        if (!util.equals(expected.fields, actual.fields)) {
+          failures.push(
+            `fields '[${JSON.stringify(
+              actual.fields
+            )}]' to match '[${JSON.stringify(expected.fields)}]'`
+          )
+        }
+
+        result.pass = failures.length === 0
+        if (result.pass) {
+          result.message = `Expected message '${actual}' to match '${expected}'`
+        } else {
+          result.message = `Expected message '[${failures}]', but it didn't`
+        }
+        return result
+      }
+    }
+  }
+}
+
+class MessageRecordingConnection {
+  constructor () {
+    this.messages = []
+    this.observers = []
+    this.flushes = []
+    this.fatalErrors = []
+  }
+
+  write (message, observer, flush) {
+    this.messages.push(message)
+    this.observers.push(observer)
+    this.flushes.push(flush)
+  }
+
+  _handleFatalError (error) {
+    this.fatalErrors.push(error)
+  }
+
+  verifyMessageCount (expected) {
+    expect(this.messages.length).toEqual(expected)
+    expect(this.observers.length).toEqual(expected)
+    expect(this.flushes.length).toEqual(expected)
   }
 }
 
@@ -56,5 +116,6 @@ export default {
   isClient,
   isServer,
   fakeStandardDateWithOffset,
-  matchers
+  matchers,
+  MessageRecordingConnection
 }

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1212,7 +1212,7 @@ describe('session', () => {
     const connectionProvider = new SingleConnectionProvider(
       Promise.resolve(connection)
     )
-    const session = new Session(READ, connectionProvider)
+    const session = new Session({ mode: READ, connectionProvider })
     session.beginTransaction() // force session to acquire new connection
     return session
   }

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -439,7 +439,9 @@ describe('session', () => {
   })
 
   it('should allow creation of a ' + neo4j.session.READ + ' session', done => {
-    const readSession = driver.session(neo4j.session.READ)
+    const readSession = driver.session({
+      defaultAccessMode: neo4j.session.READ
+    })
     readSession.run('RETURN 1').then(() => {
       readSession.close()
       done()
@@ -447,7 +449,9 @@ describe('session', () => {
   })
 
   it('should allow creation of a ' + neo4j.session.WRITE + ' session', done => {
-    const writeSession = driver.session(neo4j.session.WRITE)
+    const writeSession = driver.session({
+      defaultAccessMode: neo4j.session.WRITE
+    })
     writeSession.run('CREATE ()').then(() => {
       writeSession.close()
       done()
@@ -455,7 +459,9 @@ describe('session', () => {
   })
 
   it('should fail for illegal session mode', () => {
-    expect(() => driver.session('ILLEGAL_MODE')).toThrow()
+    expect(() =>
+      driver.session({ defaultAccessMode: 'ILLEGAL_MODE' })
+    ).toThrow()
   })
 
   it('should release connection to the pool after run', done => {
@@ -925,7 +931,7 @@ describe('session', () => {
     expect(_.uniq(bookmarks).length).toEqual(nodeCount)
     bookmarks.forEach(bookmark => expect(_.isString(bookmark)).toBeTruthy())
 
-    const session = driver.session(READ, bookmarks)
+    const session = driver.session({ defaultAccessMode: READ, bookmarks })
     try {
       const result = await session.run('MATCH (n) RETURN count(n)')
       const count = result.records[0].get(0).toInt()

--- a/test/stress.test.js
+++ b/test/stress.test.js
@@ -527,9 +527,12 @@ describe('stress tests', () => {
 
   function newSession (context, accessMode, useBookmark) {
     if (useBookmark) {
-      return context.driver.session(accessMode, context.bookmark)
+      return context.driver.session({
+        defaultAccessMode: accessMode,
+        bookmarks: [context.bookmark]
+      })
     }
-    return context.driver.session(accessMode)
+    return context.driver.session({ defaultAccessMode: accessMode })
   }
 
   function modeFromEnvOrDefault (envVariableName) {

--- a/test/types/driver.test.ts
+++ b/test/types/driver.test.ts
@@ -75,12 +75,18 @@ const writeMode2: string = WRITE
 const driver: Driver = dummy
 
 const session1: Session = driver.session()
-const session2: Session = driver.session('READ')
-const session3: Session = driver.session(READ)
-const session4: Session = driver.session('WRITE')
-const session5: Session = driver.session(WRITE)
-const session6: Session = driver.session(READ, 'bookmark1')
-const session7: Session = driver.session(WRITE, 'bookmark2')
+const session2: Session = driver.session({ defaultAccessMode: 'READ' })
+const session3: Session = driver.session({ defaultAccessMode: READ })
+const session4: Session = driver.session({ defaultAccessMode: 'WRITE' })
+const session5: Session = driver.session({ defaultAccessMode: WRITE })
+const session6: Session = driver.session({
+  defaultAccessMode: READ,
+  bookmarks: 'bookmark1'
+})
+const session7: Session = driver.session({
+  defaultAccessMode: WRITE,
+  bookmarks: 'bookmark2'
+})
 
 session1.run('RETURN 1').then(result => {
   session1.close()

--- a/types/driver.d.ts
+++ b/types/driver.d.ts
@@ -62,7 +62,15 @@ declare const READ: SessionMode
 declare const WRITE: SessionMode
 
 declare interface Driver {
-  session(mode?: SessionMode, bookmark?: string): Session
+  session({
+    defaultAccessMode,
+    bookmarks,
+    db
+  }?: {
+  defaultAccessMode?: SessionMode
+  bookmarks?: string | string[]
+  db?: string
+  }): Session
 
   close(): void
 


### PR DESCRIPTION
This PR adds multi-database support for the driver against a multi-database supporting database. A session is operating against a database which can be selected while creating the session object through `driver.session` call. The default database is set to be an empty string  `''` and connects to the default database as set on the database.

API Changes
-----------------
`driver.session` function signature is now changed in a _**breaking**_ manner. The new signature includes an object destructuring construct where you can now pass parameters by name.

While previously the parameters were positional, like 

`const session = driver.session(WRITE, bookmark)`, 

now it has been changed like

 `const session = driver.session({ defaultAccessMode: WRITE, bookmark: bookmark, db: db  })`