### PR TITLE
Fix Path unpacking when `useBigInt` is on

### DIFF
--- a/bolt-connection/src/packstream/packstream-v1.js
+++ b/bolt-connection/src/packstream/packstream-v1.js
@@ -23,6 +23,7 @@ import {
   int,
   isInt,
   Integer,
+  toNumber,
   Node,
   Path,
   PathSegment,
@@ -635,7 +636,7 @@ class Unpacker {
 
     for (let i = 0; i < sequence.length; i += 2) {
       const nextNode = nodes[sequence[i + 1]]
-      const relIndex = sequence[i]
+      const relIndex = toNumber(sequence[i])
       let rel
 
       if (relIndex > 0) {

--- a/testkit-backend/src/cypher-native-binders.js
+++ b/testkit-backend/src/cypher-native-binders.js
@@ -37,6 +37,45 @@ export function nativeToCypher (x) {
         }
         return { name: 'CypherNode', data: node }
       }
+      if (x instanceof neo4j.types.Relationship) {
+        const relationship = {
+          id: nativeToCypher(x.identity),
+          startNodeId: nativeToCypher(x.start),
+          endNodeId: nativeToCypher(x.end),
+          type: nativeToCypher(x.type),
+          props: nativeToCypher(x.properties)
+        }
+        return { name: 'CypherRelationship', data: relationship }
+      }
+      if (x instanceof neo4j.types.Path) {
+        const path = x.segments
+          .map(segment => {
+            return {
+              nodes: [segment.end],
+              relationships: [segment.relationship]
+            }
+          })
+          .reduce(
+            (previous, current) => {
+              return {
+                nodes: [...previous.nodes, ...current.nodes],
+                relationships: [
+                  ...previous.relationships,
+                  ...current.relationships
+                ]
+              }
+            },
+            { nodes: [x.start], relationships: [] }
+          )
+
+        return {
+          name: 'CypherPath',
+          data: {
+            nodes: nativeToCypher(path.nodes),
+            relationships: nativeToCypher(path.relationships)
+          }
+        }
+      }
       // If all failed, interpret as a map
       const map = {}
       for (const [key, value] of Object.entries(x)) {

--- a/testkit-backend/src/skipped-tests.js
+++ b/testkit-backend/src/skipped-tests.js
@@ -20,6 +20,10 @@ function skip (reason, ...predicate) {
 
 const skippedTests = [
   skip(
+    'Not support by the JS driver',
+    ifEquals('neo4j.sessionrun.TestSessionRun.test_partial_iteration')
+  ),
+  skip(
     'The driver has no support domain_name_resolver',
     ifEndsWith('test_should_successfully_acquire_rt_when_router_ip_changes'),
     ifEndsWith(


### PR DESCRIPTION
The code was trying to do math between Number and BigInt during the Path unpacking. The usage of `toNumber` convert any BigInt|Number|Integer to number in optimal way.