### PR TITLE
Rewrite summary.server.version to agent in testkit backend

### DIFF
--- a/testkit-backend/src/request-handlers.js
+++ b/testkit-backend/src/request-handlers.js
@@ -126,7 +126,7 @@ export function ResultConsume (context, data, wire) {
       wire.writeResponse('Summary', {
         ...summary,
         serverInfo: {
-          agent: summary.server.agent,
+          agent: summary.server.version,
           protocolVersion: summary.server.protocolVersion.toFixed(1)
         }
       })


### PR DESCRIPTION
Seems like the agent sting is stored in `summary.server.version` and not in `summary.server.agent`.