### PR TITLE
Sanitize authority token to improve connection error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -228,6 +228,10 @@ function driver (url, authToken, config = {}) {
     config.trust = trust
   }
 
+  // Sanitize authority token. Nicer error from server when a scheme is set.
+  authToken = authToken || {}
+  authToken.scheme = authToken.scheme || 'none'
+
   if (routing) {
     return new RoutingDriver(
       ServerAddress.fromUrl(parsedUrl.hostAndPort),


### PR DESCRIPTION
Error message received from neo4j server looks a bit better when scheme
is explicitly set to 'none' instead of being undefined.