### PR TITLE
Fix how numbers are converted in result summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3274,7 +3274,8 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
       "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -4695,10 +4696,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -4908,9 +4912,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
@@ -5428,7 +5432,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5449,12 +5454,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5469,17 +5476,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5596,7 +5606,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5608,6 +5619,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5622,6 +5634,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5629,12 +5642,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5653,6 +5668,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5733,7 +5749,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5745,6 +5762,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5830,7 +5848,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5866,6 +5885,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5885,6 +5905,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5928,12 +5949,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8576,9 +8599,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._basecopy": {
@@ -8722,9 +8745,9 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ=",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.pick": {
@@ -9266,9 +9289,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -9278,7 +9301,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -12056,9 +12079,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -13203,6 +13226,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "punycode": "^1.4.1"
       },
@@ -13211,7 +13235,8 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13445,38 +13470,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-filename": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "karma-source-map-support": "^1.4.0",
     "karma-spec-reporter": "^0.0.32",
     "lint-staged": "^8.1.7",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "lolex": "^4.0.1",
     "minimist": "^1.2.0",
     "mustache": "^3.0.1",

--- a/src/v1/internal/bolt-protocol-v3.js
+++ b/src/v1/internal/bolt-protocol-v3.js
@@ -21,13 +21,13 @@ import RequestMessage from './request-message'
 
 export default class BoltProtocol extends BoltProtocolV2 {
   transformMetadata (metadata) {
-    if (metadata.t_first) {
+    if ('t_first' in metadata) {
       // Bolt V3 uses shorter key 't_first' to represent 'result_available_after'
       // adjust the key to be the same as in Bolt V1 so that ResultSummary can retrieve the value
       metadata.result_available_after = metadata.t_first
       delete metadata.t_first
     }
-    if (metadata.t_last) {
+    if ('t_last' in metadata) {
       // Bolt V3 uses shorter key 't_last' to represent 'result_consumed_after'
       // adjust the key to be the same as in Bolt V1 so that ResultSummary can retrieve the value
       metadata.result_consumed_after = metadata.t_last

--- a/src/v1/result-summary.js
+++ b/src/v1/result-summary.js
@@ -167,8 +167,8 @@ class ProfiledPlan {
     this.operatorType = profile.operatorType
     this.identifiers = profile.identifiers
     this.arguments = profile.args
-    this.dbHits = profile.args.DbHits.toInt()
-    this.rows = profile.args.Rows.toInt()
+    this.dbHits = intValue(profile.args.DbHits)
+    this.rows = intValue(profile.args.Rows)
     this.children = profile.children
       ? profile.children.map(child => new ProfiledPlan(child))
       : []
@@ -201,11 +201,9 @@ class StatementStatistics {
     }
     Object.keys(statistics).forEach(index => {
       // To camelCase
-      this._stats[index.replace(/(-\w)/g, m => m[1].toUpperCase())] = isInt(
+      this._stats[index.replace(/(-\w)/g, m => m[1].toUpperCase())] = intValue(
         statistics[index]
       )
-        ? statistics[index].toInt()
-        : statistics[index]
     })
   }
 
@@ -322,9 +320,9 @@ class Notification {
       return {}
     }
     return {
-      offset: pos.offset.toInt(),
-      line: pos.line.toInt(),
-      column: pos.column.toInt()
+      offset: intValue(pos.offset),
+      line: intValue(pos.line),
+      column: intValue(pos.column)
     }
   }
 }
@@ -345,6 +343,10 @@ class ServerInfo {
       this.version = serverMeta.version
     }
   }
+}
+
+function intValue (value) {
+  return isInt(value) ? value.toInt() : value
 }
 
 const statementType = {

--- a/test/internal/node/direct.driver.boltkit.test.js
+++ b/test/internal/node/direct.driver.boltkit.test.js
@@ -287,7 +287,7 @@ describe('direct driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
-      const session = driver.session()
+      const session = driver.session(neo4j.session.READ)
       session.run('MATCH (n) RETURN n.name').catch(error => {
         expect(error.code).toEqual(neo4j.error.SERVICE_UNAVAILABLE)
 

--- a/test/internal/node/routing.driver.boltkit.test.js
+++ b/test/internal/node/routing.driver.boltkit.test.js
@@ -503,7 +503,7 @@ describe('routing driver with stub server', () => {
       9001
     )
     const readServer = boltStub.start(
-      './test/resources/boltstub/dead_read_server.script',
+      './test/resources/boltstub/dead_write_server.script',
       9007
     )
 
@@ -511,7 +511,7 @@ describe('routing driver with stub server', () => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
       // When
       const session = driver.session(neo4j.session.WRITE)
-      session.run('MATCH (n) RETURN n.name').catch(err => {
+      session.run("CREATE (n {name:'Bob'})").catch(err => {
         expect(err.code).toEqual(neo4j.error.SESSION_EXPIRED)
         driver.close()
         seedServer.exit(code1 => {
@@ -1909,7 +1909,7 @@ describe('routing driver with stub server', () => {
 
     boltStub.run(() => {
       const driver = boltStub.newDriver('bolt+routing://127.0.0.1:9001')
-      const session = driver.session()
+      const session = driver.session(neo4j.session.READ)
       session.run('MATCH (n) RETURN n.name AS name').then(result => {
         const names = result.records.map(record => record.get('name'))
         expect(names).toEqual(['Alice', 'Bob', 'Eve'])
@@ -2758,7 +2758,7 @@ describe('routing driver with stub server', () => {
       './test/resources/boltstub/address_unavailable_template.script.mst'
     const server = boltStub.startWithTemplate(
       serverTemplateScript,
-      { query: query },
+      { query: query, mode: accessMode === READ ? '"mode": "r"' : '' },
       serverPort
     )
 

--- a/test/resources/boltstub/acquire_endpoints.script
+++ b/test/resources/boltstub/acquire_endpoints.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/acquire_endpoints_and_exit.script
+++ b/test/resources/boltstub/acquire_endpoints_and_exit.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/acquire_endpoints_v3.script
+++ b/test/resources/boltstub/acquire_endpoints_v3.script
@@ -1,5 +1,6 @@
 !: BOLT 3
 !: AUTO RESET
+!: AUTO GOODBYE
 
 C: HELLO {"scheme": "basic", "principal": "neo4j", "credentials": "password", "user_agent": "neo4j-javascript/0.0.0-dev"}
 S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}

--- a/test/resources/boltstub/acquire_endpoints_v3_empty.script
+++ b/test/resources/boltstub/acquire_endpoints_v3_empty.script
@@ -1,6 +1,7 @@
 !: BOLT 3
 !: AUTO HELLO
 !: AUTO RESET
+!: AUTO GOODBYE
 
 C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL

--- a/test/resources/boltstub/acquire_endpoints_v3_point_to_empty_router_and_exit.script
+++ b/test/resources/boltstub/acquire_endpoints_v3_point_to_empty_router_and_exit.script
@@ -1,6 +1,7 @@
 !: BOLT 3
 !: AUTO HELLO
 !: AUTO RESET
+!: AUTO GOODBYE
 
 C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL

--- a/test/resources/boltstub/acquire_endpoints_v3_three_servers_and_exit.script
+++ b/test/resources/boltstub/acquire_endpoints_v3_three_servers_and_exit.script
@@ -1,5 +1,6 @@
 !: BOLT 3
 !: AUTO HELLO
+!: AUTO GOODBYE
 
 C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL

--- a/test/resources/boltstub/acquire_endpoints_with_one_of_each.script
+++ b/test/resources/boltstub/acquire_endpoints_with_one_of_each.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/address_unavailable_template.script.mst
+++ b/test/resources/boltstub/address_unavailable_template.script.mst
@@ -1,11 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "ROLLBACK" {}
-!: AUTO RUN "BEGIN" {}
-!: AUTO RUN "COMMIT" {}
+!: AUTO ROLLBACK
+!: AUTO BEGIN
+!: AUTO COMMIT
+!: AUTO GOODBYE
 
-C: RUN "{{{query}}}" {}
+C: RUN "{{{query}}}" {} { {{{mode}}} }
 C: PULL_ALL
 S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database is busy doing store copy"}
 S: IGNORED

--- a/test/resources/boltstub/dead_read_server.script
+++ b/test/resources/boltstub/dead_read_server.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "BEGIN" {}
+!: AUTO BEGIN
+!: AUTO GOODBYE
 
-C: RUN "MATCH (n) RETURN n.name" {}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
 C: PULL_ALL
 S: <EXIT>

--- a/test/resources/boltstub/dead_routing_server.script
+++ b/test/resources/boltstub/dead_routing_server.script
@@ -1,7 +1,8 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
 C: PULL_ALL
 S: <EXIT>

--- a/test/resources/boltstub/dead_write_server.script
+++ b/test/resources/boltstub/dead_write_server.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "BEGIN" {}
+!: AUTO BEGIN
+!: AUTO GOODBYE
 
-C: RUN "CREATE (n {name:'Bob'})" {}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
 C: PULL_ALL
 S: <EXIT>

--- a/test/resources/boltstub/discover_ipv6_servers_and_read.script
+++ b/test/resources/boltstub/discover_ipv6_servers_and_read.script
@@ -1,13 +1,15 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "[::1]:9001"],"role": "READ"}, {"addresses": ["[2001:db8:a0b:12f0::1]:9002","[3731:54:65fe:2::a7]:9003"], "role": "WRITE"},{"addresses": ["[ff02::1]:9001","[684D:1111:222:3333:4444:5555:6:77]:9002","[::1]:9003"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name" {}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
    PULL_ALL
 S: SUCCESS {"fields": ["n.name"]}
    SUCCESS {}

--- a/test/resources/boltstub/discover_new_servers.script
+++ b/test/resources/boltstub/discover_new_servers.script
@@ -1,13 +1,15 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9004","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name" {}
+C: RUN "MATCH (n) RETURN n.name" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["n.name"]}
    SUCCESS {}

--- a/test/resources/boltstub/discover_no_writers.script
+++ b/test/resources/boltstub/discover_no_writers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9004","127.0.0.1:9005"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/discover_one_router.script
+++ b/test/resources/boltstub/discover_one_router.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9003","127.0.0.1:9004"], "role": "READ"},{"addresses": ["127.0.0.1:9005"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/discover_servers.script
+++ b/test/resources/boltstub/discover_servers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9009"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/discover_servers_and_read.script
+++ b/test/resources/boltstub/discover_servers_and_read.script
@@ -1,13 +1,15 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name" {}
+C: RUN "MATCH (n) RETURN n.name" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["n.name"]}
    SUCCESS {}

--- a/test/resources/boltstub/empty_get_servers_response.script
+++ b/test/resources/boltstub/empty_get_servers_response.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    SUCCESS {}

--- a/test/resources/boltstub/get_routing_table.script
+++ b/test/resources/boltstub/get_routing_table.script
@@ -1,14 +1,16 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
 S: SUCCESS {"server": "Neo4j/3.2.2"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {"mode": "r"}
    PULL_ALL
 S: SUCCESS {"fields": ["name"]}
    RECORD ["Alice"]

--- a/test/resources/boltstub/get_routing_table_with_context.script
+++ b/test/resources/boltstub/get_routing_table_with_context.script
@@ -1,14 +1,16 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
 S: SUCCESS {"server": "Neo4j/3.2.3"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"policy": "my_policy", "region": "china"}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"policy": "my_policy", "region": "china"}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["name"]}
    RECORD ["Alice"]

--- a/test/resources/boltstub/multiple_bookmarks.script
+++ b/test/resources/boltstub/multiple_bookmarks.script
@@ -1,16 +1,14 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx94", "bookmarks": ["neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56", "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68"]}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56", "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68"]}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "CREATE (n {name:'Bob'})" {}
-   PULL_ALL
-S: SUCCESS {}
    SUCCESS {"bookmark": "neo4j:bookmark:v1:tx95"}
-C: RUN "COMMIT" {}
-   PULL_ALL
+C: COMMIT
 S: SUCCESS {}
-   SUCCESS {}

--- a/test/resources/boltstub/multiple_records_get_servers.script
+++ b/test/resources/boltstub/multiple_records_get_servers.script
@@ -1,8 +1,9 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/no_readers_get_servers.script
+++ b/test/resources/boltstub/no_readers_get_servers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/no_routers_get_servers.script
+++ b/test/resources/boltstub/no_routers_get_servers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"},{"addresses": ["127.0.0.1:9001"], "role": "READ"}]]

--- a/test/resources/boltstub/no_servers_entry_get_servers.script
+++ b/test/resources/boltstub/no_servers_entry_get_servers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "notServers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/no_ttl_entry_get_servers.script
+++ b/test/resources/boltstub/no_ttl_entry_get_servers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["notTtl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/no_writers.script
+++ b/test/resources/boltstub/no_writers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/non_discovery.script
+++ b/test/resources/boltstub/non_discovery.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
 C: PULL_ALL
 S: FAILURE {"code": "Neo.ClientError.Procedure.ProcedureNotFound", "message": "blabla"}
 S: IGNORED

--- a/test/resources/boltstub/not_able_to_write.script
+++ b/test/resources/boltstub/not_able_to_write.script
@@ -1,12 +1,14 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
 !: AUTO DISCARD_ALL
-!: AUTO RUN "ROLLBACK" {}
-!: AUTO RUN "BEGIN" {}
+!: AUTO ROLLBACK
+!: AUTO BEGIN
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CREATE ()" {}
+C: RUN "CREATE ()" {} {}
 C: PULL_ALL
 S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
 S: IGNORED

--- a/test/resources/boltstub/not_able_to_write_in_transaction.script
+++ b/test/resources/boltstub/not_able_to_write_in_transaction.script
@@ -1,14 +1,16 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
 !: AUTO DISCARD_ALL
-!: AUTO RUN "ROLLBACK" {}
-!: AUTO RUN "BEGIN" {}
+!: AUTO ROLLBACK
+!: AUTO BEGIN
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CREATE ()" {}
+C: RUN "CREATE ()" {} {}
 C: PULL_ALL
 S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
 S: IGNORED
-C: RUN "COMMIT" {}
+C: COMMIT
 S: IGNORED

--- a/test/resources/boltstub/one_of_each_template.script.mst
+++ b/test/resources/boltstub/one_of_each_template.script.mst
@@ -1,13 +1,15 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": {{{writers}}},"role": "WRITE"}, {"addresses": {{{readers}}}, "role": "READ"},{"addresses": {{{routers}}}, "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name" {}
+C: RUN "MATCH (n) RETURN n.name" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["n.name"]}
    SUCCESS {}

--- a/test/resources/boltstub/query_with_error.script
+++ b/test/resources/boltstub/query_with_error.script
@@ -1,7 +1,9 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "RETURN 10 / 0" {}
+C: RUN "RETURN 10 / 0" {} {}
 C: PULL_ALL
 S: FAILURE {"code": "Neo.ClientError.Statement.ArithmeticError", "message": "/ by zero"}
 S: IGNORED

--- a/test/resources/boltstub/read_server.script
+++ b/test/resources/boltstub/read_server.script
@@ -1,11 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "COMMIT" {}
-!: AUTO RUN "ROLLBACK" {}
-!: AUTO RUN "BEGIN" {}
+!: AUTO COMMIT
+!: AUTO ROLLBACK
+!: AUTO BEGIN
+!: AUTO GOODBYE
 
-C: RUN "MATCH (n) RETURN n.name" {}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
    PULL_ALL
 S: SUCCESS {"fields": ["n.name"]}
    RECORD ["Bob"]

--- a/test/resources/boltstub/read_server_and_exit.script
+++ b/test/resources/boltstub/read_server_and_exit.script
@@ -1,11 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "COMMIT" {}
-!: AUTO RUN "ROLLBACK" {}
-!: AUTO RUN "BEGIN" {}
+!: AUTO COMMIT
+!: AUTO ROLLBACK
+!: AUTO BEGIN
+!: AUTO GOODBYE
 
-C: RUN "MATCH (n) RETURN n.name" {}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
    PULL_ALL
 S: SUCCESS {"fields": ["n.name"]}
    RECORD ["Bob"]

--- a/test/resources/boltstub/read_server_v3_read.script
+++ b/test/resources/boltstub/read_server_v3_read.script
@@ -1,6 +1,7 @@
 !: BOLT 3
 !: AUTO HELLO
 !: AUTO RESET
+!: AUTO GOODBYE
 
 C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
    PULL_ALL

--- a/test/resources/boltstub/read_server_v3_read_tx.script
+++ b/test/resources/boltstub/read_server_v3_read_tx.script
@@ -1,6 +1,8 @@
 !: BOLT 3
 !: AUTO HELLO
 !: AUTO RESET
+!: AUTO GOODBYE
+!: AUTO GOODBYE
 
 C: BEGIN {"mode": "r"}
 S: SUCCESS {}

--- a/test/resources/boltstub/read_tx_with_bookmarks.script
+++ b/test/resources/boltstub/read_tx_with_bookmarks.script
@@ -1,18 +1,16 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx42", "bookmarks": ["neo4j:bookmark:v1:tx42"]}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"], "mode": "r"}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {"mode": "r"}
    PULL_ALL
 S: SUCCESS {}
-   SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {}
-   PULL_ALL
-S: SUCCESS {"fields": ["name"]}
+   SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]
    RECORD ["Alice"]
    SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
-C: RUN "COMMIT" {}
-   PULL_ALL
+C: COMMIT
 S: SUCCESS {}
-   SUCCESS {}

--- a/test/resources/boltstub/rediscover.script
+++ b/test/resources/boltstub/rediscover.script
@@ -1,13 +1,15 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9004"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005"], "role": "READ"},{"addresses": ["127.0.0.1:9002","127.0.0.1:9003","127.0.0.1:9004"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/rediscover_using_initial_router.script
+++ b/test/resources/boltstub/rediscover_using_initial_router.script
@@ -1,16 +1,18 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "BEGIN" {}
-!: AUTO RUN "COMMIT" {}
-!: AUTO RUN "ROLLBACK" {}
+!: AUTO BEGIN
+!: AUTO COMMIT
+!: AUTO ROLLBACK
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001","127.0.0.1:9009","127.0.0.1:9010"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9011"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {"mode": "r"}
    PULL_ALL
 S: SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]

--- a/test/resources/boltstub/reset_error.script
+++ b/test/resources/boltstub/reset_error.script
@@ -1,6 +1,8 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
+!: AUTO GOODBYE
 
-C: RUN "RETURN 42 AS answer" {}
+C: RUN "RETURN 42 AS answer" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["answer"]}
    RECORD [42]

--- a/test/resources/boltstub/return_x.script
+++ b/test/resources/boltstub/return_x.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "RETURN {x}" {"x": 1}
+C: RUN "RETURN {x}" {"x": 1} {}
    PULL_ALL
 S: SUCCESS {"fields": ["x"]}
    RECORD [1]

--- a/test/resources/boltstub/routing_table_with_zero_ttl.script
+++ b/test/resources/boltstub/routing_table_with_zero_ttl.script
@@ -1,22 +1,24 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [0, [{"addresses": ["127.0.0.1:9091","127.0.0.1:9092","127.0.0.1:9093","127.0.0.1:9999"],"role": "ROUTE"}, {"addresses": ["127.0.0.1:9999"], "role": "READ"},{"addresses": ["127.0.0.1:9999"], "role": "WRITE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n" {}
+C: RUN "MATCH (n) RETURN n" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["n"]}
    SUCCESS {}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [0, [{"addresses": ["127.0.0.1:9999"],"role": "ROUTE"}, {"addresses": ["127.0.0.1:9999"], "role": "READ"},{"addresses": ["127.0.0.1:9999"], "role": "WRITE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n" {}
+C: RUN "MATCH (n) RETURN n" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["n"]}
    SUCCESS {}

--- a/test/resources/boltstub/short_ttl.script
+++ b/test/resources/boltstub/short_ttl.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [0, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9004"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/single_write_server.script
+++ b/test/resources/boltstub/single_write_server.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9004","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/two_write_responses_server.script
+++ b/test/resources/boltstub/two_write_responses_server.script
@@ -1,12 +1,14 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CREATE (n {name:'Bob'})" {}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "CREATE ()" {}
+C: RUN "CREATE ()" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}

--- a/test/resources/boltstub/unparsable_servers_get_servers.script
+++ b/test/resources/boltstub/unparsable_servers_get_servers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"notAddresses": ["127.0.0.1:9001"],"memberRole": "WRITER"}, {"notAddresses": ["127.0.0.1:9002","127.0.0.1:9003"], "memberRole": "READER"},{"notAddresses": ["127.0.0.1:9001","127.0.0.1:9002"], "memberRole": "ROUTER"}]]

--- a/test/resources/boltstub/unparsable_ttl_get_servers.script
+++ b/test/resources/boltstub/unparsable_ttl_get_servers.script
@@ -1,8 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [{ttl: 9223372036854775807}, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/write_read_tx_with_bookmark_override.script
+++ b/test/resources/boltstub/write_read_tx_with_bookmark_override.script
@@ -1,30 +1,23 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx42", "bookmarks": ["neo4j:bookmark:v1:tx42"]}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "CREATE (n {name:'Bob'})" {}
-   PULL_ALL
-S: SUCCESS {}
    SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
-C: RUN "COMMIT" {}
+C: COMMIT
+S: SUCCESS {}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx99"]}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
    PULL_ALL
 S: SUCCESS {}
-   SUCCESS {}
-C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx99", "bookmarks": ["neo4j:bookmark:v1:tx99"]}
-   PULL_ALL
-S: SUCCESS {}
-   SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {}
-   PULL_ALL
-S: SUCCESS {"fields": ["name"]}
+   SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]
    SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
-C: RUN "COMMIT" {}
-   PULL_ALL
+C: COMMIT
 S: SUCCESS {}
-   SUCCESS {}
-

--- a/test/resources/boltstub/write_read_tx_with_bookmarks.script
+++ b/test/resources/boltstub/write_read_tx_with_bookmarks.script
@@ -1,30 +1,24 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx42", "bookmarks": ["neo4j:bookmark:v1:tx42"]}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "CREATE (n {name:'Bob'})" {}
-   PULL_ALL
-S: SUCCESS {}
    SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
-C: RUN "COMMIT" {}
+C: COMMIT
+S: SUCCESS {}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
    PULL_ALL
 S: SUCCESS {}
-   SUCCESS {}
-C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx4242", "bookmarks": ["neo4j:bookmark:v1:tx4242"]}
-   PULL_ALL
-S: SUCCESS {}
-   SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {}
-   PULL_ALL
-S: SUCCESS {"fields": ["name"]}
+   SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]
    SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
-C: RUN "COMMIT" {}
-   PULL_ALL
+C: COMMIT
 S: SUCCESS {}
-   SUCCESS {}
 

--- a/test/resources/boltstub/write_server.script
+++ b/test/resources/boltstub/write_server.script
@@ -1,11 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "COMMIT" {}
-!: AUTO RUN "ROLLBACK" {}
-!: AUTO RUN "BEGIN" {}
+!: AUTO COMMIT
+!: AUTO ROLLBACK
+!: AUTO BEGIN
+!: AUTO GOODBYE
 
-C: RUN "CREATE (n {name:'Bob'})" {}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}

--- a/test/resources/boltstub/write_server_v3_write.script
+++ b/test/resources/boltstub/write_server_v3_write.script
@@ -1,5 +1,6 @@
 !: BOLT 3
 !: AUTO RESET
+!: AUTO GOODBYE
 
 C: HELLO {"scheme": "basic", "principal": "neo4j", "credentials": "password", "user_agent": "neo4j-javascript/0.0.0-dev"}
 S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}

--- a/test/resources/boltstub/write_server_v3_write_tx.script
+++ b/test/resources/boltstub/write_server_v3_write_tx.script
@@ -1,5 +1,6 @@
 !: BOLT 3
 !: AUTO RESET
+!: AUTO GOODBYE
 
 C: HELLO {"scheme": "basic", "principal": "neo4j", "credentials": "password", "user_agent": "neo4j-javascript/0.0.0-dev"}
 S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}

--- a/test/resources/boltstub/write_tx_with_bookmarks.script
+++ b/test/resources/boltstub/write_tx_with_bookmarks.script
@@ -1,16 +1,14 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO GOODBYE
 
-C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx42", "bookmarks": ["neo4j:bookmark:v1:tx42"]}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "CREATE (n {name:'Bob'})" {}
-   PULL_ALL
-S: SUCCESS {}
    SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
-C: RUN "COMMIT" {}
-   PULL_ALL
+C: COMMIT
 S: SUCCESS {}
-   SUCCESS {}


### PR DESCRIPTION
When the driver is configured with `disableLosslessIntegers`, it was not possible for the numeric values  in result summary to be used as-is because the internal `Integer` value was assumed.

This PR fixes the problem by checking whether the received value is `Integer` and makes the conversion to native number only if required (i.e. only if the value is `Integer`).

Fixes #477.