### PR TITLE
Ignore keep-alive chunks sent by server

### DIFF
--- a/src/internal/chunking.js
+++ b/src/internal/chunking.js
@@ -177,10 +177,18 @@ class Dechunker {
     if (header === 0) {
       // Message boundary
       let message
-      if (this._currentMessage.length === 1) {
-        message = this._currentMessage[0]
-      } else {
-        message = new CombinedBuffer(this._currentMessage)
+      switch (this._currentMessage.length) {
+        case 0:
+          // Keep alive chunk, sent by server to keep network alive.
+          return this.AWAITING_CHUNK
+        case 1:
+          // All data in one chunk, this signals the end of that chunk.
+          message = this._currentMessage[0]
+          break
+        default:
+          // A large chunk of data received, this signals that the last chunk has been received.
+          message = new CombinedBuffer(this._currentMessage)
+          break
       }
       this._currentMessage = []
       this.onmessage(message)

--- a/test/internal/chunking.test.js
+++ b/test/internal/chunking.test.js
@@ -65,7 +65,7 @@ describe('#unit Chunker', () => {
   })
 })
 
-describe('Dechunker', () => {
+describe('#unit Dechunker', () => {
   it('should unchunk a simple message', () => {
     // Given
     const messages = []
@@ -123,6 +123,26 @@ describe('Dechunker', () => {
       expect(messages.length).toBe(1)
       expect(messages[0].toHex()).toBe('01 00 02 00 00 00 03 04 00 00 00 05')
     }
+  })
+
+  it('should ignore empty chunks sent as keep alive', () => {
+    const messages = []
+    const dechunker = new Dechunker()
+    dechunker.onmessage = buffer => {
+      messages.push(buffer)
+    }
+
+    dechunker.write(bytes(0, 0)) // Empty
+    dechunker.write(bytes(0, 1, 10, 0, 0)) // Small message
+    dechunker.write(bytes(0, 0)) // Empty
+    dechunker.write(bytes(0, 1, 11, 0, 0)) // Small message
+    dechunker.write(bytes(0, 0)) // Empty
+
+    expect(messages.length).toBe(2)
+    expect(messages[0].length).toBe(1)
+    expect(messages[0].readInt8()).toBe(10)
+    expect(messages[1].length).toBe(1)
+    expect(messages[1].readInt8()).toBe(11)
   })
 })
 


### PR DESCRIPTION
New 4.1 feature, server can keep connections alive by periodically
sending empty chunks. This should be ignored by chunking layer.