### PR TITLE
ResultSummary.server: deprecate property version and introduce property agent as replacement

### DIFF
--- a/core/src/result-summary.ts
+++ b/core/src/result-summary.ts
@@ -41,7 +41,7 @@ class ResultSummary<T extends NumberOrInteger = Integer> {
    * @param {string} query - The query this summary is for
    * @param {Object} parameters - Parameters for the query
    * @param {Object} metadata - Query metadata
-   * @param {number} protocolVersion - Bolt protocol version
+   * @param {number|undefined} protocolVersion - Bolt Protocol Version
    */
   constructor(
     query: string,
@@ -449,21 +449,51 @@ class Notification {
  * @access public
  */
 class ServerInfo {
-  address: string
-  version: string
+  address?: string
+  version?: string
   protocolVersion?: number
+  agent?: string
 
   /**
    * Create a ServerInfo instance
    * @constructor
    * @param {Object} serverMeta - Object with serverMeta data
-   * @param {number} protocolVersion - Bolt protocol version
+   * @param {Object} connectionInfo - Bolt connection info
+   * @param {number} protocolVersion - Bolt Protocol Version
    */
-  constructor(serverMeta: any, protocolVersion?: number) {
+  constructor(serverMeta?: any, protocolVersion?: number) {
     if (serverMeta) {
+      /**
+       * The server adress
+       * @type {string}
+       * @public
+       */
       this.address = serverMeta.address
+      /**
+       * The server version string.
+       * 
+       * See {@link ServerInfo#protocolVersion} and {@link ServerInfo#agent}
+       * @type {string}
+       * @deprecated in 4.3, please use ServerInfo#agent, ServerInfo#protocolVersion, or call the <i>dbms.components</i> procedure instead.
+       * <b>Method might be removed in the next major release.</b>
+       
+       * @public
+       */
       this.version = serverMeta.version
+
+      /**
+       * The server user agent string
+       * @type {string}
+       * @public
+       */
+      this.agent = serverMeta.version
     }
+
+    /**
+     * The protocol version used by the connection
+     * @type {number}
+     * @public
+     */
     this.protocolVersion = protocolVersion
   }
 }

--- a/core/test/result-summary.test.ts
+++ b/core/test/result-summary.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ServerInfo } from '../src/result-summary'
+
+describe('ServerInfo', () => {
+  it.each([
+    [
+      { address: '192.168.0.1', version: 'neo4j' },
+      4.3,
+      {
+        address: '192.168.0.1',
+        version: 'neo4j',
+        protocolVersion: 4.3,
+        agent: 'neo4j'
+      }
+    ],
+    [
+      { address: '192.168.0.1', version: 'neo4j' },
+      undefined,
+      {
+        address: '192.168.0.1',
+        version: 'neo4j',
+        protocolVersion: undefined,
+        agent: 'neo4j'
+      }
+    ],
+    [undefined, 4.3, { protocolVersion: 4.3 }],
+    [undefined, undefined, {}]
+  ])(
+    'new ServerInfo(%o, %i) === %j',
+    (meta, protocolVersion, expectedServerInfo) => {
+      expect(new ServerInfo(meta, protocolVersion)).toEqual(expectedServerInfo)
+    }
+  )
+})

--- a/test/types/result-summary.test.ts
+++ b/test/types/result-summary.test.ts
@@ -97,8 +97,8 @@ const line: number = position2.line
 const column: number = position2.column
 
 const server: ServerInfo = sum1.server
-const address: string = server.address
-const version: string = server.version
+const address: string | undefined = server.address
+const version: string | undefined = server.version
 
 const resultConsumedAfter1: Integer = sum1.resultConsumedAfter
 const resultAvailableAfter1: Integer = sum1.resultAvailableAfter

--- a/testkit-backend/src/main.js
+++ b/testkit-backend/src/main.js
@@ -60,7 +60,7 @@ class Backend {
 
     this._writeBackendError('Unknown request: ' + name)
     console.log('Unknown request: ' + name)
-    console.log(JSON.stringify(data))
+    console.log(stringify(data))
   }
 
   _writeResponse (name, data) {
@@ -69,7 +69,7 @@ class Backend {
       name: name,
       data: data
     }
-    response = JSON.stringify(response)
+    response = stringify(response)
     const lines = ['#response begin', response, '#response end']
     this._writer(lines)
   }
@@ -90,6 +90,12 @@ class Backend {
     }
     this._writeBackendError(e)
   }
+}
+
+function stringify (val) {
+  return JSON.stringify(val, (_, value) =>
+    typeof value === 'bigint' ? `${value}n` : value
+  )
 }
 
 function server () {


### PR DESCRIPTION
The name version is misleading because the information is about the server user agent, not the server version itself.