### PR TITLE
Fixing the js driver doc generation

### DIFF
--- a/src/record.js
+++ b/src/record.js
@@ -110,7 +110,7 @@ class Record {
    * of exactly two items - the key, and the value (in order).
    *
    * @generator
-   * @returns {IterableIterator<[string, Object]>}
+   * @returns {IterableIterator<Array>}
    */
   * entries () {
     for (let i = 0; i < this.keys.length; i++) {


### PR DESCRIPTION
esdoc cannot handle `[string`