### PR TITLE
testkit-backend: Fix cypherToNative to use int for CypherInt

### DIFF
--- a/testkit-backend/cypher-native-binders.js
+++ b/testkit-backend/cypher-native-binders.js
@@ -1,4 +1,4 @@
-import neo4j from 'neo4j-driver'
+import neo4j, { int } from 'neo4j-driver'
 
 export function valueResponse (name, value) {
   return { name: name, data: { value: value } }
@@ -58,7 +58,7 @@ export function cypherToNative (c) {
     case 'CypherString':
       return value
     case 'CypherInt':
-      return value
+      return int(value)
     case 'CypherFloat':
       return value
     case 'CypherNull':


### PR DESCRIPTION
The lack of conversion was making `SessionRunParameters.test_combined` fail in the stricted mode