### PR TITLE
Fix log message doesn't appearing correctly in the Bolt log.

### DIFF
--- a/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -334,7 +334,7 @@ export default class BoltProtocol {
 
     if (queued) {
       if (this._log.isDebugEnabled()) {
-        this._log.debug(`${this} C: ${message}`)
+        this._log.debug(`C: ${message}`)
       }
 
       this.packer().packStruct(

--- a/bolt-connection/src/bolt/response-handler.js
+++ b/bolt-connection/src/bolt/response-handler.js
@@ -92,13 +92,13 @@ export default class ResponseHandler {
     switch (msg.signature) {
       case RECORD:
         if (this._log.isDebugEnabled()) {
-          this._log.debug(`${this} S: RECORD ${json.stringify(msg)}`)
+          this._log.debug(`S: RECORD ${json.stringify(msg)}`)
         }
         this._currentObserver.onNext(payload)
         break
       case SUCCESS:
         if (this._log.isDebugEnabled()) {
-          this._log.debug(`${this} S: SUCCESS ${json.stringify(msg)}`)
+          this._log.debug(`S: SUCCESS ${json.stringify(msg)}`)
         }
         try {
           const metadata = this._transformMetadata(payload)
@@ -109,7 +109,7 @@ export default class ResponseHandler {
         break
       case FAILURE:
         if (this._log.isDebugEnabled()) {
-          this._log.debug(`${this} S: FAILURE ${json.stringify(msg)}`)
+          this._log.debug(`S: FAILURE ${json.stringify(msg)}`)
         }
         try {
           const error = newError(payload.message, payload.code)
@@ -125,7 +125,7 @@ export default class ResponseHandler {
         break
       case IGNORED:
         if (this._log.isDebugEnabled()) {
-          this._log.debug(`${this} S: IGNORED ${json.stringify(msg)}`)
+          this._log.debug(`S: IGNORED ${json.stringify(msg)}`)
         }
         try {
           if (this._currentFailure && this._currentObserver.onError) {


### PR DESCRIPTION
The write and receive message functions were moved from the connection to the `response-handler` and `bolt-protocol`, but logs on the functions still creating the message using the `this`, but in the nnew context the value of `this` is not serialized as the connection id.

Since the connection id data is dynamic and the depends on a response from the server, the issue was solved decorating the logger function to add connection context information.