### PR TITLE
Disable secure connection warning when the window.protocol is not available

### DIFF
--- a/src/internal/browser/browser-channel.js
+++ b/src/internal/browser/browser-channel.js
@@ -323,7 +323,9 @@ function isProtocolSecure (protocolSupplier) {
 }
 
 function verifyEncryptionSettings (encryptionOn, encryptionOff, secureProtocol) {
-  if (encryptionOn && !secureProtocol) {
+  if (secureProtocol === null) {
+    // do nothing sice the protocol could not be identified
+  } else if (encryptionOn && !secureProtocol) {
     // encryption explicitly turned on for a driver used on a HTTP web page
     console.warn(
       'Neo4j driver is configured to use secure WebSocket on a HTTP web page. ' +


### PR DESCRIPTION
The window.location is not available in the WebWorkers contexts and because of the driver keeps wrongly warning about a misconfiguration.
If the information location protocol is not available, the driver should not warning.