### PR TITLE
testkit-backend: Move all the skipTest to backend

### DIFF
--- a/bolt-connection/package-lock.json
+++ b/bolt-connection/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
+        "ts-jest": "^26.5.4",
         "typescript": "^4.1.3"
       }
     },
@@ -24,9 +25,6 @@
       "name": "neo4j-driver-core",
       "version": "4.3.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "uri-js": "^4.4.1"
-      },
       "devDependencies": {
         "@types/jest": "^26.0.20",
         "esdoc": "^1.1.0",
@@ -1351,6 +1349,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -3757,6 +3767,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -3865,6 +3881,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -5775,6 +5803,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "26.5.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.4.tgz",
+      "integrity": "sha512-I5Qsddo+VTm94SukBJ4cPimOoFZsYTeElR2xy6H2TOVs+NsvgYglW8KuQgKoApOKuaU/Ix/vrF9ebFZlb5D2Pg==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^26.1.0",
+        "json5": "2.x",
+        "lodash": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "jest": ">=26 <27",
+        "typescript": ">=3.8 <5.0"
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -7322,6 +7402,15 @@
         "electron-to-chromium": "^1.3.649",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.70"
+      }
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -9209,6 +9298,12 @@
         "semver": "^6.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -9295,6 +9390,12 @@
         "is-extendable": "^1.0.1"
       }
     },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -9336,8 +9437,7 @@
         "jest": "^26.6.3",
         "ts-jest": "^26.5.1",
         "ts-node": "^9.1.1",
-        "typescript": "^4.1.3",
-        "uri-js": "^4.4.1"
+        "typescript": "^4.1.3"
       }
     },
     "nice-try": {
@@ -10818,6 +10918,41 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
+      }
+    },
+    "ts-jest": {
+      "version": "26.5.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.4.tgz",
+      "integrity": "sha512-I5Qsddo+VTm94SukBJ4cPimOoFZsYTeElR2xy6H2TOVs+NsvgYglW8KuQgKoApOKuaU/Ix/vrF9ebFZlb5D2Pg==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^26.1.0",
+        "json5": "2.x",
+        "lodash": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
+        }
       }
     },
     "tunnel-agent": {

--- a/bolt-connection/package.json
+++ b/bolt-connection/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "jest": "^26.6.3",
+    "ts-jest": "^26.5.4",
     "typescript": "^4.1.3"
   },
   "dependencies": {

--- a/neo4j-driver-lite/package.json
+++ b/neo4j-driver-lite/package.json
@@ -10,8 +10,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:it": "jest -c jest.integration.config.ts",
-    "test:it:browser": "jest -c jest.browser.config.ts",
-    "preinstall": "cd ../core && npm ci && npm run build && cd ../bolt-connection && npm ci && npm run build || true"
+    "test:it:browser": "jest -c jest.browser.config.ts"
   },
   "unpkg": "lib/browser/neo4j-lite-web.js",
   "jsdelivr": "lib/browser/neo4j-lite-web.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "url": "git://github.com/neo4j/neo4j-javascript-driver.git"
   },
   "scripts": {
-    "preinstall": "cd core && npm ci && npm run build && cd ../bolt-connection && npm ci && npm run build || true",
     "lint": "eslint --fix --ext .js ./",
     "format": "prettier-eslint '**/*.js' '**/*.json' '**/*.md' '**/*.ts' '**/*.html' --write",
     "test": "gulp test",

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -2,11 +2,27 @@ function ifEndsWith (suffix) {
   return testName => testName.endsWith(suffix)
 }
 
+function ifStartsWith (prefix) {
+  return testName => testName.startsWith(prefix)
+}
+
+function ifEquals (expectedName) {
+  return testName => testName === expectedName
+}
+
+function or () {
+  return testName => [...arguments].find(predicate => predicate(testName))
+}
+
 function skip (reason, predicate) {
   return { reason, predicate }
 }
 
 const skippedTests = [
+  skip(
+    'Routing tests are disabled until the fix on the test scenario be merged',
+    or(ifStartsWith('stub.routing'), ifStartsWith('stub.retry.TestRetry'))
+  ),
   skip(
     'Driver is failing trying to update the routing table using the original routing server',
     ifEndsWith(
@@ -18,6 +34,65 @@ const skippedTests = [
     ifEndsWith(
       'test_should_successfully_check_if_support_for_multi_db_is_available'
     )
+  ),
+  skip(
+    'Driver should implement resolver',
+    or(
+      ifEndsWith(
+        'test_should_revert_to_initial_router_if_known_router_throws_protocol_errors'
+      ),
+      ifEndsWith(
+        'test_should_use_resolver_during_rediscovery_when_existing_routers_fail'
+      )
+    )
+  ),
+  skip(
+    'Test are not consuming the values inside the try catch',
+    or(
+      ifEndsWith('test_should_retry_read_tx_and_rediscovery_until_success'),
+      ifEndsWith('test_should_retry_write_tx_and_rediscovery_until_success'),
+      ifEndsWith('test_should_retry_write_tx_until_success'),
+      ifEndsWith(
+        'test_should_read_successfully_from_reachable_db_after_trying_unreachable_db'
+      ),
+      ifEndsWith(
+        'test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function'
+      )
+    )
+  ),
+  skip(
+    'Requires investigation',
+    or(
+      ifEndsWith(
+        'test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code'
+      ),
+      ifEndsWith(
+        'test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_session_run'
+      ),
+      ifEndsWith(
+        'test_should_fail_with_routing_failure_on_db_not_found_discovery_failure'
+      ),
+      ifEndsWith(
+        'test_should_retry_write_until_success_with_leader_change_using_tx_function'
+      ),
+      ifEndsWith(
+        'test_should_request_rt_from_all_initial_routers_until_successful'
+      ),
+      ifEndsWith('test_should_pass_bookmark_from_tx_to_tx_using_tx_run'),
+      ifEndsWith('test_should_successfully_get_routing_table_with_context')
+    )
+  ),
+  skip(
+    'Should implement result.consume',
+    ifEquals('neo4j.sessionrun.TestSessionRun.test_updates_last_bookmark')
+  ),
+  skip(
+    'It could not guarantee the order of records requests between in the nested transactions',
+    ifEquals('stub.iteration.TxRun.test_nested')
+  ),
+  skip(
+    'Keeps retrying on commit despite connection being dropped',
+    ifEquals('stub.retry.TestRetry.test_disconnect_on_commit')
   )
 ]
 

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -79,7 +79,8 @@ const skippedTests = [
         'test_should_request_rt_from_all_initial_routers_until_successful'
       ),
       ifEndsWith('test_should_pass_bookmark_from_tx_to_tx_using_tx_run'),
-      ifEndsWith('test_should_successfully_get_routing_table_with_context')
+      ifEndsWith('test_should_successfully_get_routing_table_with_context'),
+      ifStartsWith('stub.transport.Transport')
     )
   ),
   skip(

--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV NODE_OPTIONS --max_old_space_size=4096
+
 
 RUN apt-get update && \
     apt-get install -y \

--- a/testkit/build.py
+++ b/testkit/build.py
@@ -13,14 +13,14 @@ def run(args, env=None):
 
 
 def build_core():
-    npm = ["npm", "--prefix", "core"]
+    npm = ["npm", "--prefix", "./core/"]
     run(['rm', '-fr', 'core/node_modules', 'core/lib', 'core/types'])
     run([*npm, 'ci'])
     run([*npm, 'run', 'build'])
 
 
 def build_bolt_connection():
-    npm = ['npm', '--prefix', 'bolt-connection']
+    npm = ['npm', '--prefix', './bolt-connection/']
     run(['rm', '-fr', 'bolt-connection/node_modules', 'bolt-connection/lib'])
     run([*npm, 'ci'])
     run([*npm, 'run', 'build'])
@@ -33,14 +33,14 @@ def build_driver():
 
 
 def build_driver_lite():
-    npm = ['npm', '--prefix', 'neo4j-driver-lite']
+    npm = ['npm', '--prefix', './neo4j-driver-lite/']
     run(['rm', '-fr', 'neo4j-driver-lite/node_modules', 'neo4j-driver-lite/lib'])
     run([*npm, "ci"])
     run([*npm, "run", "build"])
 
 
 def build_testkit_backend(isLite):
-    npm = ["npm", "--prefix", "testkit-backend"]
+    npm = ["npm", "--prefix", "./testkit-backend/"]
     run(['rm', '-fr', 'testkit-backend/node_modules'])
     run([*npm, "install"])
     neo4jdriverPath = "neo4j@./"


### PR DESCRIPTION
The goal of this changes is make all driver specific code part of the driver repository.