### PR TITLE
Fix typings: types export

### DIFF
--- a/types/v1/index.d.ts
+++ b/types/v1/index.d.ts
@@ -91,14 +91,14 @@ declare function driver(
 ): Driver
 
 declare const types: {
-  Node: Node
-  Relationship: Relationship
-  UnboundRelationship: UnboundRelationship
-  PathSegment: PathSegment
-  Path: Path
-  Result: Result
-  ResultSummary: ResultSummary
-  Record: Record
+  Node: typeof Node
+  Relationship: typeof Relationship
+  UnboundRelationship: typeof UnboundRelationship
+  PathSegment: typeof PathSegment
+  Path: typeof Path
+  Result: typeof Result
+  ResultSummary: typeof ResultSummary
+  Record: typeof Record
   Point: typeof Point
   Duration: typeof Duration
   LocalTime: typeof LocalTime

--- a/types/v1/index.d.ts
+++ b/types/v1/index.d.ts
@@ -96,8 +96,8 @@ declare const types: {
   UnboundRelationship: typeof UnboundRelationship
   PathSegment: typeof PathSegment
   Path: typeof Path
-  Result: typeof Result
-  ResultSummary: typeof ResultSummary
+  Result: Result
+  ResultSummary: ResultSummary
   Record: typeof Record
   Point: typeof Point
   Duration: typeof Duration


### PR DESCRIPTION
exporting typeof Node, Relationship etc...
as you put it typescript thinks you export a Node with type Node instead of the actual class
(same for the rest of the types object)