### PR TITLE
Only override neo4j config when it is really needed

### DIFF
--- a/test/internal/shared-neo4j.js
+++ b/test/internal/shared-neo4j.js
@@ -134,9 +134,6 @@ const tlsConfig = {
 }
 
 const defaultConfig = {
-  // Turn off backup related ports, etc.
-  'dbms.backup.enabled': 'false',
-
   // tell neo4j to listen for IPv6 connections, only supported by 3.1+
   'dbms.connectors.default_listen_address': '::',
 
@@ -145,9 +142,6 @@ const defaultConfig = {
 
   // shorten the default time to wait for the bookmark from 30 to 5 seconds
   'dbms.transaction.bookmark_ready_timeout': '5s',
-
-  // page cache size
-  'dbms.memory.pagecache.size': '512m',
 
   // make TLS optional
   'dbms.connector.bolt.tls_level': tlsConfig.levels.optional


### PR DESCRIPTION
Way too large pagecache is configured, boltkit sets up a cachesize of
30MB. That should be enough.