### PR TITLE
testkit: Update NodeJS version in the Dockerfile

### DIFF
--- a/test/rx/transaction.test.js
+++ b/test/rx/transaction.test.js
@@ -693,7 +693,7 @@ describe('#integration-rx transaction', () => {
       .toPromise()
     expect(result).toEqual([
       Notification.createError(
-        jasmine.stringMatching(/Unexpected end of input/)
+        jasmine.stringMatching(/Unexpected end of input|Invalid input/)
       )
     ])
   }

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -387,13 +387,14 @@ describe('#integration session', () => {
               'Query failed after a long running query was terminated',
               error
             )
+            done.fail.bind(done)
           })
       })
 
     // wait some time than close the session with a long running query
     setTimeout(() => {
       session.close().catch(done.fail.bind(done))
-    }, 1000)
+    }, 200)
   }, 70000)
 
   /* flaky

--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -1,18 +1,30 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
         git \
         curl \
         python3 \
-        firefox \
         nodejs \
-        npm \
+        npm \ 
+        firefox \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g npm \
     && /bin/bash -c 'hash -d npm'
 RUN npm install -g gulp
+
+# Enable tls v1.0
+RUN echo "openssl_conf = openssl_configuration\n"|cat - /etc/ssl/openssl.cnf > /tmp/openssl_conf.cnf \  
+    && mv /tmp/openssl_conf.cnf /etc/ssl/openssl.cnf  
+RUN echo "[openssl_configuration]\n\
+ssl_conf = ssl_configuration\n\
+[ssl_configuration]\n\
+system_default = tls_system_default\n\
+[tls_system_default]\n\
+CipherString = DEFAULT:@SECLEVEL=1" >> /etc/ssl/openssl.cnf 
 
 # Install our own CAs on the image.
 # Assumes Linux Debian based image.

--- a/testkit/stress.py
+++ b/testkit/stress.py
@@ -11,4 +11,4 @@ if __name__ == "__main__":
     os.environ['STRESS_TEST_MODE'] = 'fastest'
     os.environ['RUNNING_TIME_IN_SECONDS'] = \
         os.environ.get('TEST_NEO4J_STRESS_DURATION', 0)
-    run(["npm", "run", "run-stress-tests"])
+    run(["gulp", "run-stress-tests-without-jasmine"])


### PR DESCRIPTION
The support for the `NodeJS 8.x` was dropped and the `npm update` was failing because of that.

The NodeJS upgrade is being done to `10.x` since it's the oldest version in maintenance.

This update was done by updating the Ubuntu version since the other of updates was broken the TLS configuration. Along with this, the TLS 1.0 was enable in the OpenSSL config since it is disabled by default in this ubuntu's version.