### PR TITLE
Fix connection close by server treatment by WebSocket channels

### DIFF
--- a/src/v1/internal/browser/browser-channel.js
+++ b/src/v1/internal/browser/browser-channel.js
@@ -31,7 +31,11 @@ export default class WebSocketChannel {
    * @param {ChannelConfig} config - configuration for this channel.
    * @param {function(): string} protocolSupplier - function that detects protocol of the web page. Should only be used in tests.
    */
-  constructor (config, protocolSupplier = detectWebPageProtocol) {
+  constructor (
+    config,
+    protocolSupplier = detectWebPageProtocol,
+    socketFactory = createWebSocket
+  ) {
     this._open = true
     this._pending = []
     this._error = null
@@ -44,7 +48,7 @@ export default class WebSocketChannel {
       return
     }
 
-    this._ws = createWebSocket(scheme, config.address)
+    this._ws = socketFactory(scheme, config.address)
     this._ws.binaryType = 'arraybuffer'
 
     const self = this

--- a/src/v1/internal/browser/browser-channel.js
+++ b/src/v1/internal/browser/browser-channel.js
@@ -47,20 +47,21 @@ export default class WebSocketChannel {
     this._ws = createWebSocket(scheme, config.address)
     this._ws.binaryType = 'arraybuffer'
 
-    let self = this
+    const self = this
     // All connection errors are not sent to the error handler
     // we must also check for dirty close calls
     this._ws.onclose = function (e) {
       if (!e.wasClean) {
         self._handleConnectionError()
       }
+      self._open = false
     }
     this._ws.onopen = function () {
       // Connected! Cancel the connection timeout
       self._clearConnectionTimeout()
 
       // Drain all pending messages
-      let pending = self._pending
+      const pending = self._pending
       self._pending = null
       for (let i = 0; i < pending.length; i++) {
         self.write(pending[i])


### PR DESCRIPTION
The lack of set channel._open to false when the `onclose` event is triggered was causing the channel to be broken without the other parts of the driver noticed. In this way, the next iteration trying to get the broken connection will succeed in the trial, and run the query will result in an eternal pending promise.

Mark the channel as closed enable the pool to discard and create a new connection if needed.