### PR TITLE
Fix RxResult method mapping

### DIFF
--- a/test/types/result-rx.test.ts
+++ b/test/types/result-rx.test.ts
@@ -35,7 +35,7 @@ res.records().subscribe({
   error: error => console.log(`records error: ${error}`)
 })
 
-res.summary().subscribe({
+res.consume().subscribe({
   next: value => console.log(`summary: ${value}`),
   complete: () => console.log('summary complete'),
   error: error => console.log(`summary error: ${error}`)

--- a/test/types/session-rx.test.ts
+++ b/test/types/session-rx.test.ts
@@ -109,7 +109,7 @@ const result1: RxResult = rxSession.run('RETURN 1')
 result1.keys().subscribe(keysObserver)
 result1.records().subscribe(recordsObserver)
 result1
-  .summary()
+  .consume()
   .pipe(
     concat(close1),
     catchError(err => close1.pipe(concat(throwError(err))))
@@ -120,7 +120,7 @@ const result2: RxResult = rxSession.run('RETURN $value', { value: '42' })
 result2.keys().subscribe(keysObserver)
 result2.records().subscribe(recordsObserver)
 result2
-  .summary()
+  .consume()
   .pipe(
     concat(close1),
     catchError(err => close1.pipe(concat(throwError(err))))
@@ -135,7 +135,7 @@ const result3: RxResult = rxSession.run(
 result3.keys().subscribe(keysObserver)
 result3.records().subscribe(recordsObserver)
 result3
-  .summary()
+  .consume()
   .pipe(
     concat(close1),
     catchError(err => close1.pipe(concat(throwError(err))))

--- a/test/types/transaction-rx.test.ts
+++ b/test/types/transaction-rx.test.ts
@@ -54,12 +54,12 @@ const tx: RxTransaction = dummy
 const result1: RxResult = tx.run('RETURN 1')
 result1.keys().subscribe(keysObserver)
 result1.records().subscribe(recordsObserver)
-result1.summary().subscribe(summaryObserver)
+result1.consume().subscribe(summaryObserver)
 
 const result2: RxResult = tx.run('RETURN $value', { value: '42' })
 result2.keys().subscribe(keysObserver)
 result2.records().subscribe(recordsObserver)
-result2.summary().subscribe(summaryObserver)
+result2.consume().subscribe(summaryObserver)
 
 tx.commit()
   .pipe(concat(of('committed')))

--- a/types/result-rx.d.ts
+++ b/types/result-rx.d.ts
@@ -24,7 +24,7 @@ declare interface RxResult {
 
   records(): Observable<Record>
 
-  summary(): Observable<ResultSummary>
+  consume(): Observable<ResultSummary>
 }
 
 export default RxResult


### PR DESCRIPTION
The method consume was wrongly mapped as summary.