### PR TITLE
Send connect address to routing procedure

### DIFF
--- a/src/internal/connection-provider-routing.js
+++ b/src/internal/connection-provider-routing.js
@@ -58,7 +58,9 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
 
     this._seedRouter = address
     this._routingTables = {}
-    this._rediscovery = new Rediscovery(new RoutingUtil(routingContext))
+    this._rediscovery = new Rediscovery(
+      new RoutingUtil(routingContext, address.toString())
+    )
     this._loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy(
       this._connectionPool
     )

--- a/test/internal/fake-connection.js
+++ b/test/internal/fake-connection.js
@@ -69,8 +69,10 @@ export default class FakeConnection extends Connection {
   }
 
   protocol () {
-    // return fake protocol object that simply records seen queries and parameters
+    // return fake protocol object that simply records seen queries and parameters and provide
+    // a protocol version
     return {
+      version: this.version === 'Neo4j/4.0.0' ? 4 : 3,
       run: (query, parameters, protocolOptions) => {
         this.seenQueries.push(query)
         this.seenParameters.push(parameters)

--- a/test/internal/node/routing.driver.boltkit.test.js
+++ b/test/internal/node/routing.driver.boltkit.test.js
@@ -2225,21 +2225,21 @@ describe('#stub-routing routing driver with stub server', () => {
       // Given
       const router1 = await boltStub.start(
         './test/resources/boltstub/v4/acquire_endpoints_aDatabase_no_servers.script',
-        9001
+        9002
       )
       const router2 = await boltStub.start(
         './test/resources/boltstub/v4/acquire_endpoints_aDatabase.script',
-        9002
+        9003
       )
       const reader1 = await boltStub.start(
         './test/resources/boltstub/v4/read_from_aDatabase.script',
         9005
       )
 
-      const driver = boltStub.newDriver('neo4j://127.0.0.1:9000', {
+      const driver = boltStub.newDriver('neo4j://127.0.0.1:9001', {
         resolver: address => [
-          'neo4j://127.0.0.1:9001',
-          'neo4j://127.0.0.1:9002'
+          'neo4j://127.0.0.1:9002',
+          'neo4j://127.0.0.1:9003'
         ]
       })
 

--- a/test/internal/routing-util.test.js
+++ b/test/internal/routing-util.test.js
@@ -37,6 +37,58 @@ import {
 
 const ROUTER_ADDRESS = ServerAddress.fromUrl('test.router.com:4242')
 
+class FakeSession {
+  constructor (runResponse, fakeConnection) {
+    this._runResponse = runResponse
+    this._fakeConnection = fakeConnection
+    this._closed = false
+  }
+
+  static successful (result) {
+    return new FakeSession(Promise.resolve(result), null)
+  }
+
+  static failed (error) {
+    return new FakeSession(Promise.reject(error), null)
+  }
+
+  static withFakeConnection (connection) {
+    return new FakeSession(null, connection)
+  }
+
+  _run (ignoreQuery, ignoreParameters, queryRunner) {
+    if (this._runResponse) {
+      return this._runResponse
+    }
+    queryRunner(this._fakeConnection)
+    return Promise.resolve()
+  }
+
+  withBookmark (bookmark) {
+    this._lastBookmark = bookmark
+    return this
+  }
+
+  withDatabase (database) {
+    this._database = database || ''
+    return this
+  }
+
+  withMode (mode) {
+    this._mode = mode
+    return this
+  }
+
+  close () {
+    this._closed = true
+    return Promise.resolve()
+  }
+
+  isClosed () {
+    return this._closed
+  }
+}
+
 describe('#unit RoutingUtil', () => {
   it('should return retrieved records when query succeeds', done => {
     const session = FakeSession.successful({ records: ['foo', 'bar', 'baz'] })
@@ -185,7 +237,7 @@ describe('#unit RoutingUtil', () => {
         'CALL dbms.routing.getRoutingTable($context, $database)'
       ])
       expect(connection.seenParameters).toEqual([
-        { context: {}, database: null }
+        { context: { address: '127.0.0.1' }, database: null }
       ])
       expect(connection.seenProtocolOptions).toEqual([
         jasmine.objectContaining({
@@ -212,7 +264,7 @@ describe('#unit RoutingUtil', () => {
         'CALL dbms.routing.getRoutingTable($context, $database)'
       ])
       expect(connection.seenParameters).toEqual([
-        { context: {}, database: null }
+        { context: { address: '127.0.0.1' }, database: null }
       ])
       expect(connection.seenProtocolOptions).toEqual([
         jasmine.objectContaining({
@@ -238,7 +290,7 @@ describe('#unit RoutingUtil', () => {
         'CALL dbms.routing.getRoutingTable($context, $database)'
       ])
       expect(connection.seenParameters).toEqual([
-        { context: {}, database: null }
+        { context: { address: '127.0.0.1' }, database: null }
       ])
       expect(connection.seenProtocolOptions).toEqual([
         jasmine.objectContaining({
@@ -259,6 +311,18 @@ describe('#unit RoutingUtil', () => {
       verifyBookmark(
         new Bookmark(['bookmark1', ['bookmark2'], ['bookmark3', 'bookmark4']])
       ))
+  })
+
+  it('should pass initial address while invoking routing procedure', async () => {
+    const connection = new FakeConnection().withServerVersion('Neo4j/4.0.0')
+    const session = FakeSession.withFakeConnection(connection)
+    const util = new RoutingUtil({}, 'initialAddr')
+
+    await util.callRoutingProcedure(session, '', ROUTER_ADDRESS)
+
+    expect(connection.seenParameters).toEqual([
+      { context: { address: 'initialAddr' }, database: null }
+    ])
   })
 
   it('should parse valid ttl', () => {
@@ -451,7 +515,7 @@ describe('#unit RoutingUtil', () => {
   }
 
   function callRoutingProcedure (session, database, routingContext) {
-    const util = new RoutingUtil(routingContext || {})
+    const util = new RoutingUtil(routingContext || {}, '127.0.0.1')
     return util.callRoutingProcedure(session, database, ROUTER_ADDRESS)
   }
 
@@ -502,57 +566,5 @@ describe('#unit RoutingUtil', () => {
       expect(error.code).toBe(PROTOCOL_ERROR)
       done()
     })
-  }
-
-  class FakeSession {
-    constructor (runResponse, fakeConnection) {
-      this._runResponse = runResponse
-      this._fakeConnection = fakeConnection
-      this._closed = false
-    }
-
-    static successful (result) {
-      return new FakeSession(Promise.resolve(result), null)
-    }
-
-    static failed (error) {
-      return new FakeSession(Promise.reject(error), null)
-    }
-
-    static withFakeConnection (connection) {
-      return new FakeSession(null, connection)
-    }
-
-    _run (ignoreQuery, ignoreParameters, queryRunner) {
-      if (this._runResponse) {
-        return this._runResponse
-      }
-      queryRunner(this._fakeConnection)
-      return Promise.resolve()
-    }
-
-    withBookmark (bookmark) {
-      this._lastBookmark = bookmark
-      return this
-    }
-
-    withDatabase (database) {
-      this._database = database || ''
-      return this
-    }
-
-    withMode (mode) {
-      this._mode = mode
-      return this
-    }
-
-    close () {
-      this._closed = true
-      return Promise.resolve()
-    }
-
-    isClosed () {
-      return this._closed
-    }
   }
 })

--- a/test/resources/boltstub/v4/acquire_endpoints_aDatabase.script
+++ b/test/resources/boltstub/v4/acquire_endpoints_aDatabase.script
@@ -3,7 +3,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}, "database": "aDatabase"} {"mode": "r", "db": "system"}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {"address": "127.0.0.1:9001"}, "database": "aDatabase"} {"mode": "r", "db": "system"}
    PULL {"n": -1}
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/v4/acquire_endpoints_aDatabase_no_servers.script
+++ b/test/resources/boltstub/v4/acquire_endpoints_aDatabase_no_servers.script
@@ -3,7 +3,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}, "database":"aDatabase"} {"mode": "r", "db": "system"}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {"address": "127.0.0.1:9001"}, "database":"aDatabase"} {"mode": "r", "db": "system"}
    PULL {"n": -1}
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, []]

--- a/test/resources/boltstub/v4/acquire_endpoints_aDatabase_with_bookmark.script
+++ b/test/resources/boltstub/v4/acquire_endpoints_aDatabase_with_bookmark.script
@@ -3,7 +3,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}, "database": "aDatabase"} {"mode": "r", "db": "system", "bookmarks": ["system:1111", "aDatabase:5555"]}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {"address":"127.0.0.1:9001"}, "database": "aDatabase"} {"mode": "r", "db": "system", "bookmarks": ["system:1111", "aDatabase:5555"]}
    PULL {"n": -1}
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/resources/boltstub/v4/acquire_endpoints_db_not_found.script
+++ b/test/resources/boltstub/v4/acquire_endpoints_db_not_found.script
@@ -3,7 +3,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}, "database": "aDatabase"} {"mode": "r", "db": "system"}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {"address": "127.0.0.1:9001"}, "database": "aDatabase"} {"mode": "r", "db": "system"}
    PULL {"n": -1}
 S: FAILURE {"code": "Neo.ClientError.Database.DatabaseNotFound", "message": "database not found"}
    IGNORED

--- a/test/resources/boltstub/v4/acquire_endpoints_default_database.script
+++ b/test/resources/boltstub/v4/acquire_endpoints_default_database.script
@@ -3,7 +3,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}, "database": null} {"mode": "r", "db": "system"}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {"address": "127.0.0.1:9001"}, "database": null} {"mode": "r", "db": "system"}
    PULL {"n": -1}
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -41,7 +41,7 @@ describe('#integration session', () => {
     driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
     session = driver.session()
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 70000
 
     serverVersion = await sharedNeo4j.cleanupAndGetVersion(driver)
   })

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -48,6 +48,7 @@ describe('#integration session', () => {
 
   afterEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
+    await session.close()
     await driver.close()
   })
 


### PR DESCRIPTION
Backporting 4.1 functionality that sends drivers configured address in the routing context to make single instances work without special neo4j server config.