### PR TITLE
Fix a connection leak issue

### DIFF
--- a/src/v1/driver.js
+++ b/src/v1/driver.js
@@ -80,13 +80,15 @@ class Driver {
     this._authToken = authToken
     this._config = config
     this._log = Logger.create(config)
-    this._pool = new Pool(
-      this._createConnection.bind(this),
-      this._destroyConnection.bind(this),
-      this._validateConnection.bind(this),
-      PoolConfig.fromDriverConfig(config),
-      this._log
-    )
+    this._pool = new Pool({
+      create: this._createConnection.bind(this),
+      destroy: this._destroyConnection.bind(this),
+      validate: this._validateConnection.bind(this),
+      installIdleObserver: this._installIdleObserverOnConnection.bind(this),
+      removeIdleObserver: this._removeIdleObserverOnConnection.bind(this),
+      config: PoolConfig.fromDriverConfig(config),
+      log: this._log
+    })
 
     /**
      * Reference to the connection provider. Initialized lazily by {@link _getOrCreateConnectionProvider}.
@@ -175,6 +177,14 @@ class Driver {
     const maxConnectionLifetime = this._config.maxConnectionLifetime
     const lifetime = Date.now() - conn.creationTimestamp
     return lifetime <= maxConnectionLifetime
+  }
+
+  _installIdleObserverOnConnection (conn, observer) {
+    conn._queueObserver(observer)
+  }
+
+  _removeIdleObserverOnConnection (conn) {
+    conn._updateCurrentObserver()
   }
 
   /**

--- a/test/internal/connection-providers.test.js
+++ b/test/internal/connection-providers.test.js
@@ -1210,9 +1210,10 @@ function setupLoadBalancerToRememberRouters (loadBalancer, routersArray) {
 }
 
 function newPool () {
-  return new Pool((address, release) =>
-    Promise.resolve(new FakeConnection(address, release))
-  )
+  return new Pool({
+    create: (address, release) =>
+      Promise.resolve(new FakeConnection(address, release))
+  })
 }
 
 function expectRoutingTable (loadBalancer, routers, readers, writers) {

--- a/test/internal/least-connected-load-balancing-strategy.test.js
+++ b/test/internal/least-connected-load-balancing-strategy.test.js
@@ -140,7 +140,7 @@ describe('LeastConnectedLoadBalancingStrategy', () => {
 
 class DummyPool extends Pool {
   constructor (activeConnections) {
-    super(() => 42)
+    super({ create: () => 42 })
     this._activeConnections = activeConnections
   }
 

--- a/test/internal/node/direct.driver.boltkit.test.js
+++ b/test/internal/node/direct.driver.boltkit.test.js
@@ -17,10 +17,10 @@
  * limitations under the License.
  */
 
-import neo4j from '../../../src/v1'
+import neo4j, { Neo4jError } from '../../../src/v1'
 import { READ, WRITE } from '../../../src/v1/driver'
 import boltStub from '../bolt-stub'
-import { SERVICE_UNAVAILABLE } from '../../../src/v1/error'
+import { newError, SERVICE_UNAVAILABLE } from '../../../src/v1/error'
 
 describe('direct driver with stub server', () => {
   let originalTimeout
@@ -415,6 +415,55 @@ describe('direct driver with stub server', () => {
               }
               expect(containsDbConnectionIdMessage).toBeTruthy()
 
+              done()
+            })
+          })
+        })
+        .catch(error => done.fail(error))
+    })
+  })
+
+  it('should close connection if it dies sitting idle in connection pool', done => {
+    if (!boltStub.supported) {
+      done()
+      return
+    }
+
+    const server = boltStub.start(
+      './test/resources/boltstub/read_server_v3_read.script',
+      9001
+    )
+
+    boltStub.run(() => {
+      const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
+      const session = driver.session(READ)
+
+      session
+        .run('MATCH (n) RETURN n.name')
+        .then(result => {
+          const records = result.records
+          expect(records.length).toEqual(3)
+          expect(records[0].get(0)).toBe('Bob')
+          expect(records[1].get(0)).toBe('Alice')
+          expect(records[2].get(0)).toBe('Tina')
+
+          const connection = driver._openConnections[0]
+          session.close(() => {
+            // generate a fake fatal error
+            connection._handleFatalError(
+              newError('connection reset', SERVICE_UNAVAILABLE)
+            )
+
+            // expect that the connection to be removed from the pool
+            expect(driver._pool._pools['127.0.0.1:9001'].length).toEqual(0)
+            expect(
+              driver._pool._activeResourceCounts['127.0.0.1:9001']
+            ).toBeFalsy()
+            // expect that the connection to be unregistered from the open connections registry
+            expect(driver._openConnections[0]).toBeFalsy()
+            driver.close()
+            server.exit(code => {
+              expect(code).toEqual(0)
               done()
             })
           })

--- a/test/internal/node/direct.driver.boltkit.test.js
+++ b/test/internal/node/direct.driver.boltkit.test.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import neo4j, { Neo4jError } from '../../../src/v1'
+import neo4j from '../../../src/v1'
 import { READ, WRITE } from '../../../src/v1/driver'
 import boltStub from '../bolt-stub'
 import { newError, SERVICE_UNAVAILABLE } from '../../../src/v1/error'
@@ -447,7 +447,10 @@ describe('direct driver with stub server', () => {
           expect(records[1].get(0)).toBe('Alice')
           expect(records[2].get(0)).toBe('Tina')
 
-          const connection = driver._openConnections[0]
+          const connectionKey = Object.keys(driver._openConnections)[0]
+          expect(connectionKey).toBeTruthy()
+
+          const connection = driver._openConnections[connectionKey]
           session.close(() => {
             // generate a fake fatal error
             connection._handleFatalError(
@@ -460,7 +463,7 @@ describe('direct driver with stub server', () => {
               driver._pool._activeResourceCounts['127.0.0.1:9001']
             ).toBeFalsy()
             // expect that the connection to be unregistered from the open connections registry
-            expect(driver._openConnections[0]).toBeFalsy()
+            expect(driver._openConnections[connectionKey]).toBeFalsy()
             driver.close()
             server.exit(code => {
               expect(code).toEqual(0)


### PR DESCRIPTION
This PR fixes an issue when a connection fails (due to network issues or server going down) while it's idle in the connection pool (waiting to be acquired), that connection is not removed from the pool.

Based on #463.