### PR TITLE
Ensures `records` cannot be visited after `summary` with reactive API.

### DIFF
--- a/src/result-rx.js
+++ b/src/result-rx.js
@@ -96,7 +96,7 @@ export default class RxResult {
    * @public
    * @returns {Observable<ResultSummary>} - An observable stream (with exactly one element) of result summary.
    */
-  summary () {
+  consume () {
     return this._result.pipe(
       flatMap(
         result =>
@@ -114,16 +114,16 @@ export default class RxResult {
   } = {}) {
     const subscriptions = []
 
-    if (recordsObserver) {
-      subscriptions.push(this._records.subscribe(recordsObserver))
-    }
-
     if (summaryObserver) {
       subscriptions.push(this._summary.subscribe(summaryObserver))
     }
 
     if (this._state < States.STREAMING) {
       this._state = States.STREAMING
+
+      if (recordsObserver) {
+        subscriptions.push(this._records.subscribe(recordsObserver))
+      }
 
       subscriptions.push({
         unsubscribe: () => {
@@ -156,10 +156,10 @@ export default class RxResult {
           this._state = States.COMPLETED
         }
       })
-    } else if (this._state === States.STREAMING && recordsObserver) {
+    } else if (recordsObserver) {
       recordsObserver.error(
         newError(
-          'Streaming has already started with a previous records or summary subscription.'
+          'Streaming has already started/consumed with a previous records or summary subscription.'
         )
       )
     }

--- a/test/internal/node/routing.driver.boltkit.test.js
+++ b/test/internal/node/routing.driver.boltkit.test.js
@@ -1477,7 +1477,7 @@ describe('#stub-routing routing driver with stub server', () => {
     const driver = boltStub.newDriver('neo4j://127.0.0.1:9010')
 
     // run a dummy query to force routing table initialization
-    const session = driver.session({ defaultAccessMode: READ })
+    var session = driver.session({ defaultAccessMode: READ })
     const result1 = await session.run('MATCH (n) RETURN n.name')
     expect(result1.records.length).toEqual(3)
     await session.close()
@@ -1491,6 +1491,7 @@ describe('#stub-routing routing driver with stub server', () => {
       9010
     )
 
+    session = driver.session({ defaultAccessMode: READ })
     const result2 = await session.readTransaction(tx =>
       tx.run('MATCH (n) RETURN n.name AS name')
     )

--- a/test/rx/summary.test.js
+++ b/test/rx/summary.test.js
@@ -249,7 +249,7 @@ describe('#integration-rx summary', () => {
 
     const summary = await runnable
       .run('UNWIND RANGE(1,10) AS n RETURN n')
-      .summary()
+      .consume()
       .toPromise()
 
     expect(summary).toBeDefined()
@@ -553,7 +553,7 @@ describe('#integration-rx summary', () => {
 
     const summary = await runnable
       .run('CREATE (n) RETURN n')
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.hasPlan()).toBeFalsy()
@@ -573,7 +573,7 @@ describe('#integration-rx summary', () => {
 
     const summary = await runnable
       .run('EXPLAIN CREATE (n) RETURN n')
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.hasPlan()).toBeTruthy()
@@ -594,7 +594,7 @@ describe('#integration-rx summary', () => {
 
     const summary = await runnable
       .run('PROFILE CREATE (n) RETURN n')
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.hasPlan()).toBeTruthy()
@@ -616,7 +616,7 @@ describe('#integration-rx summary', () => {
 
     const summary = await runnable
       .run('CREATE (n) RETURN n')
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.notifications).toBeTruthy()
@@ -634,7 +634,7 @@ describe('#integration-rx summary', () => {
 
     const summary = await runnable
       .run('EXPLAIN MATCH (n:ThisLabelDoesNotExist) RETURN n')
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.notifications).toBeTruthy()
@@ -664,7 +664,7 @@ describe('#integration-rx summary', () => {
   ) {
     const summary = await runnable
       .run(statement, parameters)
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.statement).toBeDefined()
@@ -685,7 +685,7 @@ describe('#integration-rx summary', () => {
   ) {
     const summary = await runnable
       .run(statement)
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.statementType).toBe(expectedStatementType)
@@ -701,7 +701,7 @@ describe('#integration-rx summary', () => {
   async function verifyUpdates (runnable, statement, parameters, stats) {
     const summary = await runnable
       .run(statement, parameters)
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.counters.containsUpdates()).toBeTruthy()
@@ -725,7 +725,7 @@ describe('#integration-rx summary', () => {
   ) {
     const summary = await runnable
       .run(statement, parameters)
-      .summary()
+      .consume()
       .toPromise()
     expect(summary).toBeDefined()
 

--- a/test/rx/transaction.test.js
+++ b/test/rx/transaction.test.js
@@ -535,7 +535,7 @@ describe('#integration-rx transaction', () => {
       )
     ])
 
-    const summary = await result.summary().toPromise()
+    const summary = await result.consume().toPromise()
     expect(summary).toBeTruthy()
   })
 
@@ -588,15 +588,15 @@ describe('#integration-rx transaction', () => {
 
     await txc
       .run('CREATE (n:Node {id: 1})')
-      .summary()
+      .consume()
       .toPromise()
     await txc
       .run('CREATE (n:Node {id: 2})')
-      .summary()
+      .consume()
       .toPromise()
     await txc
       .run('CREATE (n:Node {id: 1})')
-      .summary()
+      .consume()
       .toPromise()
 
     await verifyCanCommitOrRollback(txc, commit)

--- a/test/temporal-types.test.js
+++ b/test/temporal-types.test.js
@@ -1460,8 +1460,6 @@ describe('#integration temporal-types', () => {
 
     const receivedValue = records[0].get(0)
     expect(receivedValue).toEqual(value)
-
-    await session.close()
   }
 
   async function testDurationToString (values) {


### PR DESCRIPTION
Renames reactive result method `summary` to `consume`.
Adds more tests to ensure correct usage pattern for reactive API.
Bookmark is returned as `string[]`.