### PR TITLE
Fix connection close by server treatment by WebSocket channels (#684)

### DIFF
--- a/src/internal/browser/browser-channel.js
+++ b/src/internal/browser/browser-channel.js
@@ -65,6 +65,7 @@ export default class WebSocketChannel {
       if (e && !e.wasClean) {
         self._handleConnectionError()
       }
+      self._open = false
     }
     this._ws.onopen = function () {
       // Connected! Cancel the connection timeout


### PR DESCRIPTION
The lack of set channel._open to false when the onclose event is triggered was causing the channel be broken without the other parts of the driver notice. In tbis way, a next iteration trying to get the broken connection will succeded in the try and run the query will result in a eternal pending promise.

Mark the channel as closed enable the pool to discard and create a new connection if it needed.