### PR TITLE
testkit-backend: add support to the StartTest message

### DIFF
--- a/testkit-backend/src/request-handlers.js
+++ b/testkit-backend/src/request-handlers.js
@@ -212,3 +212,8 @@ export function SessionWriteTransaction (context, data, wire) {
     .then(_ => wire.writeResponse('RetryableDone', null))
     .catch(error => wire.writeError(error))
 }
+
+export function StartTest (_, { testName }, wire) {
+  console.log(`>>> Starting test ${testName}`)
+  wire.writeResponse('RunTest', null)
+}


### PR DESCRIPTION
This protocol message is used to decide which test should run or skip, the lack of implementation of this protocol message make the testkit fails.