### PR TITLE
Plan/Profile fixes for neo4j server 4.1

### DIFF
--- a/test/rx/summary.test.js
+++ b/test/rx/summary.test.js
@@ -571,7 +571,7 @@ describe('#integration-rx summary', () => {
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.hasPlan()).toBeTruthy()
-    expect(summary.plan.operatorType).toBe('ProduceResults')
+    expect(summary.plan.operatorType).toContain('ProduceResults')
     expect(summary.plan.identifiers).toEqual(['n'])
     expect(summary.hasProfile()).toBeFalsy()
     expect(summary.profile).toBeFalsy()
@@ -592,10 +592,10 @@ describe('#integration-rx summary', () => {
       .toPromise()
     expect(summary).toBeDefined()
     expect(summary.hasPlan()).toBeTruthy()
-    expect(summary.plan.operatorType).toBe('ProduceResults')
+    expect(summary.plan.operatorType).toContain('ProduceResults')
     expect(summary.plan.identifiers).toEqual(['n'])
     expect(summary.hasProfile()).toBeTruthy()
-    expect(summary.profile.operatorType).toBe('ProduceResults')
+    expect(summary.profile.operatorType).toContain('ProduceResults')
     expect(summary.profile.identifiers).toEqual(['n'])
   }
 
@@ -727,25 +727,18 @@ describe('#integration-rx summary', () => {
   }
 
   async function dropConstraintsAndIndices (driver) {
-    function getName (record) {
-      const obj = record.toObject()
-      const name = obj.description || obj.name
-      if (!name) {
-        throw new Error('unable to identify name of the constraint/index')
-      }
-      return name
-    }
-
     const session = driver.session()
     try {
       const constraints = await session.run('CALL db.constraints()')
       for (let i = 0; i < constraints.records.length; i++) {
-        await session.run(`DROP ${getName(constraints.records[i])}`)
+        const name = constraints.records[i].toObject().name
+        await session.run('DROP CONSTRAINT ' + name) // ${getName(constraints.records[i])}`)
       }
 
       const indices = await session.run('CALL db.indexes()')
       for (let i = 0; i < indices.records.length; i++) {
-        await session.run(`DROP INDEX ${getName(indices.records[i])}`)
+        const name = indices.records[i].toObject().name
+        await session.run('DROP INDEX ' + name) // ${getName(constraints.records[i])}`)
       }
     } finally {
       await session.close()

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -688,7 +688,7 @@ describe('#integration session', () => {
   })
 
   it('should not commit already committed write transaction', done => {
-    const resultPromise = session.readTransaction(tx => {
+    const resultPromise = session.writeTransaction(tx => {
       return new Promise((resolve, reject) => {
         tx.run('CREATE (n:Node {id: 42}) RETURN n.id AS answer')
           .then(result => {
@@ -747,7 +747,7 @@ describe('#integration session', () => {
 
   it('should not commit rolled back write transaction', done => {
     const bookmarkBefore = session.lastBookmark()
-    const resultPromise = session.readTransaction(tx => {
+    const resultPromise = session.writeTransaction(tx => {
       return new Promise((resolve, reject) => {
         tx.run('CREATE (n:Node {id: 42}) RETURN n.id AS answer')
           .then(result => {


### PR DESCRIPTION
Format of operator type has changed in server 4.1. Fix so that tests
accepts old and new format.

Also use correct read/write transaction as fabric has stricter checks for this.

Also remove obsolete index/constraint syntax as preparation.