### PR TITLE
resolve #485 

### DIFF
--- a/src/v1/internal/transaction-executor.js
+++ b/src/v1/internal/transaction-executor.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { newError, SERVICE_UNAVAILABLE, SESSION_EXPIRED } from '../error'
+import { newError, Neo4jError, SERVICE_UNAVAILABLE, SESSION_EXPIRED } from '../error'
 
 const DEFAULT_MAX_RETRY_TIME_MS = 30 * 1000 // 30 seconds
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 1000 // 1 seconds
@@ -199,6 +199,7 @@ export default class TransactionExecutor {
   static _canRetryOn (error) {
     return (
       error &&
+      error instanceof Neo4jError &&
       error.code &&
       (error.code === SERVICE_UNAVAILABLE ||
         error.code === SESSION_EXPIRED ||


### PR DESCRIPTION
Checking the type of the error. Without this check, the driver will try to divine meaning from Errors it didn't create, and the property might not be in a format it can understand.