### PR TITLE
testkit: Speedup the test by enable skip the browser tests

### DIFF
--- a/testkit/integration.py
+++ b/testkit/integration.py
@@ -8,7 +8,8 @@ def run(args):
 
 
 def test_driver():
-    if os.environ.get("TEST_DRIVER_SKIP_BROWSER", False):
+    if (os.environ.get("TEST_DRIVER_SKIP_BROWSER", "false").lower()
+            in ("y", "yes", "t", "true", "1", "on")):
         run(["gulp", "test-browser"])
     run(["gulp", "test-nodejs-integration"])
 

--- a/testkit/integration.py
+++ b/testkit/integration.py
@@ -8,7 +8,8 @@ def run(args):
 
 
 def test_driver():
-    run(["gulp", "test-browser"])
+    if os.environ.get("TEST_DRIVER_SKIP_BROWSER", False):
+        run(["gulp", "test-browser"])
     run(["gulp", "test-nodejs-integration"])
 
 


### PR DESCRIPTION
Browser tests are consuming a huge amount of time and making the testkit PR take a long time just to change unrelated issue.

The env var `TEST_DRIVER_SKIP_BROWSER` could be used to skip the browser tests.