### PR TITLE
Ensure idle observers are removed when purging

### DIFF
--- a/src/v1/internal/pool.js
+++ b/src/v1/internal/pool.js
@@ -210,7 +210,10 @@ class Pool {
         if (this._installIdleObserver) {
           this._installIdleObserver(resource, {
             onError: () => {
-              this._pools[key] = this._pools[key].filter(r => r !== resource)
+              const pool = this._pools[key]
+              if (pool) {
+                this._pools[key] = pool.filter(r => r !== resource)
+              }
               this._destroy(resource)
             }
           })
@@ -235,6 +238,9 @@ class Pool {
     const pool = this._pools[key] || []
     while (pool.length) {
       const resource = pool.pop()
+      if (this._removeIdleObserver) {
+        this._removeIdleObserver(resource)
+      }
       this._destroy(resource)
     }
     delete this._pools[key]

--- a/test/internal/connection-providers.test.js
+++ b/test/internal/connection-providers.test.js
@@ -51,6 +51,16 @@ describe('DirectConnectionProvider', () => {
 })
 
 describe('LoadBalancer', () => {
+  let originalTimeout
+  beforeEach(function () {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
+  })
+
+  afterEach(function () {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
+  })
+
   const server0 = ServerAddress.fromUrl('server0')
   const server1 = ServerAddress.fromUrl('server1')
   const server2 = ServerAddress.fromUrl('server2')

--- a/test/internal/http/http-request-runner.test.js
+++ b/test/internal/http/http-request-runner.test.js
@@ -28,6 +28,16 @@ const VALID_URI = 'http://localhost'
 const INVALID_URI = 'http://not-localhost'
 
 describe('http request runner', () => {
+  let originalTimeout
+  beforeEach(function () {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
+  })
+
+  afterEach(function () {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
+  })
+
   it('should begin transaction', done => {
     if (testUtils.isServer()) {
       done()


### PR DESCRIPTION
This PR ensures that idle observers are removed as part of the purge process so that they're not get called during after on.