### PR TITLE
4.1 gulp set version fix (#598)

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -153,8 +153,11 @@ gulp.task(
 
 /** Set the project version, controls package.json and version.js */
 gulp.task('set', function () {
-  // Get the --version arg from command line
-  const version = minimist(process.argv.slice(2), { string: 'version' }).version
+  // example: gulp set --x 4.0.2
+
+  // Get the --x arg from command line
+  const command = minimist(process.argv.slice(2), { string: 'x' })
+  const version = command.x
 
   if (!semver.valid(version)) {
     throw new Error(`Invalid version "${version}"`)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "neo4j-driver",
-  "version": "2.0.0-dev",
-  "description": "Connect to Neo4j 3.0.0 and up from JavaScript",
+  "version": "4.0.0-dev",
+  "description": "Connect to Neo4j 3.4.0 and up from JavaScript",
   "author": "Neo4j",
   "license": "Apache-2.0",
   "repository": {
@@ -18,7 +18,7 @@
     "run-stress-tests": "gulp run-stress-tests",
     "run-ts-declaration-tests": "gulp run-ts-declaration-tests",
     "docs": "esdoc -c esdoc.json",
-    "versionRelease": "gulp set --version $VERSION && npm version $VERSION --no-git-tag-version",
+    "versionRelease": "gulp set --x $VERSION && npm version $VERSION --no-git-tag-version",
     "browser": "gulp browser && gulp test-browser"
   },
   "husky": {

--- a/src/version.js
+++ b/src/version.js
@@ -19,7 +19,8 @@
 
 // DO NOT CHANGE THE VERSION BELOW HERE
 // This is set by the build system at release time, using
-//   gulp set --version <releaseversion>
+//
+// gulp set --x <releaseversion>
 //
 // This is set up this way to keep the version in the code in
 // sync with the npm package version, and to allow the build


### PR DESCRIPTION
* fixed gulp set --version

the --version and -v is gulp specific arguments and cant be used for
task arguments.

changed the argument to --x

old:

gulp set --version 4.0.0

new:

gulp set --x 4.0.0

* fixed the npm run versionRelease command to use new gulp set command

script that updates 'src/version.js' and package.json'

VERSION=$VERSION npm run versionRelease