### PR TITLE
Pull Results in Batches

### DIFF
--- a/src/internal/bolt-protocol-v4.js
+++ b/src/internal/bolt-protocol-v4.js
@@ -76,8 +76,9 @@ export default class BoltProtocol extends BoltProtocolV3 {
     const observer = new ResultStreamObserver({
       connection: this._connection,
       reactive: reactive,
-      moreFunction: reactive ? this._requestMore : this._noOp,
-      discardFunction: reactive ? this._requestDiscard : this._noOp,
+      fetchSize: fetchSize,
+      moreFunction: this._requestMore,
+      discardFunction: this._requestDiscard,
       beforeKeys,
       afterKeys,
       beforeError,
@@ -99,7 +100,11 @@ export default class BoltProtocol extends BoltProtocolV3 {
     )
 
     if (!reactive) {
-      this._connection.write(RequestMessage.pull(), observer, flush)
+      this._connection.write(
+        RequestMessage.pull({ n: fetchSize }),
+        observer,
+        flush
+      )
     }
 
     return observer

--- a/src/internal/bolt-protocol-v4.js
+++ b/src/internal/bolt-protocol-v4.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import BoltProtocolV3 from './bolt-protocol-v3'
-import RequestMessage from './request-message'
+import RequestMessage, { ALL } from './request-message'
 import { ResultStreamObserver } from './stream-observers'
 import { BOLT_PROTOCOL_V4 } from './constants'
 
@@ -69,7 +69,8 @@ export default class BoltProtocol extends BoltProtocolV3 {
       beforeComplete,
       afterComplete,
       flush = true,
-      reactive = false
+      reactive = false,
+      fetchSize = ALL
     } = {}
   ) {
     const observer = new ResultStreamObserver({

--- a/src/internal/request-message.js
+++ b/src/internal/request-message.js
@@ -43,7 +43,7 @@ const READ_MODE = 'r'
 /* eslint-enable no-unused-vars */
 
 const NO_STATEMENT_ID = -1
-const ALL = -1
+export const ALL = -1
 
 export default class RequestMessage {
   constructor (signature, fields, toString) {
@@ -220,19 +220,19 @@ export default class RequestMessage {
 function buildTxMetadata (bookmark, txConfig, database, mode) {
   const metadata = {}
   if (!bookmark.isEmpty()) {
-    metadata['bookmarks'] = bookmark.values()
+    metadata.bookmarks = bookmark.values()
   }
   if (txConfig.timeout) {
-    metadata['tx_timeout'] = txConfig.timeout
+    metadata.tx_timeout = txConfig.timeout
   }
   if (txConfig.metadata) {
-    metadata['tx_metadata'] = txConfig.metadata
+    metadata.tx_metadata = txConfig.metadata
   }
   if (database) {
-    metadata['db'] = assertString(database, 'database')
+    metadata.db = assertString(database, 'database')
   }
   if (mode === ACCESS_MODE_READ) {
-    metadata['mode'] = READ_MODE
+    metadata.mode = READ_MODE
   }
   return metadata
 }
@@ -246,7 +246,7 @@ function buildTxMetadata (bookmark, txConfig, database, mode) {
 function buildStreamMetadata (stmtId, n) {
   const metadata = { n: int(n) }
   if (stmtId !== NO_STATEMENT_ID) {
-    metadata['qid'] = int(stmtId)
+    metadata.qid = int(stmtId)
   }
   return metadata
 }

--- a/src/internal/stream-observers.js
+++ b/src/internal/stream-observers.js
@@ -21,8 +21,7 @@ import Connection from './connection'
 import { newError, PROTOCOL_ERROR } from '../error'
 import { isString } from './util'
 import Integer from '../integer'
-
-const DefaultBatchSize = 50
+import { ALL } from './request-message'
 
 class StreamObserver {
   onNext (rawRecord) {}
@@ -63,7 +62,7 @@ class ResultStreamObserver extends StreamObserver {
     reactive = false,
     moreFunction,
     discardFunction,
-    batchSize = DefaultBatchSize,
+    batchSize = ALL,
     beforeError,
     afterError,
     beforeKeys,
@@ -108,7 +107,7 @@ class ResultStreamObserver extends StreamObserver {
    * @param {Array} rawRecord - An array with the raw record
    */
   onNext (rawRecord) {
-    let record = new Record(this._fieldKeys, rawRecord, this._fieldLookup)
+    const record = new Record(this._fieldKeys, rawRecord, this._fieldLookup)
     if (this._observers.some(o => o.onNext)) {
       this._observers.forEach(o => {
         if (o.onNext) {

--- a/src/internal/stream-observers.js
+++ b/src/internal/stream-observers.js
@@ -97,6 +97,7 @@ class ResultStreamObserver extends StreamObserver {
     this._discardFunction = discardFunction
     this._discard = false
     this._fetchSize = fetchSize
+    this._finished = false
   }
 
   /**
@@ -188,6 +189,7 @@ class ResultStreamObserver extends StreamObserver {
 
         delete meta.has_more
       } else {
+        this._finished = true
         const completionMetadata = Object.assign(
           this._connection ? { server: this._connection.server } : {},
           this._meta,
@@ -279,6 +281,7 @@ class ResultStreamObserver extends StreamObserver {
     this._head = []
     this._fieldKeys = []
     this._tail = {}
+    this._finished = true
   }
 
   /**
@@ -299,6 +302,7 @@ class ResultStreamObserver extends StreamObserver {
       return
     }
 
+    this._finished = true
     this._hasFailed = true
     this._error = error
 
@@ -354,7 +358,7 @@ class ResultStreamObserver extends StreamObserver {
     }
     this._observers.push(observer)
 
-    if (this._reactive) {
+    if (this._reactive && !this._finished) {
       this._handleStreaming()
     }
   }

--- a/src/internal/stream-observers.js
+++ b/src/internal/stream-observers.js
@@ -282,9 +282,9 @@ class ResultStreamObserver extends StreamObserver {
   }
 
   /**
-   * Discard pending record stream
+   * Cancel pending record stream
    */
-  discard () {
+  cancel () {
     this._discard = true
   }
 

--- a/src/internal/stream-observers.js
+++ b/src/internal/stream-observers.js
@@ -19,7 +19,6 @@
 import Record from '../record'
 import Connection from './connection'
 import { newError, PROTOCOL_ERROR } from '../error'
-import { isString } from './util'
 import Integer from '../integer'
 import { ALL } from './request-message'
 
@@ -49,7 +48,7 @@ class ResultStreamObserver extends StreamObserver {
    * @param {boolean} param.reactive
    * @param {function(connection: Connection, stmtId: number|Integer, n: number|Integer, observer: StreamObserver)} param.moreFunction -
    * @param {function(connection: Connection, stmtId: number|Integer, observer: StreamObserver)} param.discardFunction -
-   * @param {number|Integer} param.batchSize -
+   * @param {number|Integer} param.fetchSize -
    * @param {function(err: Error): Promise|void} param.beforeError -
    * @param {function(err: Error): Promise|void} param.afterError -
    * @param {function(keys: string[]): Promise|void} param.beforeKeys -
@@ -62,7 +61,7 @@ class ResultStreamObserver extends StreamObserver {
     reactive = false,
     moreFunction,
     discardFunction,
-    batchSize = ALL,
+    fetchSize = ALL,
     beforeError,
     afterError,
     beforeKeys,
@@ -97,7 +96,7 @@ class ResultStreamObserver extends StreamObserver {
     this._moreFunction = moreFunction
     this._discardFunction = discardFunction
     this._discard = false
-    this._batchSize = batchSize
+    this._fetchSize = fetchSize
   }
 
   /**
@@ -228,7 +227,6 @@ class ResultStreamObserver extends StreamObserver {
 
   _handleStreaming () {
     if (
-      this._reactive &&
       this._head &&
       this._observers.some(o => o.onNext || o.onCompleted) &&
       !this._streaming
@@ -241,7 +239,7 @@ class ResultStreamObserver extends StreamObserver {
         this._moreFunction(
           this._connection,
           this._statementId,
-          this._batchSize,
+          this._fetchSize,
           this
         )
       }

--- a/src/result-rx.js
+++ b/src/result-rx.js
@@ -134,7 +134,7 @@ export default class RxResult {
       })
 
       if (this._records.observers.length === 0) {
-        result._discard()
+        result._cancel()
       }
 
       result.subscribe({

--- a/src/result.js
+++ b/src/result.js
@@ -85,6 +85,7 @@ class Result {
   summary () {
     return new Promise((resolve, reject) => {
       this._streamObserverPromise.then(o => {
+        o.cancel()
         o.subscribe({
           onCompleted: metadata => resolve(metadata),
           onError: err => reject(err)
@@ -192,8 +193,8 @@ class Result {
    * @protected
    * @since 4.0.0
    */
-  _discard () {
-    this._streamObserverPromise.then(o => o.discard())
+  _cancel () {
+    this._streamObserverPromise.then(o => o.cancel())
   }
 }
 

--- a/src/result.js
+++ b/src/result.js
@@ -84,12 +84,12 @@ class Result {
    */
   summary () {
     return new Promise((resolve, reject) => {
-      this._streamObserverPromise.then(o =>
+      this._streamObserverPromise.then(o => {
         o.subscribe({
           onCompleted: metadata => resolve(metadata),
           onError: err => reject(err)
         })
-      )
+      })
     })
   }
 
@@ -102,8 +102,8 @@ class Result {
   _getOrCreatePromise () {
     if (!this._p) {
       this._p = new Promise((resolve, reject) => {
-        let records = []
-        let observer = {
+        const records = []
+        const observer = {
           onNext: record => {
             records.push(record)
           },

--- a/src/session.js
+++ b/src/session.js
@@ -49,6 +49,7 @@ class Session {
    * @param {string} args.database the database name
    * @param {Object} args.config={} - this driver configuration.
    * @param {boolean} args.reactive - whether this session should create reactive streams
+   * @param {number} args.fetchSize - defines how many records is pulled in each pulling batch
    */
   constructor ({
     mode,
@@ -56,11 +57,13 @@ class Session {
     bookmark,
     database,
     config,
-    reactive
+    reactive,
+    fetchSize
   }) {
     this._mode = mode
     this._database = database
     this._reactive = reactive
+    this._fetchSize = fetchSize
     this._readConnectionHolder = new ConnectionHolder({
       mode: ACCESS_MODE_READ,
       database,
@@ -107,7 +110,8 @@ class Session {
         mode: this._mode,
         database: this._database,
         afterComplete: this._onComplete,
-        reactive: this._reactive
+        reactive: this._reactive,
+        fetchSize: this._fetchSize
       })
     )
   }

--- a/src/session.js
+++ b/src/session.js
@@ -180,7 +180,8 @@ class Session {
       connectionHolder,
       onClose: this._transactionClosed.bind(this),
       onBookmark: this._updateBookmark.bind(this),
-      reactive: this._reactive
+      reactive: this._reactive,
+      fetchSize: this._fetchSize
     })
     tx._begin(this._lastBookmark, txConfig)
     return tx

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -385,7 +385,7 @@ function finishTransaction (
   const observerPromise = connectionHolder
     .getConnection()
     .then(connection => {
-      pendingResults.forEach(r => r.summary())
+      pendingResults.forEach(r => r._cancel())
       return Promise.all(pendingResults).then(results => {
         if (commit) {
           return connection.protocol().commitTransaction({

--- a/test/driver.test.js
+++ b/test/driver.test.js
@@ -253,6 +253,28 @@ describe('#integration driver', () => {
     )
   })
 
+  it('should validate fetch size in the config', async () => {
+    await validateConfigSanitizing({}, 1000)
+    await validateConfigSanitizing({ fetchSize: 42 }, 42)
+    await validateConfigSanitizing({ fetchSize: -1 }, -1)
+    await validateConfigSanitizing({ fetchSize: '42' }, 42)
+    await validateConfigSanitizing({ fetchSize: '-1' }, -1)
+  })
+
+  it('should fail when fetch size is negative', () => {
+    expect(() =>
+      neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
+        fetchSize: -77
+      })
+    ).toThrow()
+  })
+
+  it('should fail when fetch size is 0', () => {
+    expect(() =>
+      neo4j.driver('bolt://localhost', sharedNeo4j.authToken, { fetchSize: 0 })
+    ).toThrow()
+  })
+
   it('should discard closed connections', async () => {
     driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
 

--- a/test/internal/node/direct.driver.boltkit.test.js
+++ b/test/internal/node/direct.driver.boltkit.test.js
@@ -585,6 +585,99 @@ describe('#stub-direct direct driver with stub server', () => {
     it('v2', () => verifyFailureOnCommit('v2'))
   })
 
+  describe('should cancel stream with result summary method', () => {
+    async function verifyFailureOnCommit (version) {
+      if (!boltStub.supported) {
+        return
+      }
+
+      const server = await boltStub.start(
+        `./test/resources/boltstub/${version}/read_discard.script`,
+        9001
+      )
+
+      const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
+      const session = driver.session({ defaultAccessMode: READ, fetchSize: 2 })
+
+      const result = session.run('MATCH (n) RETURN n.name')
+      await result.summary()
+      const records = (await result).records
+      expect(records.length).toEqual(2)
+      expect(records[0].get(0)).toBe('Bob')
+      expect(records[1].get(0)).toBe('Alice')
+
+      const connectionKey = Object.keys(openConnections(driver))[0]
+      expect(connectionKey).toBeTruthy()
+
+      const connection = openConnections(driver, connectionKey)
+      await session.close()
+
+      // generate a fake fatal error
+      connection._handleFatalError(
+        newError('connection reset', SERVICE_UNAVAILABLE)
+      )
+
+      // expect that the connection to be removed from the pool
+      expect(connectionPool(driver, '127.0.0.1:9001').length).toEqual(0)
+      expect(activeResources(driver, '127.0.0.1:9001')).toBeFalsy()
+      // expect that the connection to be unregistered from the open connections registry
+      expect(openConnections(driver, connectionKey)).toBeFalsy()
+
+      await driver.close()
+      await server.exit()
+    }
+
+    it('v4', () => verifyFailureOnCommit('v4'))
+  })
+
+  describe('should cancel stream with tx commit', () => {
+    async function verifyFailureOnCommit (version) {
+      if (!boltStub.supported) {
+        return
+      }
+
+      const server = await boltStub.start(
+        `./test/resources/boltstub/${version}/read_tx_discard.script`,
+        9001
+      )
+
+      const driver = boltStub.newDriver('bolt://127.0.0.1:9001')
+      const session = driver.session({ defaultAccessMode: READ, fetchSize: 2 })
+      const tx = session.beginTransaction()
+
+      const result = tx.run('MATCH (n) RETURN n.name')
+      await tx.commit()
+
+      // Client will receive a partial result
+      const records = (await result).records
+      expect(records.length).toEqual(2)
+      expect(records[0].get(0)).toBe('Bob')
+      expect(records[1].get(0)).toBe('Alice')
+
+      const connectionKey = Object.keys(openConnections(driver))[0]
+      expect(connectionKey).toBeTruthy()
+
+      const connection = openConnections(driver, connectionKey)
+      await session.close()
+
+      // generate a fake fatal error
+      connection._handleFatalError(
+        newError('connection reset', SERVICE_UNAVAILABLE)
+      )
+
+      // expect that the connection to be removed from the pool
+      expect(connectionPool(driver, '127.0.0.1:9001').length).toEqual(0)
+      expect(activeResources(driver, '127.0.0.1:9001')).toBeFalsy()
+      // expect that the connection to be unregistered from the open connections registry
+      expect(openConnections(driver, connectionKey)).toBeFalsy()
+
+      await driver.close()
+      await server.exit()
+    }
+
+    it('v4', () => verifyFailureOnCommit('v4'))
+  })
+
   function connectionPool (driver, key) {
     return driver._connectionProvider._connectionPool._pools[key]
   }

--- a/test/resources/boltstub/v3/acquire_endpoints_self_as_reader.script
+++ b/test/resources/boltstub/v3/acquire_endpoints_self_as_reader.script
@@ -9,7 +9,7 @@ S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001","127.0.0.1:9009","127.0.0.1:9010"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9011"], "role": "ROUTE"}]]
    SUCCESS {}
 C: BEGIN {"mode": "r"}
-   RUN "MATCH (n) RETURN n.name AS name" {} {"mode": "r"}
+   RUN "MATCH (n) RETURN n.name AS name" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {"fields": ["name"]}

--- a/test/resources/boltstub/v3/read_tx.script
+++ b/test/resources/boltstub/v3/read_tx.script
@@ -5,7 +5,7 @@
 
 C: BEGIN {"mode": "r"}
 S: SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
+C: RUN "MATCH (n) RETURN n.name" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["n.name"]}
    RECORD ["Bob"]

--- a/test/resources/boltstub/v3/read_tx_dead.script
+++ b/test/resources/boltstub/v3/read_tx_dead.script
@@ -3,7 +3,7 @@
 !: AUTO RESET
 
 C: BEGIN {"mode": "r"}
-   RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
+   RUN "MATCH (n) RETURN n.name" {} {}
    PULL_ALL
 S: SUCCESS {"fields": []}
    <EXIT>

--- a/test/resources/boltstub/v3/read_tx_with_bookmarks.script
+++ b/test/resources/boltstub/v3/read_tx_with_bookmarks.script
@@ -4,7 +4,7 @@
 !: AUTO GOODBYE
 
 C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"], "mode": "r"}
-C: RUN "MATCH (n) RETURN n.name AS name" {} {"mode": "r"}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {"fields": ["name"]}

--- a/test/resources/boltstub/v3/write_tx_not_a_leader.script
+++ b/test/resources/boltstub/v3/write_tx_not_a_leader.script
@@ -9,5 +9,3 @@ C: BEGIN {}
 S: SUCCESS {}
    FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
    IGNORED
-C: COMMIT
-S: IGNORED

--- a/test/resources/boltstub/v4/hello_run_exit.script
+++ b/test/resources/boltstub/v4/hello_run_exit.script
@@ -4,7 +4,7 @@
 C: HELLO {"credentials": "password", "scheme": "basic", "user_agent": "neo4j-javascript/0.0.0-dev", "principal": "neo4j"}
 S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
 C: RUN "MATCH (n) RETURN n.name" {} {}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {"fields": ["n.name"]}
    RECORD ["Foo"]
    RECORD ["Bar"]

--- a/test/resources/boltstub/v4/query_with_error.script
+++ b/test/resources/boltstub/v4/query_with_error.script
@@ -3,7 +3,7 @@
 !: AUTO GOODBYE
 
 C: RUN "RETURN 10 / 0" {} {}
-C: PULL {"n": -1}
+C: PULL {"n": 1000}
 S: FAILURE {"code": "Neo.ClientError.Statement.ArithmeticError", "message": "/ by zero"}
 S: IGNORED
 C: RESET

--- a/test/resources/boltstub/v4/read.script
+++ b/test/resources/boltstub/v4/read.script
@@ -4,7 +4,7 @@
 !: AUTO GOODBYE
 
 C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {"fields": ["n.name"]}
    RECORD ["Bob"]
    RECORD ["Alice"]

--- a/test/resources/boltstub/v4/read_dead.script
+++ b/test/resources/boltstub/v4/read_dead.script
@@ -3,5 +3,5 @@
 !: AUTO RESET
 
 C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
-C: PULL {"n": -1}
+C: PULL {"n": 1000}
 S: <EXIT>

--- a/test/resources/boltstub/v4/read_discard.script
+++ b/test/resources/boltstub/v4/read_discard.script
@@ -1,0 +1,13 @@
+!: BOLT 4
+!: AUTO HELLO
+!: AUTO RESET
+!: AUTO GOODBYE
+
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
+   PULL {"n": 2}
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   SUCCESS {"has_more":true}
+C: DISCARD {"n": -1}
+S: SUCCESS {}

--- a/test/resources/boltstub/v4/read_from_aDatabase_with_bookmark.script
+++ b/test/resources/boltstub/v4/read_from_aDatabase_with_bookmark.script
@@ -4,7 +4,7 @@
 !: AUTO GOODBYE
 
 C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r", "db": "aDatabase", "bookmarks": ["system:1111", "aDatabase:5555"]}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {"fields": ["n.name"]}
    RECORD ["Bob"]
    RECORD ["Alice"]

--- a/test/resources/boltstub/v4/read_in_batch.script
+++ b/test/resources/boltstub/v4/read_in_batch.script
@@ -3,10 +3,12 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r", "db": "aDatabase"}
-   PULL {"n": 1000}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
+   PULL {"n": 2}
 S: SUCCESS {"fields": ["n.name"]}
    RECORD ["Bob"]
    RECORD ["Alice"]
-   RECORD ["Tina"]
+   SUCCESS {"has_more":true}
+C: PULL {"n": 2}
+S: RECORD ["Tina"]
    SUCCESS {}

--- a/test/resources/boltstub/v4/read_tx_discard.script
+++ b/test/resources/boltstub/v4/read_tx_discard.script
@@ -1,0 +1,17 @@
+!: BOLT 4
+!: AUTO HELLO
+!: AUTO RESET
+!: AUTO GOODBYE
+
+C: BEGIN {"mode": "r"}
+   RUN "MATCH (n) RETURN n.name" {} {}
+   PULL {"n": 2}
+S: SUCCESS {}
+   SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   SUCCESS {"has_more":true}
+C: DISCARD {"n": -1}
+S: SUCCESS {}
+C: COMMIT
+S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}

--- a/test/resources/boltstub/v4/read_tx_with_bookmarks.script
+++ b/test/resources/boltstub/v4/read_tx_with_bookmarks.script
@@ -5,7 +5,7 @@
 
 C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"], "mode": "r"}
 C: RUN "MATCH (n) RETURN n.name AS name" {} {"mode": "r"}
-   PULL { "n": -1 }
+   PULL { "n": 1000 }
 S: SUCCESS {}
    SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]

--- a/test/resources/boltstub/v4/read_tx_with_bookmarks.script
+++ b/test/resources/boltstub/v4/read_tx_with_bookmarks.script
@@ -4,7 +4,7 @@
 !: AUTO GOODBYE
 
 C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"], "mode": "r"}
-C: RUN "MATCH (n) RETURN n.name AS name" {} {"mode": "r"}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
    PULL { "n": 1000 }
 S: SUCCESS {}
    SUCCESS {"fields": ["name"]}

--- a/test/resources/boltstub/v4/reset_error.script
+++ b/test/resources/boltstub/v4/reset_error.script
@@ -3,7 +3,7 @@
 !: AUTO GOODBYE
 
 C: RUN "RETURN 42 AS answer" {} {}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {"fields": ["answer"]}
    RECORD [42]
    SUCCESS {}

--- a/test/resources/boltstub/v4/return_x.script
+++ b/test/resources/boltstub/v4/return_x.script
@@ -4,7 +4,7 @@
 !: AUTO GOODBYE
 
 C: RUN "RETURN $x" {"x": 1} {}
-   PULL { "n": -1 }
+   PULL { "n": 1000 }
 S: SUCCESS {"fields": ["x"]}
    RECORD [1]
    SUCCESS {}

--- a/test/resources/boltstub/v4/write.script
+++ b/test/resources/boltstub/v4/write.script
@@ -4,6 +4,6 @@
 !: AUTO GOODBYE
 
 C: RUN "CREATE (n {name:'Bob'})" {} {}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {"fields": []}
    SUCCESS {}

--- a/test/resources/boltstub/v4/write_read_tx_with_bookmarks.script
+++ b/test/resources/boltstub/v4/write_read_tx_with_bookmarks.script
@@ -5,7 +5,7 @@
 
 C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
    RUN "CREATE (n {name:'Bob'})" {} {}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {}
    SUCCESS {"fields": []}
    SUCCESS {}
@@ -13,7 +13,7 @@ C: COMMIT
 S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
 C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
    RUN "MATCH (n) RETURN n.name AS name" {} {}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {}
    SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]

--- a/test/resources/boltstub/v4/write_to_aDatabase.script
+++ b/test/resources/boltstub/v4/write_to_aDatabase.script
@@ -4,6 +4,6 @@
 !: AUTO GOODBYE
 
 C: RUN "CREATE (n {name:'Bob'})" {} {"db": "aDatabase"}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {"fields": []}
    SUCCESS {}

--- a/test/resources/boltstub/v4/write_tx_with_bookmarks.script
+++ b/test/resources/boltstub/v4/write_tx_with_bookmarks.script
@@ -5,7 +5,7 @@
 
 C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
 C: RUN "CREATE (n {name:'Bob'})" {} {}
-   PULL {"n": -1}
+   PULL {"n": 1000}
 S: SUCCESS {}
    SUCCESS {"fields": []}
    SUCCESS {}

--- a/test/rx/summary.test.js
+++ b/test/rx/summary.test.js
@@ -670,7 +670,7 @@ describe('#integration-rx summary', () => {
 
       const indices = await session.run('CALL db.indexes()')
       for (let i = 0; i < indices.records.length; i++) {
-        await session.run(`DROP ${getName(indices.records[i])}`)
+        await session.run(`DROP INDEX ${getName(indices.records[i])}`)
       }
     } finally {
       await session.close()

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -250,6 +250,7 @@ describe('#integration session', () => {
 
     session.run(statement).then(result => {
       const sum = result.summary
+      expect(result.records.length).toBe(10000)
       expect(sum.resultAvailableAfter.toInt()).not.toBeLessThan(0)
       expect(sum.resultConsumedAfter.toInt()).not.toBeLessThan(0)
       done()

--- a/test/types/transaction.test.ts
+++ b/test/types/transaction.test.ts
@@ -83,18 +83,10 @@ result4.subscribe({
   onCompleted: (summary: ResultSummary) => console.log(summary)
 })
 
-tx.commit()
-  .then((res: StatementResult) => {
-    console.log(res)
-  })
-  .catch((error: Error) => {
-    console.log(error)
-  })
+tx.commit().then(() => {
+  console.log('transaction committed')
+})
 
-tx.rollback()
-  .then((res: StatementResult) => {
-    console.log(res)
-  })
-  .catch((error: Error) => {
-    console.log(error)
-  })
+tx.rollback().then(() => {
+  console.log('transaction rolled back')
+})

--- a/types/driver.d.ts
+++ b/types/driver.d.ts
@@ -49,9 +49,11 @@ declare interface Config {
   trust?: TrustStrategy
   trustedCertificates?: string[]
   knownHosts?: string
+  fetchSize?: number
   maxConnectionPoolSize?: number
   maxTransactionRetryTime?: number
   maxConnectionLifetime?: number
+  connectionAcquisitionTimeout?: number
   connectionTimeout?: number
   disableLosslessIntegers?: boolean
   logging?: LoggingConfig
@@ -71,6 +73,7 @@ declare interface Driver {
   }?: {
     defaultAccessMode?: SessionMode
     bookmarks?: string | string[]
+    fetchSize?: number
     database?: string
   }): Session
 

--- a/types/transaction.d.ts
+++ b/types/transaction.d.ts
@@ -21,9 +21,9 @@ import Result from './result'
 import StatementRunner from './statement-runner'
 
 declare interface Transaction extends StatementRunner {
-  commit(): Result
+  commit(): Promise<void>
 
-  rollback(): Result
+  rollback(): Promise<void>
 
   isOpen(): boolean
 }


### PR DESCRIPTION
* Added fetchSize as an optional configuration option on driver config and session config.
* Allowed async to pull results in batches.
* Ensured `Transaction#commit` and `Transaction#rollback` to always finish query execution before commit/rollback.
* Fixed a bug where parameter `mode` and `database` shall not be send on `RUN` message of session run.
* Fixed some type errors in the type script