### PR TITLE
Update uri-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15452,9 +15452,9 @@
       "dev": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
     "@babel/runtime": "^7.5.5",
     "rxjs": "^6.6.3",
     "text-encoding-utf-8": "^1.0.2",
-    "uri-js": "^4.2.2"
+    "uri-js": "^4.4.0"
   }
 }

--- a/src/internal/url-util.js
+++ b/src/internal/url-util.js
@@ -77,9 +77,20 @@ function parseDatabaseUrl (url) {
   const formattedHost = formatHost(host) // has square brackets for IPv6
   const port = extractPort(parsedUrl.port, scheme)
   const hostAndPort = `${formattedHost}:${port}`
-  const query = extractQuery(parsedUrl.query, url)
+  const query = extractQuery(
+    parsedUrl.query || extractResourceQueryString(parsedUrl.resourceName),
+    url
+  )
 
   return new Url(scheme, host, port, hostAndPort, query)
+}
+
+function extractResourceQueryString (resource) {
+  if (typeof resource !== 'string') {
+    return null
+  }
+  const [_, query] = resource.split('?')
+  return query
 }
 
 function sanitizeUrl (url) {


### PR DESCRIPTION
The new version of `uri-js` is not extracting the query params when the protocol is `ws` or `wss`, the query is being treated as
`resourceName` together with the resource path.

In maner to update this library version, a small patch was applied to handle this especial case.

(See https://github.com/garycourt/uri-js#wswss-support)