### PR TITLE
Extend URI configuration with schemes for encryption/trust

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -31,6 +31,7 @@ import {
 import Session from './session'
 import RxSession from './session-rx'
 import { ALL } from './internal/request-message'
+import { ENCRYPTION_ON, ENCRYPTION_OFF } from './internal/util'
 
 const DEFAULT_MAX_CONNECTION_LIFETIME = 60 * 60 * 1000 // 1 hour
 
@@ -134,6 +135,34 @@ class Driver {
   supportsTransactionConfig () {
     const connectionProvider = this._getOrCreateConnectionProvider()
     return connectionProvider.supportsTransactionConfig()
+  }
+
+  /**
+   * @protected
+   * @returns {boolean}
+   */
+  _supportsRouting () {
+    return false
+  }
+
+  /**
+   * Returns boolean to indicate if driver has been configured with encryption enabled.
+   *
+   * @protected
+   * @returns {boolean}
+   */
+  _isEncrypted () {
+    return this._config.encrypted === ENCRYPTION_ON
+  }
+
+  /**
+   * Returns the configured trust strategy that the driver has been configured with.
+   *
+   * @protected
+   * @returns {TrustStrategy}
+   */
+  _getTrust () {
+    return this._config.trust
   }
 
   /**

--- a/src/routing-driver.js
+++ b/src/routing-driver.js
@@ -52,6 +52,10 @@ class RoutingDriver extends Driver {
       authToken: authToken
     })
   }
+
+  _supportsRouting () {
+    return true
+  }
 }
 
 /**

--- a/test/internal/node/tls.test.js
+++ b/test/internal/node/tls.test.js
@@ -57,6 +57,20 @@ describe('#integration trust', () => {
           done()
         })
     })
+
+    it('should work with default certificate using URL scheme', done => {
+      // Given
+      driver = neo4j.driver('bolt+ssc://localhost', sharedNeo4j.authToken)
+
+      // When
+      driver
+        .session()
+        .run('RETURN 1')
+        .then(result => {
+          expect(result.records[0].get(0).toNumber()).toBe(1)
+          done()
+        })
+    })
   })
 
   describe('trust-custom-ca-signed-certificates', () => {
@@ -117,6 +131,20 @@ describe('#integration trust', () => {
         encrypted: true,
         trust: 'TRUST_SYSTEM_CA_SIGNED_CERTIFICATES'
       })
+
+      // When
+      driver
+        .session()
+        .run('RETURN 1')
+        .catch(err => {
+          expect(err.message).toContain('Server certificate is not trusted')
+          done()
+        })
+    })
+
+    it('should reject unknown certificates using URL scheme', done => {
+      // Given
+      driver = neo4j.driver('bolt+s://localhost', sharedNeo4j.authToken)
 
       // When
       driver


### PR DESCRIPTION
4 additional connection schemes:

- bolt+s and neo4j+s which enables encryption and configures the trust settings to use the local system's certificate store
- bolt+ssc and neo4j+ssc which configures trust to use all certificates
