### PR TITLE
Fix connection close by server treatment by WebSocket channels (#684)

### DIFF
--- a/src/internal/browser/browser-channel.js
+++ b/src/internal/browser/browser-channel.js
@@ -65,6 +65,7 @@ export default class WebSocketChannel {
       if (e && !e.wasClean) {
         self._handleConnectionError()
       }
+      self._open = false
     }
     this._ws.onopen = function () {
       // Connected! Cancel the connection timeout

--- a/test/internal/browser/browser-channel.test.js
+++ b/test/internal/browser/browser-channel.test.js
@@ -23,7 +23,6 @@ import { SERVICE_UNAVAILABLE } from '../../../src/error'
 import { setTimeoutMock } from '../timers-util'
 import { ENCRYPTION_OFF, ENCRYPTION_ON } from '../../../src/internal/util'
 import ServerAddress from '../../../src/internal/server-address'
-import { read } from 'fs'
 
 const WS_CONNECTING = 0
 const WS_OPEN = 1
@@ -266,9 +265,32 @@ describe('#unit WebSocketChannel', () => {
     }
   }
 
+  it('should set _open to false when connection closes', async () => {
+    const fakeSetTimeout = setTimeoutMock.install()
+    try {
+      // do not execute setTimeout callbacks
+      fakeSetTimeout.pause()
+      const address = ServerAddress.fromUrl('bolt://localhost:8989')
+      const driverConfig = { connectionTimeout: 4242 }
+      const channelConfig = new ChannelConfig(
+        address,
+        driverConfig,
+        SERVICE_UNAVAILABLE
+      )
+      webSocketChannel = new WebSocketChannel(
+        channelConfig,
+        undefined,
+        createWebSocketFactory(WS_OPEN)
+      )
+      webSocketChannel._ws.close()
+      expect(webSocketChannel._open).toBe(false)
+    } finally {
+      fakeSetTimeout.uninstall()
+    }
+  })
+
   function createWebSocketFactory (readyState) {
     const ws = {}
-
     ws.readyState = readyState
     ws.close = () => {
       ws.readyState = WS_CLOSED
@@ -276,7 +298,6 @@ describe('#unit WebSocketChannel', () => {
         ws.onclose({ wasClean: true })
       }
     }
-
     return url => {
       ws.url = url
       return ws


### PR DESCRIPTION
The lack of set channel._open to false when the onclose event is triggered was causing the channel be broken without the other parts of the driver notice. In tbis way, a next iteration trying to get the broken connection will succeded in the try and run the query will result in a eternal pending promise.

Mark the channel as closed enable the pool to discard and create a new connection if it needed.