### PR TITLE
Replace text-encoding dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13028,10 +13028,10 @@
         }
       }
     },
-    "text-encoding": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
+    "text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",
-    "text-encoding": "^0.7.0",
+    "text-encoding-utf-8": "^1.0.2",
     "uri-js": "^4.2.2"
   }
 }

--- a/src/v1/internal/browser/browser-utf8.js
+++ b/src/v1/internal/browser/browser-utf8.js
@@ -18,10 +18,10 @@
  */
 
 import HeapBuffer from '../browser/browser-buf'
-import textEncoding from 'text-encoding'
+import { TextEncoder, TextDecoder } from 'text-encoding-utf-8'
 
-const encoder = new textEncoding.TextEncoder('utf-8')
-const decoder = new textEncoding.TextDecoder('utf-8')
+const encoder = new TextEncoder('utf-8')
+const decoder = new TextDecoder('utf-8')
 
 function encode (str) {
   return new HeapBuffer(encoder.encode(str).buffer)


### PR DESCRIPTION
This PR removes `text-encoding` dependency and replaces it with `text-encoding-utf-8`.

Based on #462 and resolves #455.