### PR TITLE
Fix HELLO message RoutingContext and send bookmarks in the ROUTE message

### DIFF
--- a/bolt-connection/src/bolt/bolt-protocol-v4x0.js
+++ b/bolt-connection/src/bolt/bolt-protocol-v4x0.js
@@ -156,7 +156,7 @@ export default class BoltProtocol extends BoltProtocolV3 {
     const resultObserver = this.run(
       CALL_GET_ROUTING_TABLE_MULTI_DB,
       {
-        [CONTEXT]: { ...routingContext, address: initialAddress },
+        [CONTEXT]: routingContext,
         [DATABASE]: databaseName
       },
       { ...sessionContext, txConfig: TxConfig.empty() }

--- a/bolt-connection/src/bolt/bolt-protocol-v4x0.js
+++ b/bolt-connection/src/bolt/bolt-protocol-v4x0.js
@@ -149,7 +149,6 @@ export default class BoltProtocol extends BoltProtocolV3 {
     routingContext = {},
     databaseName = null,
     sessionContext = {},
-    initialAddress = null,
     onError,
     onCompleted
   }) {

--- a/bolt-connection/src/bolt/bolt-protocol-v4x3.js
+++ b/bolt-connection/src/bolt/bolt-protocol-v4x3.js
@@ -56,10 +56,7 @@ export default class BoltProtocol extends BoltProtocolV42 {
     })
 
     this.write(
-      RequestMessage.route(
-        { ...routingContext, address: initialAddress },
-        databaseName
-      ),
+      RequestMessage.route(routingContext, databaseName),
       observer,
       true
     )

--- a/bolt-connection/src/bolt/bolt-protocol-v4x3.js
+++ b/bolt-connection/src/bolt/bolt-protocol-v4x3.js
@@ -23,6 +23,7 @@ import { RouteObserver } from './stream-observers'
 import { internal } from 'neo4j-driver-core'
 
 const {
+  bookmark: { Bookmark },
   constants: { BOLT_PROTOCOL_V4_3 }
 } = internal
 
@@ -38,6 +39,7 @@ export default class BoltProtocol extends BoltProtocolV42 {
    * @param {object} param.routingContext The routing context used to define the routing table.
    *  Multi-datacenter deployments is one of its use cases
    * @param {string} param.databaseName The database name
+   * @param {Bookmark} params.sessionContext.bookmark The bookmark used for request the routing table
    * @param {function(err: Error)} param.onError
    * @param {function(RawRoutingTable)} param.onCompleted
    * @returns {RouteObserver} the route observer
@@ -45,7 +47,7 @@ export default class BoltProtocol extends BoltProtocolV42 {
   requestRoutingInformation ({
     routingContext = {},
     databaseName = null,
-    initialAddress = null,
+    sessionContext = {},
     onError,
     onCompleted
   }) {
@@ -54,9 +56,9 @@ export default class BoltProtocol extends BoltProtocolV42 {
       onError,
       onCompleted
     })
-
+    const bookmark = sessionContext.bookmark || Bookmark.empty()
     this.write(
-      RequestMessage.route(routingContext, databaseName),
+      RequestMessage.route(routingContext, bookmark.values(), databaseName),
       observer,
       true
     )

--- a/bolt-connection/src/bolt/request-message.js
+++ b/bolt-connection/src/bolt/request-message.js
@@ -223,14 +223,18 @@ export default class RequestMessage {
    * Generate the ROUTE message, this message is used to fetch the routing table from the server
    *
    * @param {object} routingContext The routing context used to define the routing table. Multi-datacenter deployments is one of its use cases
+   * @param {string[]} bookmarks The list of the bookmark should be used
    * @param {string} databaseName The name of the database to get the routing table for.
    * @return {RequestMessage} the ROUTE message.
    */
-  static route (routingContext = {}, databaseName = null) {
+  static route (routingContext = {}, bookmarks = [], databaseName = null) {
     return new RequestMessage(
       ROUTE,
-      [routingContext, databaseName],
-      () => `ROUTE ${json.stringify(routingContext)} ${databaseName}`
+      [routingContext, bookmarks, databaseName],
+      () =>
+        `ROUTE ${json.stringify(routingContext)} ${json.stringify(
+          bookmarks
+        )} ${databaseName}`
     )
   }
 }

--- a/bolt-connection/src/bolt/request-message.js
+++ b/bolt-connection/src/bolt/request-message.js
@@ -108,7 +108,7 @@ export default class RequestMessage {
    */
   static hello (userAgent, authToken, routing = null) {
     const metadata = Object.assign({ user_agent: userAgent }, authToken)
-    if (routing != null) {
+    if (routing) {
       metadata.routing = routing
     }
     return new RequestMessage(

--- a/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -65,12 +65,13 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         this._config,
         this._createConnectionErrorHandler(),
         this._log,
-        routingContext || {}
+        this._routingContext
       )
     })
 
+    this._routingContext = { ...routingContext, address: address.toString() }
     this._seedRouter = address
-    this._rediscovery = new Rediscovery(routingContext, address.toString())
+    this._rediscovery = new Rediscovery(this._routingContext)
     this._loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy(
       this._connectionPool
     )

--- a/bolt-connection/src/rediscovery/rediscovery.js
+++ b/bolt-connection/src/rediscovery/rediscovery.js
@@ -28,11 +28,9 @@ export default class Rediscovery {
   /**
    * @constructor
    * @param {object} routingContext
-   * @param {string} initialAddress
    */
-  constructor (routingContext, initialAddress) {
+  constructor (routingContext) {
     this._routingContext = routingContext
-    this._initialAddress = initialAddress
   }
 
   /**
@@ -66,7 +64,6 @@ export default class Rediscovery {
     return new Promise((resolve, reject) => {
       connection.protocol().requestRoutingInformation({
         routingContext: this._routingContext,
-        initialAddress: this._initialAddress,
         databaseName: database,
         sessionContext: {
           bookmark: session._lastBookmark,

--- a/bolt-connection/test/bolt/bolt-protocol-v4x0.test.js
+++ b/bolt-connection/test/bolt/bolt-protocol-v4x0.test.js
@@ -146,7 +146,7 @@ describe('#unit BoltProtocolV4x0', () => {
     expect(protocol._run[0]).toEqual([
       'CALL dbms.routing.getRoutingTable($context, $database)',
       {
-        context: { ...routingContext, address: initialAddress },
+        context: routingContext,
         database: databaseName
       },
       { ...sessionContext, txConfig: TxConfig.empty() }

--- a/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
+++ b/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
@@ -49,7 +49,31 @@ describe('#unit BoltProtocolV4x3', () => {
 
     protocol.verifyMessageCount(1)
     expect(protocol.messages[0]).toBeMessage(
-      RequestMessage.route(routingContext, databaseName)
+      RequestMessage.route(routingContext, [], databaseName)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(observer).toEqual(jasmine.any(RouteObserver))
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  it('should request routing information sending bookmarks', () => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x3(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+    const routingContext = { someContextParam: 'value' }
+    const listOfBookmarks = ['a', 'b', 'c']
+    const bookmark = new Bookmark(listOfBookmarks)
+    const databaseName = 'name'
+
+    const observer = protocol.requestRoutingInformation({
+      routingContext,
+      databaseName,
+      sessionContext: { bookmark }
+    })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.route(routingContext, listOfBookmarks, databaseName)
     )
     expect(protocol.observers).toEqual([observer])
     expect(observer).toEqual(jasmine.any(RouteObserver))

--- a/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
+++ b/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
@@ -49,7 +49,7 @@ describe('#unit BoltProtocolV4x3', () => {
 
     protocol.verifyMessageCount(1)
     expect(protocol.messages[0]).toBeMessage(
-      RequestMessage.route({ ...routingContext, address: null }, databaseName)
+      RequestMessage.route(routingContext, databaseName)
     )
     expect(protocol.observers).toEqual([observer])
     expect(observer).toEqual(jasmine.any(RouteObserver))

--- a/bolt-connection/test/bolt/request-message.test.js
+++ b/bolt-connection/test/bolt/request-message.test.js
@@ -242,14 +242,17 @@ describe('#unit RequestMessage', () => {
   describe('BoltV4.3', () => {
     it('should create ROUTE message', () => {
       const requestContext = { someValue: '1234' }
+      const bookmarks = ['a', 'b']
       const database = 'user_db'
 
-      const message = RequestMessage.route(requestContext, database)
+      const message = RequestMessage.route(requestContext, bookmarks, database)
 
       expect(message.signature).toEqual(0x66)
-      expect(message.fields).toEqual([requestContext, database])
+      expect(message.fields).toEqual([requestContext, bookmarks, database])
       expect(message.toString()).toEqual(
-        `ROUTE ${json.stringify(requestContext)} ${database}`
+        `ROUTE ${json.stringify(requestContext)} ${json.stringify(
+          bookmarks
+        )} ${database}`
       )
     })
 
@@ -257,8 +260,10 @@ describe('#unit RequestMessage', () => {
       const message = RequestMessage.route()
 
       expect(message.signature).toEqual(0x66)
-      expect(message.fields).toEqual([{}, null])
-      expect(message.toString()).toEqual(`ROUTE ${json.stringify({})} ${null}`)
+      expect(message.fields).toEqual([{}, [], null])
+      expect(message.toString()).toEqual(
+        `ROUTE ${json.stringify({})} ${json.stringify([])} ${null}`
+      )
     })
   })
 })

--- a/bolt-connection/test/fake-connection.js
+++ b/bolt-connection/test/fake-connection.js
@@ -17,13 +17,7 @@
  * limitations under the License.
  */
 
-import Connection from '../../bolt-connection/lib/connection/connection'
-import {
-  ServerVersion,
-  VERSION_3_4_0,
-  VERSION_3_5_0,
-  VERSION_4_0_0
-} from '../../src/internal/server-version'
+import Connection from '../src/connection/connection'
 
 /**
  * This class is like a mock of {@link Connection} that tracks invocations count.
@@ -125,25 +119,6 @@ export default class FakeConnection extends Connection {
   _handleProtocolError (message) {
     this.protocolErrorsHandled++
     this.seenProtocolErrors.push(message)
-  }
-
-  withServerVersion (version) {
-    this.version = version
-    const serverVersion = ServerVersion.fromString(version)
-    if (serverVersion.compareTo(VERSION_4_0_0) >= 0) {
-      // from 4.0 onwards, the Bolt protocol version matches
-      // the Neo4j product version
-      this.protocolVersion = Number(
-        serverVersion.major + '.' + serverVersion.minor
-      )
-    } else if (serverVersion.compareTo(VERSION_3_5_0) >= 0) {
-      this.protocolVersion = 3
-    } else if (serverVersion.compareTo(VERSION_3_4_0) >= 0) {
-      this.protocolVersion = 2
-    } else {
-      this.protocolVersion = 1
-    }
-    return this
   }
 
   withProtocolVersion (version) {

--- a/bolt-connection/test/rediscovery/rediscovery.test.js
+++ b/bolt-connection/test/rediscovery/rediscovery.test.js
@@ -17,10 +17,10 @@
  * limitations under the License.
  */
 
-import { RawRoutingTable } from '../../bolt-connection/lib/bolt'
-import Rediscovery from '../../bolt-connection/lib/rediscovery'
-import RoutingTable from '../../bolt-connection/lib/rediscovery/routing-table'
-import FakeConnection from './fake-connection'
+import { RawRoutingTable } from '../../src/bolt'
+import Rediscovery from '../../src/rediscovery'
+import RoutingTable from '../../src/rediscovery/routing-table'
+import FakeConnection from '../fake-connection'
 import lolex from 'lolex'
 import { newError, error, int, internal } from 'neo4j-driver-core'
 
@@ -106,7 +106,6 @@ describe('#unit Rediscovery', () => {
     const requestParams = connection.seenRequestRoutingInformation[0]
     expect(requestParams.routingContext).toEqual(routingContext)
     expect(requestParams.databaseName).toEqual(database)
-    expect(requestParams.initialAddress).toEqual(initialAddress)
     expect(requestParams.sessionContext).toEqual({
       bookmark: session._lastBookmark,
       mode: session._mode,

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -24,6 +24,10 @@ const skippedTests = [
     or(ifStartsWith('stub.routing'), ifStartsWith('stub.retry.TestRetry'))
   ),
   skip(
+    'The driver no support domain_name_resolver',
+    ifEndsWith('test_should_successfully_acquire_rt_when_router_ip_changes')
+  ),
+  skip(
     'Driver is failing trying to update the routing table using the original routing server',
     ifEndsWith(
       'test_should_use_initial_router_for_discovery_when_others_unavailable'


### PR DESCRIPTION
The routing context was missing information about the initial routing server. This information is important for the server side routing.

The bookmarks in the ROUTE message are important in the case of a creation of a new database to make sure the database is running in all the clusters nodes returned.