### PR TITLE
Supporting browser, integration and stress tests on testkit

### DIFF
--- a/test/bolt-v3.test.js
+++ b/test/bolt-v3.test.js
@@ -37,7 +37,10 @@ describe('#integration Bolt V3 API', () => {
   let originalTimeout
 
   beforeEach(async () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.session()
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
@@ -52,7 +55,7 @@ describe('#integration Bolt V3 API', () => {
   })
 
   it('should set transaction metadata for auto-commit transaction', async () => {
-    if (!databaseSupportsBoltV3()) {
+    if (!databaseSupportsBoltV3() || !databaseSupportsListTransaction()) {
       return
     }
 
@@ -144,7 +147,7 @@ describe('#integration Bolt V3 API', () => {
     ))
 
   it('should set transaction metadata for explicit transactions', async () => {
-    if (!databaseSupportsBoltV3()) {
+    if (!databaseSupportsBoltV3() || !databaseSupportsListTransaction()) {
       return
     }
 
@@ -395,7 +398,7 @@ describe('#integration Bolt V3 API', () => {
   })
 
   async function testTransactionMetadataWithTransactionFunctions (read) {
-    if (!databaseSupportsBoltV3()) {
+    if (!databaseSupportsBoltV3() || !databaseSupportsListTransaction()) {
       return
     }
 
@@ -497,5 +500,9 @@ describe('#integration Bolt V3 API', () => {
 
   function databaseSupportsBoltV3 () {
     return protocolVersion >= 3
+  }
+
+  function databaseSupportsListTransaction () {
+    return sharedNeo4j.edition === 'enterprise'
   }
 })

--- a/test/bolt-v4x0.test.js
+++ b/test/bolt-v4x0.test.js
@@ -27,7 +27,10 @@ describe('#integration Bolt V4.0 API', () => {
   let originalTimeout
 
   beforeEach(async () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.session()
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000

--- a/test/browser/karma-chrome.conf.js
+++ b/test/browser/karma-chrome.conf.js
@@ -41,6 +41,9 @@ module.exports = function (config) {
     autoWatch: false,
     singleRun: true,
     concurrency: 1,
-    browserNoActivityTimeout: 30 * 60 * 1000
+    browserNoActivityTimeout: 30 * 60 * 1000,
+    client: {
+      env: process.env
+    }
   })
 }

--- a/test/browser/karma-firefox.conf.js
+++ b/test/browser/karma-firefox.conf.js
@@ -50,6 +50,9 @@ module.exports = function (config) {
           'network.websocket.max-connections': 256 // as in Chrome
         }
       }
+    },
+    client: {
+      env: process.env
     }
   })
 }

--- a/test/driver.test.js
+++ b/test/driver.test.js
@@ -39,40 +39,58 @@ describe('#unit driver', () => {
   })
 
   it('should create an unencrypted, non-routed driver for scheme: bolt', () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     expect(driver._isEncrypted()).toBeFalsy()
     expect(driver._supportsRouting()).toBeFalsy()
   })
 
   it('should create an encrypted, system CAs trusting, non-routed driver for scheme: bolt+s', () => {
-    driver = neo4j.driver('bolt+s://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt+s://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     expect(driver._isEncrypted()).toBeTruthy()
     expect(driver._getTrust()).toEqual('TRUST_SYSTEM_CA_SIGNED_CERTIFICATES')
     expect(driver._supportsRouting()).toBeFalsy()
   })
 
   it('should create an encrypted, all trusting, non-routed driver for scheme: bolt+ssc', () => {
-    driver = neo4j.driver('bolt+ssc://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt+ssc://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     expect(driver._isEncrypted()).toBeTruthy()
     expect(driver._getTrust()).toEqual('TRUST_ALL_CERTIFICATES')
     expect(driver._supportsRouting()).toBeFalsy()
   })
 
   it('should create an unencrypted, routed driver for scheme: neo4j', () => {
-    driver = neo4j.driver('neo4j://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `neo4j://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     expect(driver._isEncrypted()).toBeFalsy()
     expect(driver._supportsRouting()).toBeTruthy()
   })
 
   it('should create an encrypted, system CAs trusting, routed driver for scheme: neo4j+s', () => {
-    driver = neo4j.driver('neo4j+s://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `neo4j+s://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     expect(driver._isEncrypted()).toBeTruthy()
     expect(driver._getTrust()).toEqual('TRUST_SYSTEM_CA_SIGNED_CERTIFICATES')
     expect(driver._supportsRouting()).toBeTruthy()
   })
 
   it('should create an encrypted, all trusting, routed driver for scheme: neo4j+ssc', () => {
-    driver = neo4j.driver('neo4j+ssc://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `neo4j+ssc://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     expect(driver._isEncrypted()).toBeTruthy()
     expect(driver._getTrust()).toEqual('TRUST_ALL_CERTIFICATES')
     expect(driver._supportsRouting()).toBeTruthy()
@@ -80,13 +98,17 @@ describe('#unit driver', () => {
 
   it('should throw when encryption in url AND in config', () => {
     expect(() =>
-      neo4j.driver('neo4j+ssc://localhost', sharedNeo4j.authToken, {
-        encrypted: 'ENCRYPTION_OFF'
-      })
+      neo4j.driver(
+        `neo4j+ssc://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken,
+        {
+          encrypted: 'ENCRYPTION_OFF'
+        }
+      )
     ).toThrow()
     // Throw even in case where there is no conflict
     expect(() =>
-      neo4j.driver('neo4j+s://localhost', sharedNeo4j.authToken, {
+      neo4j.driver(`neo4j+s://${sharedNeo4j.hostname}`, sharedNeo4j.authToken, {
         encrypted: 'ENCRYPTION_ON'
       })
     ).toThrow()
@@ -98,7 +120,10 @@ describe('#integration driver', () => {
   let protocolVersion
 
   beforeAll(async () => {
-    const tmpDriver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const tmpDriver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     protocolVersion = await sharedNeo4j.cleanupAndGetProtocolVersion(tmpDriver)
     await tmpDriver.close()
   })
@@ -117,7 +142,11 @@ describe('#integration driver', () => {
       connectionAcquisitionTimeout: 0,
       encrypted: false
     }
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, config)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken,
+      config
+    )
 
     function beginTxWithoutCommit (driver) {
       const session = driver.session()
@@ -146,7 +175,10 @@ describe('#integration driver', () => {
 
   it('should expose sessions', () => {
     // Given
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
 
     // When
     const session = driver.session()
@@ -177,7 +209,10 @@ describe('#integration driver', () => {
       return
     }
 
-    driver = neo4j.driver('bolt://localhost:80', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}:80`,
+      sharedNeo4j.authToken
+    )
 
     driver
       .session()
@@ -206,20 +241,22 @@ describe('#integration driver', () => {
 
   it('should handle wrong scheme', () => {
     expect(() =>
-      neo4j.driver('tank://localhost', sharedNeo4j.authToken)
+      neo4j.driver(`tank://${sharedNeo4j.hostname}`, sharedNeo4j.authToken)
     ).toThrow(new Error('Unknown scheme: tank'))
   })
 
   it('should handle URL parameter string', () => {
-    expect(() => neo4j.driver({ uri: 'bolt://localhost' })).toThrowError(
+    expect(() =>
+      neo4j.driver({ uri: `bolt://${sharedNeo4j.hostname}` })
+    ).toThrowError(TypeError)
+
+    expect(() => neo4j.driver([`bolt:${sharedNeo4j.hostname}`])).toThrowError(
       TypeError
     )
 
-    expect(() => neo4j.driver(['bolt:localhost'])).toThrowError(TypeError)
-
     expect(() => {
       const driver = neo4j.driver(
-        String('bolt://localhost'),
+        String(`bolt://${sharedNeo4j.hostname}`),
         sharedNeo4j.authToken
       )
       return driver.session()
@@ -228,7 +265,7 @@ describe('#integration driver', () => {
 
   it('should fail early on wrong credentials', async () => {
     // Given
-    driver = neo4j.driver('bolt://localhost', wrongCredentials())
+    driver = neo4j.driver(`bolt://${sharedNeo4j.hostname}`, wrongCredentials())
     const session = driver.session()
     const txc = session.beginTransaction()
 
@@ -242,7 +279,7 @@ describe('#integration driver', () => {
   })
 
   it('should fail queries on wrong credentials', done => {
-    driver = neo4j.driver('bolt://localhost', wrongCredentials())
+    driver = neo4j.driver(`bolt://${sharedNeo4j.hostname}`, wrongCredentials())
 
     const session = driver.session()
     session.run('RETURN 1').catch(error => {
@@ -253,7 +290,10 @@ describe('#integration driver', () => {
 
   it('should indicate success early on correct credentials', done => {
     // Given
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
 
     // Expect
     driver.verifyConnectivity().then(server => {
@@ -265,7 +305,7 @@ describe('#integration driver', () => {
   it('should be possible to pass a realm with basic auth tokens', done => {
     // Given
     driver = neo4j.driver(
-      'bolt://localhost',
+      `bolt://${sharedNeo4j.hostname}`,
       neo4j.auth.basic(sharedNeo4j.username, sharedNeo4j.password, 'native')
     )
 
@@ -279,7 +319,7 @@ describe('#integration driver', () => {
   it('should be possible to create custom auth tokens', done => {
     // Given
     driver = neo4j.driver(
-      'bolt://localhost',
+      `bolt://${sharedNeo4j.hostname}`,
       neo4j.auth.custom(
         sharedNeo4j.username,
         sharedNeo4j.password,
@@ -298,7 +338,7 @@ describe('#integration driver', () => {
   it('should be possible to create custom auth tokens with additional parameters', done => {
     // Given
     driver = neo4j.driver(
-      'bolt://localhost',
+      `bolt://${sharedNeo4j.hostname}`,
       neo4j.auth.custom(
         sharedNeo4j.username,
         sharedNeo4j.password,
@@ -321,7 +361,10 @@ describe('#integration driver', () => {
     }
 
     // Given
-    driver = neo4j.driver('neo4j://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `neo4j://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const session = driver.session()
 
     await expectAsync(session.run('RETURN 1')).toBeRejectedWith(
@@ -335,18 +378,18 @@ describe('#integration driver', () => {
   })
 
   it('should have correct user agent', async () => {
-    const directDriver = neo4j.driver('bolt://localhost')
+    const directDriver = neo4j.driver(`bolt://${sharedNeo4j.hostname}`)
     expect(directDriver._userAgent).toBe('neo4j-javascript/0.0.0-dev')
     await directDriver.close()
 
-    const routingDriver = neo4j.driver('neo4j://localhost')
+    const routingDriver = neo4j.driver(`neo4j://${sharedNeo4j.hostname}`)
     expect(routingDriver._userAgent).toBe('neo4j-javascript/0.0.0-dev')
     await routingDriver.close()
   })
 
   it('should fail when bolt:// scheme used with routing params', () => {
     expect(() =>
-      neo4j.driver('bolt://localhost:7687/?policy=my_policy')
+      neo4j.driver(`bolt://${sharedNeo4j.hostname}:7687/?policy=my_policy`)
     ).toThrow()
   })
 
@@ -369,7 +412,7 @@ describe('#integration driver', () => {
 
   it('should fail when fetch size is negative', () => {
     expect(() =>
-      neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
+      neo4j.driver(`bolt://${sharedNeo4j.hostname}`, sharedNeo4j.authToken, {
         fetchSize: -77
       })
     ).toThrow()
@@ -377,12 +420,17 @@ describe('#integration driver', () => {
 
   it('should fail when fetch size is 0', () => {
     expect(() =>
-      neo4j.driver('bolt://localhost', sharedNeo4j.authToken, { fetchSize: 0 })
+      neo4j.driver(`bolt://${sharedNeo4j.hostname}`, sharedNeo4j.authToken, {
+        fetchSize: 0
+      })
     ).toThrow()
   })
 
   it('should discard closed connections', async () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
 
     const session1 = driver.session()
     await session1.run('CREATE () RETURN 42')
@@ -408,9 +456,13 @@ describe('#integration driver', () => {
 
   it('should discard old connections', async () => {
     const maxLifetime = 100000
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-      maxConnectionLifetime: maxLifetime
-    })
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken,
+      {
+        maxConnectionLifetime: maxLifetime
+      }
+    )
 
     const session1 = driver.session()
     await session1.run('CREATE () RETURN 42')
@@ -457,11 +509,13 @@ describe('#integration driver', () => {
     })
   })
 
-  it('should connect to IPv6 address without port', done => {
+  const itIpv6 = sharedNeo4j.ipv6Enabled ? it : xit
+
+  itIpv6('should connect to IPv6 address without port', done => {
     testIPv6Connection('bolt://[::1]', done)
   })
 
-  it('should connect to IPv6 address with port', done => {
+  itIpv6('should connect to IPv6 address with port', done => {
     testIPv6Connection('bolt://[::1]:7687', done)
   })
 
@@ -525,9 +579,13 @@ describe('#integration driver', () => {
   }
 
   function testNumberInReturnedRecord (inputNumber, expectedNumber, done) {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-      disableLosslessIntegers: true
-    })
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken,
+      {
+        disableLosslessIntegers: true
+      }
+    )
 
     const session = driver.session()
     session
@@ -583,7 +641,7 @@ describe('#integration driver', () => {
     expectedValue
   ) {
     const driver = neo4j.driver(
-      'bolt://localhost',
+      `bolt://${sharedNeo4j.hostname}`,
       sharedNeo4j.authToken,
       config
     )

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -45,7 +45,7 @@ describe('#integration examples', () => {
 
   const user = sharedNeo4j.username
   const password = sharedNeo4j.password
-  const uri = 'bolt://localhost:7687'
+  const uri = `bolt://${sharedNeo4j.hostname}:7687`
 
   beforeAll(() => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
@@ -201,7 +201,8 @@ describe('#integration examples', () => {
     await driver.close()
   })
 
-  it('config trust example', async () => {
+  /// TODO: re-enable it
+  xit('config trust example', async () => {
     // tag::config-trust[]
     const driver = neo4j.driver(uri, neo4j.auth.basic(user, password), {
       encrypted: 'ENCRYPTION_ON',
@@ -633,7 +634,7 @@ describe('#integration examples', () => {
   it('service unavailable example', done => {
     const console = consoleOverride
     const consoleLoggedMsg = consoleOverridePromise
-    const uri = 'bolt://localhost:7688' // wrong port
+    const uri = `bolt://${sharedNeo4j.hostname}:7688` // wrong port
     const password = 'wrongPassword'
 
     // tag::service-unavailable[]

--- a/test/internal/connection-channel.test.js
+++ b/test/internal/connection-channel.test.js
@@ -57,7 +57,7 @@ describe('#integration ChannelConnection', () => {
     try {
       clock.setSystemTime(424242)
 
-      connection = createConnection('bolt://localhost')
+      connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
       expect(connection.creationTimestamp).toEqual(424242)
     } finally {
@@ -66,7 +66,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should read/write basic messages', done => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection._negotiateProtocol().then(() => {
       connection.protocol().initialize({
@@ -82,7 +82,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should retrieve stream', done => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     const records = []
     const pullAllObserver = {
@@ -133,7 +133,9 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should provide error message when connecting to http-port', done => {
-    connection = createConnection('bolt://localhost:7474', { encrypted: false })
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}:7474`, {
+      encrypted: false
+    })
 
     connection.connect('mydriver/0.0.0', basicAuthToken()).catch(error => {
       expect(error).toBeDefined()
@@ -178,7 +180,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should notify when connection initialization completes', done => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection
       .connect('mydriver/0.0.0', basicAuthToken())
@@ -189,7 +191,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should notify when connection initialization fails', done => {
-    connection = createConnection('bolt://localhost:7474') // wrong port
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}:7474`) // wrong port
 
     connection
       .connect('mydriver/0.0.0', basicAuthToken())
@@ -201,7 +203,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should have server version after connection initialization completed', done => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection
       .connect('mydriver/0.0.0', basicAuthToken())
@@ -214,7 +216,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should fail all new observers after failure to connect', done => {
-    connection = createConnection('bolt://localhost:7474') // wrong port
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}:7474`) // wrong port
 
     connection
       .connect('mydriver/0.0.0', basicAuthToken())
@@ -274,7 +276,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should reset and flush when SUCCESS received', done => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection.connect('my-driver/1.2.3', basicAuthToken()).then(() => {
       connection
@@ -295,7 +297,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should fail to reset and flush when FAILURE received', done => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection.connect('my-driver/1.2.3', basicAuthToken()).then(() => {
       connection
@@ -320,7 +322,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should fail to reset and flush when RECORD received', done => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection.connect('my-driver/1.2.3', basicAuthToken()).then(() => {
       connection
@@ -345,7 +347,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should acknowledge failure with RESET when SUCCESS received', done => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection.connect('my-driver/1.2.3', basicAuthToken()).then(() => {
       connection._currentFailure = newError('Hello')
@@ -377,7 +379,7 @@ describe('#integration ChannelConnection', () => {
     )
 
     connection = ChannelConnection.create(
-      ServerAddress.fromUrl('bolt://localhost'),
+      ServerAddress.fromUrl(`bolt://${sharedNeo4j.hostname}`),
       {},
       errorHandler,
       Logger.noOp()
@@ -398,7 +400,7 @@ describe('#integration ChannelConnection', () => {
 
   it('should send INIT/HELLO and GOODBYE messages', async () => {
     const messages = []
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
     recordWrittenMessages(connection, messages)
 
     await connection.connect('mydriver/0.0.0', basicAuthToken())
@@ -416,7 +418,7 @@ describe('#integration ChannelConnection', () => {
   })
 
   it('should not prepare broken connection to close', async () => {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     await connection.connect('my-connection/9.9.9', basicAuthToken())
     expect(connection._protocol).toBeDefined()
@@ -503,7 +505,7 @@ describe('#integration ChannelConnection', () => {
   }
 
   function testQueueingOfObserversWithBrokenConnection (connectionAction, done) {
-    connection = createConnection('bolt://localhost')
+    connection = createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection._negotiateProtocol().then(() => {
       connection._handleMessage(ILLEGAL_MESSAGE)

--- a/test/internal/logger.test.js
+++ b/test/internal/logger.test.js
@@ -79,7 +79,7 @@ describe('#integration Logger', () => {
     const logged = []
     const config = memorizingLoggerConfig(logged)
     const driver = neo4j.driver(
-      'bolt://localhost',
+      `bolt://${sharedNeo4j.hostname}`,
       sharedNeo4j.authToken,
       config
     )
@@ -111,9 +111,13 @@ describe('#integration Logger', () => {
     const logged = []
     console.log = message => logged.push(message)
 
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-      logging: neo4j.logging.console('debug')
-    })
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken,
+      {
+        logging: neo4j.logging.console('debug')
+      }
+    )
 
     try {
       const session = driver.session()
@@ -144,9 +148,13 @@ describe('#integration Logger', () => {
     const logged = []
     console.log = message => logged.push(message)
 
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-      logging: neo4j.logging.console()
-    }) // info is the default level
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken,
+      {
+        logging: neo4j.logging.console()
+      }
+    ) // info is the default level
 
     try {
       const session = driver.session()

--- a/test/internal/node/encryption.test.js
+++ b/test/internal/node/encryption.test.js
@@ -20,7 +20,8 @@
 import neo4j from '../../../src'
 import sharedNeo4j from '../shared-neo4j'
 
-describe('#integration encryption', () => {
+// Moved to testkit
+xdescribe('#integration encryption', () => {
   let originalTimeout
 
   beforeEach(() => {
@@ -80,7 +81,7 @@ describe('#integration encryption', () => {
       config.trust = trust
     }
     const driver = neo4j.driver(
-      'bolt://localhost',
+      `bolt://${sharedNeo4j.hostname}`,
       sharedNeo4j.authToken,
       config
     )

--- a/test/internal/node/tls.test.js
+++ b/test/internal/node/tls.test.js
@@ -20,9 +20,13 @@
 import neo4j from '../../../src'
 import sharedNeo4j from '../shared-neo4j'
 
-describe('#integration trust', () => {
+// It's alread covered by testkit
+xdescribe('#integration trust', () => {
   beforeAll(async () => {
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     try {
       await sharedNeo4j.cleanupAndGetProtocolVersion(driver)
     } finally {
@@ -41,10 +45,14 @@ describe('#integration trust', () => {
 
     it('should work with default certificate', done => {
       // Given
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-        encrypted: 'ENCRYPTION_ON',
-        trust: 'TRUST_ALL_CERTIFICATES'
-      })
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken,
+        {
+          encrypted: 'ENCRYPTION_ON',
+          trust: 'TRUST_ALL_CERTIFICATES'
+        }
+      )
 
       // When
       driver
@@ -58,7 +66,10 @@ describe('#integration trust', () => {
 
     it('should work with default certificate using URL scheme', done => {
       // Given
-      driver = neo4j.driver('bolt+ssc://localhost', sharedNeo4j.authToken)
+      driver = neo4j.driver(
+        `bolt+ssc://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
 
       // When
       driver
@@ -82,11 +93,15 @@ describe('#integration trust', () => {
 
     it('should reject unknown certificates', done => {
       // Given
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-        encrypted: true,
-        trust: 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES',
-        trustedCertificates: ['test/resources/random.certificate']
-      })
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken,
+        {
+          encrypted: true,
+          trust: 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES',
+          trustedCertificates: ['test/resources/random.certificate']
+        }
+      )
 
       // When
       driver
@@ -100,11 +115,15 @@ describe('#integration trust', () => {
 
     it('should accept known certificates', done => {
       // Given
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-        encrypted: true,
-        trust: 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES',
-        trustedCertificates: [sharedNeo4j.neo4jCertPath()]
-      })
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken,
+        {
+          encrypted: true,
+          trust: 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES',
+          trustedCertificates: [sharedNeo4j.neo4jCertPath()]
+        }
+      )
 
       // When
       driver
@@ -125,10 +144,14 @@ describe('#integration trust', () => {
 
     it('should reject unknown certificates', done => {
       // Given
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-        encrypted: true,
-        trust: 'TRUST_SYSTEM_CA_SIGNED_CERTIFICATES'
-      })
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken,
+        {
+          encrypted: true,
+          trust: 'TRUST_SYSTEM_CA_SIGNED_CERTIFICATES'
+        }
+      )
 
       // When
       driver
@@ -142,7 +165,10 @@ describe('#integration trust', () => {
 
     it('should reject unknown certificates using URL scheme', done => {
       // Given
-      driver = neo4j.driver('bolt+s://localhost', sharedNeo4j.authToken)
+      driver = neo4j.driver(
+        `bolt+s://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
 
       // When
       driver
@@ -156,9 +182,13 @@ describe('#integration trust', () => {
 
     it('should reject unknown certificates if trust not specified', done => {
       // Given
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-        encrypted: true
-      })
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken,
+        {
+          encrypted: true
+        }
+      )
 
       // When
       driver

--- a/test/internal/server-version.test.js
+++ b/test/internal/server-version.test.js
@@ -153,7 +153,10 @@ describe('#unit ServerVersion', () => {
 
 describe('#integration ServerVersion', () => {
   it('should fetch version using driver', async () => {
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const version = await ServerVersion.fromDriver(driver)
     await driver.close()
 
@@ -163,7 +166,10 @@ describe('#integration ServerVersion', () => {
   })
 
   it('should fail to fetch version using incorrect driver', async () => {
-    const driver = neo4j.driver('bolt://localhost:4242', sharedNeo4j.authToken) // use wrong port
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}:4242`,
+      sharedNeo4j.authToken
+    ) // use wrong port
 
     await expectAsync(ServerVersion.fromDriver(driver)).toBeRejected()
 

--- a/test/internal/shared-neo4j.js
+++ b/test/internal/shared-neo4j.js
@@ -118,9 +118,16 @@ class SupportedPlatform extends UnsupportedPlatform {
 }
 
 const platform = SupportedPlatform.create() || new UnsupportedPlatform()
+const env = global.__karma__ ? global.__karma__.config.env : process.env
 
-const username = 'neo4j'
-const password = 'password'
+const username = env.TEST_NEO4J_USER || 'neo4j'
+const password = env.TEST_NEO4J_PASS || 'password'
+const hostname = env.TEST_NEO4J_HOST || 'localhost'
+const edition = env.TEST_NEO4J_EDITION || 'enterprise'
+const ipv6Enabled =
+  env.TEST_NEO4J_IPV6_ENABLED !== undefined
+    ? env.TEST_NEO4J_IPV6_ENABLED.toUpperCase() === 'TRUE'
+    : true
 const authToken = neo4j.auth.basic(username, password)
 
 const tlsConfig = {
@@ -359,5 +366,8 @@ export default {
   logging: debugLogging,
   cleanupAndGetProtocolVersion: cleanupAndGetProtocolVersion,
   tlsConfig: tlsConfig,
-  getEdition: getEdition
+  getEdition: getEdition,
+  hostname: hostname,
+  ipv6Enabled: ipv6Enabled,
+  edition: edition
 }

--- a/test/nested-statements.test.js
+++ b/test/nested-statements.test.js
@@ -48,7 +48,10 @@ describe('#integration session', () => {
   let originalTimeout
 
   beforeEach(async () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.session({ fetchSize: 2 })
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000

--- a/test/result.test.js
+++ b/test/result.test.js
@@ -25,7 +25,10 @@ describe('#integration result stream', () => {
   let driver, session
 
   beforeEach(async () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.session()
 
     await sharedNeo4j.cleanupAndGetProtocolVersion(driver)

--- a/test/rx/navigation.test.js
+++ b/test/rx/navigation.test.js
@@ -33,7 +33,10 @@ describe('#integration-rx navigation', () => {
     let originalTimeout
 
     beforeEach(async () => {
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
       session = driver.rxSession()
       originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
       jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
@@ -125,7 +128,10 @@ describe('#integration-rx navigation', () => {
     let originalTimeout
 
     beforeEach(async () => {
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
       session = driver.rxSession()
       txc = await session.beginTransaction().toPromise()
       originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL

--- a/test/rx/nested-statements.test.js
+++ b/test/rx/nested-statements.test.js
@@ -39,7 +39,10 @@ describe('#integration-rx transaction', () => {
   let protocolVersion
 
   beforeEach(async () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.rxSession()
 
     protocolVersion = await sharedNeo4j.cleanupAndGetProtocolVersion(driver)

--- a/test/rx/session.test.js
+++ b/test/rx/session.test.js
@@ -34,7 +34,10 @@ describe('#integration rx-session', () => {
   beforeEach(async () => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.rxSession()
 
     protocolVersion = await sharedNeo4j.cleanupAndGetProtocolVersion(driver)

--- a/test/rx/summary.test.js
+++ b/test/rx/summary.test.js
@@ -30,7 +30,10 @@ describe('#integration-rx summary', () => {
     let protocolVersion
 
     beforeEach(async () => {
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
       session = driver.rxSession()
 
       protocolVersion = await sharedNeo4j.cleanupAndGetProtocolVersion(driver)
@@ -120,7 +123,10 @@ describe('#integration-rx summary', () => {
     let protocolVersion
 
     beforeEach(async () => {
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
       session = driver.rxSession()
       txc = await session.beginTransaction().toPromise()
 
@@ -217,7 +223,10 @@ describe('#integration-rx summary', () => {
     let protocolVersion
 
     beforeEach(async () => {
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
       session = driver.rxSession({ database: 'system' })
       //
 

--- a/test/rx/transaction.test.js
+++ b/test/rx/transaction.test.js
@@ -40,7 +40,10 @@ describe('#integration-rx transaction', () => {
   let protocolVersion
 
   beforeEach(async () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.rxSession()
 
     protocolVersion = await sharedNeo4j.cleanupAndGetProtocolVersion(driver)

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -38,7 +38,10 @@ describe('#integration session', () => {
   let originalTimeout
 
   beforeEach(async () => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.session()
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 70000
@@ -107,7 +110,10 @@ describe('#integration session', () => {
   })
 
   it('should be possible to close driver after closing session with failed tx ', done => {
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const session = driver.session()
     const tx = session.beginTransaction()
     tx.run('INVALID QUERY').catch(() => {
@@ -236,7 +242,7 @@ describe('#integration session', () => {
     session.run(query).then(result => {
       const sum = result.summary
       expect(sum.server).toBeDefined()
-      expect(sum.server.address).toEqual('localhost:7687')
+      expect(sum.server.address).toEqual(`${sharedNeo4j.hostname}:7687`)
       expect(sum.server.version).toBeDefined()
       done()
     })
@@ -1239,7 +1245,9 @@ describe('#integration session', () => {
 
   function numberOfAcquiredConnectionsFromPool () {
     const pool = driver._connectionProvider._connectionPool
-    return pool.activeResourceCount(ServerAddress.fromUrl('localhost:7687'))
+    return pool.activeResourceCount(
+      ServerAddress.fromUrl(`${sharedNeo4j.hostname}:7687`)
+    )
   }
 
   function testConnectionTimeout (encrypted, done) {

--- a/test/spatial-types.test.js
+++ b/test/spatial-types.test.js
@@ -35,9 +35,12 @@ describe('#integration spatial-types', () => {
   let protocolVersion
 
   beforeAll(() => {
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     driverWithNativeNumbers = neo4j.driver(
-      'bolt://localhost',
+      `bolt://${sharedNeo4j.hostname}`,
       sharedNeo4j.authToken,
       { disableLosslessIntegers: true }
     )

--- a/test/stress.test.js
+++ b/test/stress.test.js
@@ -44,7 +44,7 @@ describe('#integration stress tests', () => {
   const TEST_MODE = modeFromEnvOrDefault('STRESS_TEST_MODE')
   const DATABASE_URI = fromEnvOrDefault(
     'STRESS_TEST_DATABASE_URI',
-    'bolt://localhost'
+    `bolt://${sharedNeo4j.hostname}`
   )
 
   const USERNAME = fromEnvOrDefault(

--- a/test/summary.test.js
+++ b/test/summary.test.js
@@ -25,7 +25,10 @@ describe('#integration result summary', () => {
     let driver, session
 
     beforeEach(done => {
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
       session = driver.session()
 
       session.run('MATCH (n) DETACH DELETE n').then(done)
@@ -60,9 +63,13 @@ describe('#integration result summary', () => {
     let driver, session
 
     beforeEach(done => {
-      driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken, {
-        disableLosslessIntegers: true
-      })
+      driver = neo4j.driver(
+        `bolt://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken,
+        {
+          disableLosslessIntegers: true
+        }
+      )
       session = driver.session()
 
       session.run('MATCH (n) DETACH DELETE n').then(done)

--- a/test/temporal-types.test.js
+++ b/test/temporal-types.test.js
@@ -58,9 +58,12 @@ describe('#integration temporal-types', () => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
 
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     driverWithNativeNumbers = neo4j.driver(
-      'bolt://localhost',
+      `bolt://${sharedNeo4j.hostname}`,
       sharedNeo4j.authToken,
       { disableLosslessIntegers: true }
     )

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -34,7 +34,10 @@ describe('#integration transaction', () => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
 
-    driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     session = driver.session()
 
     const result = await session.run('MATCH (n) DETACH DELETE n')
@@ -458,7 +461,7 @@ describe('#integration transaction', () => {
       .then(result => {
         const sum = result.summary
         expect(sum.server).toBeDefined()
-        expect(sum.server.address).toEqual('localhost:7687')
+        expect(sum.server.address).toEqual(`${sharedNeo4j.hostname}:7687`)
         expect(sum.server.version).toBeDefined()
         tx.commit().then(done)
       })
@@ -478,7 +481,7 @@ describe('#integration transaction', () => {
         const server = summary.server
 
         expect(server).toBeDefined()
-        expect(server.address).toEqual('localhost:7687')
+        expect(server.address).toEqual(`${sharedNeo4j.hostname}:7687`)
         expect(server.version).toBeDefined()
 
         done()

--- a/test/types.test.js
+++ b/test/types.test.js
@@ -102,7 +102,10 @@ describe('#integration map values', () => {
 describe('#integration node values', () => {
   it('should support returning nodes ', done => {
     // Given
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const session = driver.session()
 
     // When
@@ -123,7 +126,10 @@ describe('#integration node values', () => {
 describe('#integration relationship values', () => {
   it('should support returning relationships', done => {
     // Given
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const session = driver.session()
 
     // When
@@ -144,7 +150,10 @@ describe('#integration relationship values', () => {
 describe('#integration path values', () => {
   it('should support returning paths', done => {
     // Given
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const session = driver.session()
 
     // When
@@ -209,7 +218,10 @@ describe('#integration byte arrays', () => {
   })
 
   it('should fail to return byte array if server does not support byte arrays', done => {
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const session = driver.session()
     session
       .run('RETURN $array', { array: randomByteArray(42) })
@@ -225,7 +237,10 @@ describe('#integration byte arrays', () => {
 
 function testValue (actual, expected) {
   return done => {
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const queryPromise = runReturnQuery(driver, actual, expected)
 
     queryPromise
@@ -237,7 +252,10 @@ function testValue (actual, expected) {
 
 function testValues (values) {
   return done => {
-    const driver = neo4j.driver('bolt://localhost', sharedNeo4j.authToken)
+    const driver = neo4j.driver(
+      `bolt://${sharedNeo4j.hostname}`,
+      sharedNeo4j.authToken
+    )
     const queriesPromise = values.reduce(
       (acc, value) => acc.then(() => runReturnQuery(driver, value)),
       Promise.resolve()


### PR DESCRIPTION
Teskit doesn't run Neo4j on the localhost and with the same credentials of boltkit, but it exposes
the host and credentials as env variables.

So all this configuration being loaded to karma on the config files, parsed in `shared-neo4j` with fallback to
the process env (case it's running the usual integration test) and to the default boltkit values.

All the integration tests were changed to use the values from the shareNeo4j object.

Disabled tests:
* IPV6 tests are skipped on the testkit because of the lack of support for this
* TLS tests are disabled since it's already tested on the testkit suite
* Tests which depends on the enterprise edition of Neo4j is running only on this scenario