### PR TITLE
Fix issues which are blocking the build pipeline

### DIFF
--- a/core/src/record.ts
+++ b/core/src/record.ts
@@ -110,7 +110,7 @@ class Record<
    */
   forEach(visitor: Visitor<Entries, Key>): void {
     for (const [key, value] of this.entries()) {
-      visitor(value as any, key as any, this)
+      visitor(value, key as Key, this)
     }
   }
 
@@ -128,7 +128,7 @@ class Record<
     const resultArray = []
 
     for (const [key, value] of this.entries()) {
-      resultArray.push(visitor(value as any, key as any, this))
+      resultArray.push(visitor(value, key as Key, this))
     }
 
     return resultArray
@@ -180,7 +180,7 @@ class Record<
     const obj: Entries = {} as Entries
 
     for (const [key, value] of this.entries()) {
-      obj[key as any] = value
+      obj[key as Key] = value
     }
 
     return obj

--- a/core/test/result.test.ts
+++ b/core/test/result.test.ts
@@ -407,7 +407,7 @@ describe('Result', () => {
       it('should call finally on error', done => {
         streamObserverMock.onError(expectedError)
 
-        result.finally(done)
+        result.catch(() => {}).finally(done)
       })
 
       describe.each([


### PR DESCRIPTION
The wrong typecasting the `record.ts` was giving a `Type 'any' cannot be used to index type 'Entries'.` during the build. And it was fixed just by adjusting the type casting.

The test case `Result Promise should call finally on error` was not handling correctly the error before call finally and it was giving `Unhandled promise rejection` error during the tests.