### PR TITLE
Re-enabling skipped tests

### DIFF
--- a/testkit-backend/src/main.js
+++ b/testkit-backend/src/main.js
@@ -83,7 +83,8 @@ class Backend {
       const id = this._context.addError(e)
       this._writeResponse('DriverError', {
         id,
-        msg: e.message + ' (' + e.code + ')'
+        msg: e.message + ' (' + e.code + ')',
+        code: e.code
       })
       return
     }

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -49,9 +49,6 @@ const skippedTests = [
       ),
       ifEndsWith(
         'test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_session_run'
-      ),
-      ifEndsWith(
-        'test_should_fail_with_routing_failure_on_db_not_found_discovery_failure'
       )
     )
   ),

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -61,6 +61,22 @@ const skippedTests = [
       '.test_should_use_initial_router_for_discovery_when_others_unavailable'
     ),
     ifEndsWith('.test_should_successfully_get_routing_table_with_context')
+  ),
+  skip(
+    'Driver is executing the second tx for the same session in a diferent server',
+    ifEndsWith('test_should_pass_bookmark_from_tx_to_tx_using_tx_run')
+  ),
+  skip(
+    'Driver resolves the address during the record fetch',
+    ifEndsWith(
+      'test_should_use_resolver_during_rediscovery_when_existing_routers_fail'
+    )
+  ),
+  skip(
+    'Needs investigation. It is only failing in the RoutingV3 case',
+    ifEndsWith(
+      'RoutingV3.test_should_accept_routing_table_without_writers_and_then_rediscover'
+    )
   )
 ]
 

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -20,8 +20,11 @@ function skip (reason, ...predicate) {
 
 const skippedTests = [
   skip(
-    'The driver no support domain_name_resolver',
-    ifEndsWith('test_should_successfully_acquire_rt_when_router_ip_changes')
+    'The driver has no support domain_name_resolver',
+    ifEndsWith('test_should_successfully_acquire_rt_when_router_ip_changes'),
+    ifEndsWith(
+      'test_should_request_rt_from_all_initial_routers_until_successful'
+    )
   ),
   skip(
     'Driver is start to run tx_function before have a valid connection in hands',
@@ -49,9 +52,6 @@ const skippedTests = [
       ),
       ifEndsWith(
         'test_should_retry_write_until_success_with_leader_change_using_tx_function'
-      ),
-      ifEndsWith(
-        'test_should_request_rt_from_all_initial_routers_until_successful'
       )
     )
   ),

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -54,8 +54,7 @@ const skippedTests = [
         'test_should_request_rt_from_all_initial_routers_until_successful'
       ),
       ifEndsWith('test_should_pass_bookmark_from_tx_to_tx_using_tx_run'),
-      ifEndsWith('test_should_successfully_get_routing_table_with_context'),
-      ifStartsWith('stub.transport.Transport')
+      ifEndsWith('test_should_successfully_get_routing_table_with_context')
     )
   ),
   skip(

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -14,8 +14,8 @@ function or () {
   return testName => [...arguments].find(predicate => predicate(testName))
 }
 
-function skip (reason, predicate) {
-  return { reason, predicate }
+function skip (reason, ...predicate) {
+  return { reason, predicate: or(...predicate) }
 }
 
 const skippedTests = [
@@ -53,8 +53,7 @@ const skippedTests = [
       ifEndsWith(
         'test_should_request_rt_from_all_initial_routers_until_successful'
       ),
-      ifEndsWith('test_should_pass_bookmark_from_tx_to_tx_using_tx_run'),
-      ifEndsWith('test_should_successfully_get_routing_table_with_context')
+      ifEndsWith('test_should_pass_bookmark_from_tx_to_tx_using_tx_run')
     )
   ),
   skip(
@@ -75,7 +74,8 @@ const skippedTests = [
     'Wait clarification about verifyConnectivity behaviour when no reader connection is available',
     ifEndsWith(
       '.test_should_use_initial_router_for_discovery_when_others_unavailable'
-    )
+    ),
+    ifEndsWith('.test_should_successfully_get_routing_table_with_context')
   )
 ]
 

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -98,6 +98,10 @@ const skippedTests = [
   skip(
     'Keeps retrying on commit despite connection being dropped',
     ifEquals('stub.retry.TestRetry.test_disconnect_on_commit')
+  ),
+  skip(
+    'Wrong behaviour treating exceptions',
+    ifEquals('test_client_exception_rolls_back_change')
   )
 ]
 

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -20,12 +20,14 @@ function skip (reason, predicate) {
 
 const skippedTests = [
   skip(
-    'Routing tests are disabled until the fix on the test scenario be merged',
-    or(ifStartsWith('stub.routing'), ifStartsWith('stub.retry.TestRetry'))
-  ),
-  skip(
     'The driver no support domain_name_resolver',
     ifEndsWith('test_should_successfully_acquire_rt_when_router_ip_changes')
+  ),
+  skip(
+    'Driver is start to run tx_function before have a valid connection in hands',
+    ifEndsWith(
+      'test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function'
+    )
   ),
   skip(
     'Driver is failing trying to update the routing table using the original routing server',
@@ -47,20 +49,6 @@ const skippedTests = [
       ),
       ifEndsWith(
         'test_should_use_resolver_during_rediscovery_when_existing_routers_fail'
-      )
-    )
-  ),
-  skip(
-    'Test are not consuming the values inside the try catch',
-    or(
-      ifEndsWith('test_should_retry_read_tx_and_rediscovery_until_success'),
-      ifEndsWith('test_should_retry_write_tx_and_rediscovery_until_success'),
-      ifEndsWith('test_should_retry_write_tx_until_success'),
-      ifEndsWith(
-        'test_should_read_successfully_from_reachable_db_after_trying_unreachable_db'
-      ),
-      ifEndsWith(
-        'test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function'
       )
     )
   ),
@@ -98,10 +86,6 @@ const skippedTests = [
   skip(
     'Keeps retrying on commit despite connection being dropped',
     ifEquals('stub.retry.TestRetry.test_disconnect_on_commit')
-  ),
-  skip(
-    'Wrong behaviour treating exceptions',
-    ifEquals('test_client_exception_rolls_back_change')
   )
 ]
 

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -30,6 +30,9 @@ const skippedTests = [
     'Driver is start to run tx_function before have a valid connection in hands',
     ifEndsWith(
       'test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function'
+    ),
+    ifEndsWith(
+      'test_should_retry_write_until_success_with_leader_change_using_tx_function'
     )
   ),
   skip(
@@ -49,9 +52,6 @@ const skippedTests = [
       ),
       ifEndsWith(
         'test_should_fail_with_routing_failure_on_db_not_found_discovery_failure'
-      ),
-      ifEndsWith(
-        'test_should_retry_write_until_success_with_leader_change_using_tx_function'
       )
     )
   ),

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -42,17 +42,6 @@ const skippedTests = [
     )
   ),
   skip(
-    'Requires investigation',
-    or(
-      ifEndsWith(
-        'test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code'
-      ),
-      ifEndsWith(
-        'test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_session_run'
-      )
-    )
-  ),
-  skip(
     'Fails when runned with the full suite',
     ifEndsWith(
       '.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors'

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -59,10 +59,6 @@ const skippedTests = [
     )
   ),
   skip(
-    'Should implement result.consume',
-    ifEquals('neo4j.sessionrun.TestSessionRun.test_updates_last_bookmark')
-  ),
-  skip(
     'Fails when runned with the full suite',
     ifEndsWith(
       '.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors'
@@ -77,7 +73,7 @@ const skippedTests = [
     ifEquals('stub.retry.TestRetry.test_disconnect_on_commit')
   ),
   skip(
-    'Wait clarification about verifyConnective behaviour when no reader connection is available',
+    'Wait clarification about verifyConnectivity behaviour when no reader connection is available',
     ifEndsWith(
       '.test_should_use_initial_router_for_discovery_when_others_unavailable'
     )

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -42,17 +42,6 @@ const skippedTests = [
     )
   ),
   skip(
-    'Driver should implement resolver',
-    or(
-      ifEndsWith(
-        'test_should_revert_to_initial_router_if_known_router_throws_protocol_errors'
-      ),
-      ifEndsWith(
-        'test_should_use_resolver_during_rediscovery_when_existing_routers_fail'
-      )
-    )
-  ),
-  skip(
     'Requires investigation',
     or(
       ifEndsWith(
@@ -78,6 +67,12 @@ const skippedTests = [
   skip(
     'Should implement result.consume',
     ifEquals('neo4j.sessionrun.TestSessionRun.test_updates_last_bookmark')
+  ),
+  skip(
+    'Fails when runned with the full suite',
+    ifEndsWith(
+      '.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors'
+    )
   ),
   skip(
     'It could not guarantee the order of records requests between in the nested transactions',

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -52,8 +52,7 @@ const skippedTests = [
       ),
       ifEndsWith(
         'test_should_request_rt_from_all_initial_routers_until_successful'
-      ),
-      ifEndsWith('test_should_pass_bookmark_from_tx_to_tx_using_tx_run')
+      )
     )
   ),
   skip(

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -30,12 +30,6 @@ const skippedTests = [
     )
   ),
   skip(
-    'Driver is failing trying to update the routing table using the original routing server',
-    ifEndsWith(
-      'test_should_use_initial_router_for_discovery_when_others_unavailable'
-    )
-  ),
-  skip(
     'Driver is creating a dedicated connection to check the MultiDBSupport',
     ifEndsWith(
       'test_should_successfully_check_if_support_for_multi_db_is_available'
@@ -81,6 +75,12 @@ const skippedTests = [
   skip(
     'Keeps retrying on commit despite connection being dropped',
     ifEquals('stub.retry.TestRetry.test_disconnect_on_commit')
+  ),
+  skip(
+    'Wait clarification about verifyConnective behaviour when no reader connection is available',
+    ifEndsWith(
+      '.test_should_use_initial_router_for_discovery_when_others_unavailable'
+    )
   )
 ]
 


### PR DESCRIPTION
Some tests were disabled for different reasons, the objective of this PR is to re-enable some skipped tests. 

This PR re-enable tests related to:

- ROUTE message receiving the bookmarks
- HELLO message receiving the initial address in the routing context
- Routing tests which were skipped because of the lack of result consumption and wrong try_count verification