### PR TITLE
RxJS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ try {
 rxSession
   .beginTransaction()
   .pipe(
-    flatMap(txc =>
+    mergeMap(txc =>
       concat(
         txc
           .run(

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ rxSession
   .records()
   .pipe(
     map(record => record.get('name')),
-    concat(rxSession.close())
+    concatWith(rxSession.close())
   )
   .subscribe({
     next: data => console.log(data),

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "@babel/runtime": "^7.5.5",
     "neo4j-driver-bolt-connection": "file:./bolt-connection",
     "neo4j-driver-core": "file:./core",
-    "rxjs": "^6.6.3"
+    "rxjs": "^7.3.0"
   }
 }

--- a/src/internal/retry-logic-rx.js
+++ b/src/internal/retry-logic-rx.js
@@ -19,7 +19,7 @@
 
 import { newError, error, internal } from 'neo4j-driver-core'
 import { Observable, throwError, of } from 'rxjs'
-import { retryWhen, flatMap, delay } from 'rxjs/operators'
+import { retryWhen, mergeMap as flatMap, delay } from 'rxjs/operators'
 
 const {
   logger: {

--- a/src/internal/retry-logic-rx.js
+++ b/src/internal/retry-logic-rx.js
@@ -82,7 +82,7 @@ export default class RxRetryLogic {
         return failedWork.pipe(
           flatMap(err => {
             if (!canRetryOn(err)) {
-              return throwError(err)
+              return throwError(() => err)
             }
 
             handledExceptions.push(err)
@@ -98,7 +98,7 @@ export default class RxRetryLogic {
 
               error.seenErrors = handledExceptions
 
-              return throwError(error)
+              return throwError(() => error)
             }
 
             const nextDelayDuration = this._computeNextDelay(delayDuration)

--- a/src/result-rx.js
+++ b/src/result-rx.js
@@ -18,7 +18,7 @@
  */
 import { newError, Record, ResultSummary } from 'neo4j-driver-core'
 import { Observable, Subject, ReplaySubject, from } from 'rxjs'
-import { flatMap, publishReplay, refCount, shareReplay } from 'rxjs/operators'
+import { mergeMap as flatMap, publishReplay, refCount } from 'rxjs/operators'
 
 const States = {
   READY: 0,

--- a/src/result-rx.js
+++ b/src/result-rx.js
@@ -18,7 +18,7 @@
  */
 import { newError, Record, ResultSummary } from 'neo4j-driver-core'
 import { Observable, Subject, ReplaySubject, from } from 'rxjs'
-import { mergeMap as flatMap, publishReplay, refCount } from 'rxjs/operators'
+import { mergeMap as flatMap, shareReplay } from 'rxjs/operators'
 
 const States = {
   READY: 0,
@@ -36,13 +36,12 @@ export default class RxResult {
    * @param {Observable<Result>} result - An observable of single Result instance to relay requests.
    */
   constructor (result) {
-    const replayedResult = result.pipe(publishReplay(1), refCount())
+    const replayedResult = result.pipe(shareReplay(1))
 
     this._result = replayedResult
     this._keys = replayedResult.pipe(
       flatMap(r => from(r.keys())),
-      publishReplay(1),
-      refCount()
+      shareReplay(1)
     )
     this._records = new Subject()
     this._summary = new ReplaySubject()

--- a/src/session-rx.js
+++ b/src/session-rx.js
@@ -128,10 +128,9 @@ export default class RxSession {
    * @private
    */
   _beginTransaction (accessMode, transactionConfig) {
-    let txConfig = TxConfig.empty()
-    if (transactionConfig) {
-      txConfig = new TxConfig(transactionConfig)
-    }
+    const txConfig = transactionConfig
+      ? new TxConfig(transactionConfig)
+      : TxConfig.empty()
 
     return defer(() => [
       new RxTransaction(this._session._beginTransaction(accessMode, txConfig))
@@ -142,11 +141,6 @@ export default class RxSession {
    * @private
    */
   _runTransaction (accessMode, work, transactionConfig) {
-    let txConfig = TxConfig.empty()
-    if (transactionConfig) {
-      txConfig = new TxConfig(transactionConfig)
-    }
-
     return this._retryLogic.retry(
       this._beginTransaction(accessMode, transactionConfig).pipe(
         flatMap(txc =>

--- a/src/session-rx.js
+++ b/src/session-rx.js
@@ -17,7 +17,11 @@
  * limitations under the License.
  */
 import { defer, Observable, throwError } from 'rxjs'
-import { mergeMap as flatMap, catchError, concat } from 'rxjs/operators'
+import {
+  mergeMap as flatMap,
+  catchError,
+  concatWith as concat
+} from 'rxjs/operators'
 import RxResult from './result-rx'
 import { Session, internal } from 'neo4j-driver-core'
 import RxTransaction from './transaction-rx'

--- a/src/session-rx.js
+++ b/src/session-rx.js
@@ -77,7 +77,7 @@ export default class RxSession {
    * Starts a new explicit transaction with the provided transaction configuration.
    *
    * @public
-   * @param {TransactionConfig} transactionConfig - Configuration for the new transaction.
+   * @param {TransactionConfig} [transactionConfig] - Configuration for the new transaction.
    * @returns {Observable<RxTransaction>} - A reactive stream that will generate at most **one** RxTransaction instance.
    */
   beginTransaction (transactionConfig) {
@@ -89,7 +89,7 @@ export default class RxSession {
    * transaction configuration.
    * @public
    * @param {function(txc: RxTransaction): Observable} work - A unit of work to be executed.
-   * @param {TransactionConfig} transactionConfig - Configuration for the enclosing transaction created by the driver.
+   * @param {TransactionConfig} [transactionConfig] - Configuration for the enclosing transaction created by the driver.
    * @returns {Observable} - A reactive stream returned by the unit of work.
    */
   readTransaction (work, transactionConfig) {

--- a/src/session-rx.js
+++ b/src/session-rx.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { defer, Observable, throwError } from 'rxjs'
-import { flatMap, catchError, concat } from 'rxjs/operators'
+import { mergeMap as flatMap, catchError, concat } from 'rxjs/operators'
 import RxResult from './result-rx'
 import { Session, internal } from 'neo4j-driver-core'
 import RxTransaction from './transaction-rx'

--- a/src/session-rx.js
+++ b/src/session-rx.js
@@ -177,10 +177,12 @@ export default class RxSession {
             try {
               return work(txc)
             } catch (err) {
-              return throwError(err)
+              return throwError(() => err)
             }
           }).pipe(
-            catchError(err => txc.rollback().pipe(concat(throwError(err)))),
+            catchError(err =>
+              txc.rollback().pipe(concat(throwError(() => err)))
+            ),
             concat(txc.commit())
           )
         )

--- a/src/transaction-rx.js
+++ b/src/transaction-rx.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Observable } from 'rxjs'
+import { defer, from, Observable } from 'rxjs'
 import RxResult from './result-rx'
 import Transaction from 'neo4j-driver-core'
 
@@ -41,53 +41,27 @@ export default class RxTransaction {
    * @param {Object} parameters - Parameter values to use in query execution.
    * @returns {RxResult} - A reactive result
    */
-
   run (query, parameters) {
-    return new RxResult(
-      new Observable(observer => {
-        try {
-          observer.next(this._txc.run(query, parameters))
-          observer.complete()
-        } catch (err) {
-          observer.error(err)
-        }
-
-        return () => {}
-      })
-    )
+    return new RxResult(defer(() => [this._txc.run(query, parameters)]))
   }
 
   /**
    *  Commits the transaction.
    *
    * @public
-   * @returns {Observable} - An empty observable
+   * @returns {Observable<void>} - An empty observable
    */
   commit () {
-    return new Observable(observer => {
-      this._txc
-        .commit()
-        .then(() => {
-          observer.complete()
-        })
-        .catch(err => observer.error(err))
-    })
+    return from(this._txc.commit())
   }
 
   /**
    *  Rolls back the transaction.
    *
    * @public
-   * @returns {Observable} - An empty observable
+   * @returns {Observable<void>} - An empty observable
    */
   rollback () {
-    return new Observable(observer => {
-      this._txc
-        .rollback()
-        .then(() => {
-          observer.complete()
-        })
-        .catch(err => observer.error(err))
-    })
+    return from(this._txc.rollback())
   }
 }

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -21,7 +21,7 @@ import neo4j from '../src'
 import sharedNeo4j from './internal/shared-neo4j'
 import { ServerVersion, VERSION_4_0_0 } from '../src/internal/server-version'
 import { map, materialize, toArray } from 'rxjs/operators'
-import { Notification } from 'rxjs'
+import { Notification, lastValueFrom } from 'rxjs'
 
 /**
  * The tests below are examples that get pulled into the Driver Manual using the tags inside the tests.
@@ -143,7 +143,7 @@ describe('#integration examples', () => {
     }
 
     // end::rx-autocommit-transaction[]
-    const result = await readProductTitles().toPromise()
+    const result = await lastValueFrom(readProductTitles())
 
     expect(result).toEqual([
       Notification.createNext('Product-0'),
@@ -623,7 +623,7 @@ describe('#integration examples', () => {
       )
     // end::rx-result-consume[]
 
-    const people = await result.toPromise()
+    const people = await lastValueFrom(result)
     expect(people).toEqual([
       Notification.createNext('Alice'),
       Notification.createNext('Bob'),
@@ -802,7 +802,7 @@ describe('#integration examples', () => {
     )
     // end::rx-transaction-function[]
 
-    const people = await result.toPromise()
+    const people = await lastValueFrom(result)
     expect(people).toEqual([
       Notification.createNext('Infinity Gauntlet'),
       Notification.createNext('Mjölnir'),

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -21,7 +21,7 @@ import neo4j from '../src'
 import sharedNeo4j from './internal/shared-neo4j'
 import { ServerVersion, VERSION_4_0_0 } from '../src/internal/server-version'
 import { map, materialize, toArray } from 'rxjs/operators'
-import { Notification, lastValueFrom } from 'rxjs'
+import { lastValueFrom } from 'rxjs'
 
 /**
  * The tests below are examples that get pulled into the Driver Manual using the tags inside the tests.
@@ -145,10 +145,7 @@ describe('#integration examples', () => {
     // end::rx-autocommit-transaction[]
     const result = await lastValueFrom(readProductTitles())
 
-    expect(result).toEqual([
-      Notification.createNext('Product-0'),
-      Notification.createComplete()
-    ])
+    expect(result).toEqual([{ kind: 'N', value: 'Product-0' }, { kind: 'C' }])
   }, 60000)
 
   it('basic auth example', async () => {
@@ -625,9 +622,9 @@ describe('#integration examples', () => {
 
     const people = await lastValueFrom(result)
     expect(people).toEqual([
-      Notification.createNext('Alice'),
-      Notification.createNext('Bob'),
-      Notification.createComplete()
+      { kind: 'N', value: 'Alice' },
+      { kind: 'N', value: 'Bob' },
+      { kind: 'C' }
     ])
   }, 60000)
 
@@ -804,9 +801,9 @@ describe('#integration examples', () => {
 
     const people = await lastValueFrom(result)
     expect(people).toEqual([
-      Notification.createNext('Infinity Gauntlet'),
-      Notification.createNext('Mjölnir'),
-      Notification.createComplete()
+      { kind: 'N', value: 'Infinity Gauntlet' },
+      { kind: 'N', value: 'Mjölnir' },
+      { kind: 'C' }
     ])
   }, 60000)
 

--- a/test/internal/retry-logic-rx.test.js
+++ b/test/internal/retry-logic-rx.test.js
@@ -245,7 +245,7 @@ describe('#unit-rx retrylogic', () => {
         clock.tick(delayBy)
       }
       if (index < errors.length) {
-        return throwError(errors[index++])
+        return throwError(() => errors[index++])
       } else {
         return of(value)
       }

--- a/test/rx/navigation.test.js
+++ b/test/rx/navigation.test.js
@@ -18,7 +18,7 @@
  */
 import neo4j from '../../src'
 import sharedNeo4j from '../internal/shared-neo4j'
-import { lastValueFrom, Notification } from 'rxjs'
+import { lastValueFrom } from 'rxjs'
 import { materialize, toArray, map } from 'rxjs/operators'
 
 describe('#integration-rx navigation', () => {
@@ -372,8 +372,8 @@ describe('#integration-rx navigation', () => {
     )
 
     expect(result).toEqual([
-      Notification.createNext(['f1', 'f2', 'f3']),
-      Notification.createComplete()
+      { kind: 'N', value: ['f1', 'f2', 'f3'] },
+      { kind: 'C' }
     ])
   }
 
@@ -587,10 +587,7 @@ describe('#integration-rx navigation', () => {
         .keys()
         .pipe(materialize(), toArray())
     )
-    expect(keys).toEqual([
-      Notification.createNext([]),
-      Notification.createComplete()
-    ])
+    expect(keys).toEqual([{ kind: 'N', value: [] }, { kind: 'C' }])
   }
 
   /**
@@ -792,8 +789,8 @@ describe('#integration-rx navigation', () => {
       result.keys().pipe(materialize(), toArray())
     )
     expect(keys).toEqual([
-      Notification.createNext(['number', 'text']),
-      Notification.createComplete()
+      { kind: 'N', value: ['number', 'text'] },
+      { kind: 'C' }
     ])
   }
 
@@ -806,12 +803,12 @@ describe('#integration-rx navigation', () => {
       )
     )
     expect(records).toEqual([
-      Notification.createNext([neo4j.int(1), 't1']),
-      Notification.createNext([neo4j.int(2), 't2']),
-      Notification.createNext([neo4j.int(3), 't3']),
-      Notification.createNext([neo4j.int(4), 't4']),
-      Notification.createNext([neo4j.int(5), 't5']),
-      Notification.createComplete()
+      { kind: 'N', value: [neo4j.int(1), 't1'] },
+      { kind: 'N', value: [neo4j.int(2), 't2'] },
+      { kind: 'N', value: [neo4j.int(3), 't3'] },
+      { kind: 'N', value: [neo4j.int(4), 't4'] },
+      { kind: 'N', value: [neo4j.int(5), 't5'] },
+      { kind: 'C' }
     ])
   }
 
@@ -824,14 +821,14 @@ describe('#integration-rx navigation', () => {
       )
     )
     expect(summary).toEqual([
-      Notification.createNext(expectedQueryType),
-      Notification.createComplete()
+      { kind: 'N', value: expectedQueryType },
+      { kind: 'C' }
     ])
   }
 
   async function collectAndAssertEmpty (stream) {
     const result = await lastValueFrom(stream.pipe(materialize(), toArray()))
-    expect(result).toEqual([Notification.createComplete()])
+    expect(result).toEqual([{ kind: 'C' }])
   }
 
   /**
@@ -842,6 +839,6 @@ describe('#integration-rx navigation', () => {
   async function collectAndAssertError (stream, expectedError) {
     const result = await lastValueFrom(stream.pipe(materialize(), toArray()))
 
-    expect(result).toEqual([Notification.createError(expectedError)])
+    expect(result).toEqual([{ kind: 'E', error: expectedError }])
   }
 })

--- a/test/rx/nested-statements.test.js
+++ b/test/rx/nested-statements.test.js
@@ -80,7 +80,9 @@ describe('#integration-rx transaction', () => {
               ),
               map(r => r.get(0)),
               concat(txc.commit()),
-              catchError(err => txc.rollback().pipe(concat(throwError(err)))),
+              catchError(err =>
+                txc.rollback().pipe(concat(throwError(() => err)))
+              ),
               materialize(),
               toArray()
             )

--- a/test/rx/nested-statements.test.js
+++ b/test/rx/nested-statements.test.js
@@ -19,7 +19,7 @@
 
 import { Notification, throwError } from 'rxjs'
 import {
-  flatMap,
+  mergeMap as flatMap,
   materialize,
   toArray,
   concat,

--- a/test/rx/nested-statements.test.js
+++ b/test/rx/nested-statements.test.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { lastValueFrom, Notification, throwError } from 'rxjs'
+import { lastValueFrom, throwError } from 'rxjs'
 import {
   mergeMap as flatMap,
   materialize,
@@ -28,7 +28,6 @@ import {
   catchError
 } from 'rxjs/operators'
 import neo4j from '../../src'
-import RxSession from '../../src/session-rx'
 import sharedNeo4j from '../internal/shared-neo4j'
 
 describe('#integration-rx transaction', () => {
@@ -90,7 +89,7 @@ describe('#integration-rx transaction', () => {
     )
 
     expect(messages.length).toBe(size + 1)
-    expect(messages[size]).toEqual(Notification.createComplete())
+    expect(messages[size]).toEqual({ kind: 'C' })
   })
 
   it('should give proper error when nesting queries within one session', async () => {
@@ -120,11 +119,12 @@ describe('#integration-rx transaction', () => {
     )
 
     expect(result).toEqual([
-      Notification.createError(
-        jasmine.stringMatching(
+      {
+        kind: 'E',
+        error: jasmine.stringMatching(
           /Queries cannot be run directly on a session with an open transaction/
         )
-      )
+      }
     ])
   })
 })

--- a/test/rx/nested-statements.test.js
+++ b/test/rx/nested-statements.test.js
@@ -22,7 +22,7 @@ import {
   mergeMap as flatMap,
   materialize,
   toArray,
-  concat,
+  concatWith as concat,
   map,
   bufferCount,
   catchError

--- a/test/rx/session.test.js
+++ b/test/rx/session.test.js
@@ -18,7 +18,7 @@
  */
 
 import { Notification, throwError } from 'rxjs'
-import { map, materialize, toArray, concat } from 'rxjs/operators'
+import { map, materialize, toArray, concatWith as concat } from 'rxjs/operators'
 import neo4j from '../../src'
 import sharedNeo4j from '../internal/shared-neo4j'
 import { newError, error } from 'neo4j-driver-core'

--- a/test/rx/session.test.js
+++ b/test/rx/session.test.js
@@ -264,7 +264,9 @@ describe('#integration rx-session', () => {
       }
 
       if (this._reactiveFailuresIndex < this._reactiveFailures.length) {
-        return throwError(this._reactiveFailures[this._reactiveFailuresIndex++])
+        return throwError(
+          () => this._reactiveFailures[this._reactiveFailuresIndex++]
+        )
       }
 
       return txc

--- a/test/rx/transaction.test.js
+++ b/test/rx/transaction.test.js
@@ -22,7 +22,7 @@ import {
   mergeMap as flatMap,
   materialize,
   toArray,
-  concat,
+  concatWith as concat,
   map
 } from 'rxjs/operators'
 import neo4j from '../../src'

--- a/test/rx/transaction.test.js
+++ b/test/rx/transaction.test.js
@@ -17,18 +17,15 @@
  * limitations under the License.
  */
 
-import { Notification, throwError } from 'rxjs'
+import { Notification } from 'rxjs'
 import {
-  flatMap,
+  mergeMap as flatMap,
   materialize,
   toArray,
   concat,
-  map,
-  bufferCount,
-  catchError
+  map
 } from 'rxjs/operators'
 import neo4j from '../../src'
-import RxSession from '../../src/session-rx'
 import sharedNeo4j from '../internal/shared-neo4j'
 import { newError } from 'neo4j-driver-core'
 

--- a/test/rx/transaction.test.js
+++ b/test/rx/transaction.test.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { Notification } from 'rxjs'
+import { lastValueFrom, Notification } from 'rxjs'
 import {
   mergeMap as flatMap,
   materialize,
@@ -48,7 +48,7 @@ describe('#integration-rx transaction', () => {
 
   afterEach(async () => {
     if (session) {
-      await session.close().toPromise()
+      await lastValueFrom(session.close(), { defaultValue: undefined })
     }
     await driver.close()
   })
@@ -58,14 +58,13 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const result = await session
-      .beginTransaction()
-      .pipe(
+    const result = await lastValueFrom(
+      session.beginTransaction().pipe(
         flatMap(txc => txc.commit()),
         materialize(),
         toArray()
       )
-      .toPromise()
+    )
 
     expect(result).toEqual([Notification.createComplete()])
   })
@@ -75,14 +74,13 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const result = await session
-      .beginTransaction()
-      .pipe(
+    const result = await lastValueFrom(
+      session.beginTransaction().pipe(
         flatMap(txc => txc.rollback()),
         materialize(),
         toArray()
       )
-      .toPromise()
+    )
 
     expect(result).toEqual([Notification.createComplete()])
   })
@@ -92,9 +90,8 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const result = await session
-      .beginTransaction()
-      .pipe(
+    const result = await lastValueFrom(
+      session.beginTransaction().pipe(
         flatMap(txc =>
           txc
             .run('CREATE (n:Node {id: 42}) RETURN n')
@@ -107,7 +104,7 @@ describe('#integration-rx transaction', () => {
         materialize(),
         toArray()
       )
-      .toPromise()
+    )
     expect(result).toEqual([
       Notification.createNext(neo4j.int(42)),
       Notification.createComplete()
@@ -121,9 +118,8 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const result = await session
-      .beginTransaction()
-      .pipe(
+    const result = await lastValueFrom(
+      session.beginTransaction().pipe(
         flatMap(txc =>
           txc
             .run('CREATE (n:Node {id: 42}) RETURN n')
@@ -136,7 +132,7 @@ describe('#integration-rx transaction', () => {
         materialize(),
         toArray()
       )
-      .toPromise()
+    )
     expect(result).toEqual([
       Notification.createNext(neo4j.int(42)),
       Notification.createComplete()
@@ -174,14 +170,13 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyFailsWithWrongQuery(txc)
 
-    const result = await txc
-      .commit()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.commit().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.objectContaining({
@@ -198,14 +193,13 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyFailsWithWrongQuery(txc)
 
-    const result = await txc
-      .rollback()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.rollback().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([Notification.createComplete()])
   })
 
@@ -214,16 +208,15 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyCanCreateNode(txc, 5)
     await verifyCanReturnOne(txc)
     await verifyFailsWithWrongQuery(txc)
 
-    const result = await txc
-      .commit()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.commit().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.objectContaining({
@@ -240,16 +233,15 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyCanCreateNode(txc, 5)
     await verifyCanReturnOne(txc)
     await verifyFailsWithWrongQuery(txc)
 
-    const result = await txc
-      .rollback()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.rollback().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([Notification.createComplete()])
   })
 
@@ -258,15 +250,16 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyFailsWithWrongQuery(txc)
 
-    const result = await txc
-      .run('CREATE ()')
-      .records()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc
+        .run('CREATE ()')
+        .records()
+        .pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.objectContaining({
@@ -283,15 +276,14 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyCanCreateNode(txc, 6)
     await verifyCanCommit(txc)
 
-    const result = await txc
-      .commit()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.commit().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.objectContaining({
@@ -308,15 +300,14 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyCanCreateNode(txc, 6)
     await verifyCanRollback(txc)
 
-    const result = await txc
-      .rollback()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.rollback().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.objectContaining({
@@ -333,15 +324,14 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyCanCreateNode(txc, 6)
     await verifyCanCommit(txc)
 
-    const result = await txc
-      .rollback()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.rollback().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.objectContaining({
@@ -358,15 +348,14 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     await verifyCanCreateNode(txc, 6)
     await verifyCanRollback(txc)
 
-    const result = await txc
-      .commit()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.commit().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.objectContaining({
@@ -393,12 +382,12 @@ describe('#integration-rx transaction', () => {
 
     const bookmark0 = session.lastBookmark()
 
-    const txc1 = await session.beginTransaction().toPromise()
+    const txc1 = await lastValueFrom(session.beginTransaction())
     await verifyCanCreateNode(txc1, 20)
     await verifyCanCommit(txc1)
     const bookmark1 = session.lastBookmark()
 
-    const txc2 = await session.beginTransaction().toPromise()
+    const txc2 = await lastValueFrom(session.beginTransaction())
     await verifyCanCreateNode(txc2, 21)
     await verifyCanCommit(txc2)
     const bookmark2 = session.lastBookmark()
@@ -415,16 +404,15 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     const result1 = txc.run('CREATE (:TestNode) RETURN 1 AS n')
     const result2 = txc.run('CREATE (:TestNode) RETURN 2 AS n')
     const result3 = txc.run('RETURN 10 / 0 AS n')
     const result4 = txc.run('CREATE (:TestNode) RETURN 3 AS n')
 
-    const result = await result1
-      .records()
-      .pipe(
+    const result = await lastValueFrom(
+      result1.records().pipe(
         concat(result2.records()),
         concat(result3.records()),
         concat(result4.records()),
@@ -432,7 +420,7 @@ describe('#integration-rx transaction', () => {
         materialize(),
         toArray()
       )
-      .toPromise()
+    )
     expect(result).toEqual([
       Notification.createNext(1),
       Notification.createNext(2),
@@ -447,16 +435,15 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     const result1 = txc.run('RETURN 1')
     const result2 = txc.run('RETURN 2')
     const result3 = txc.run('RETURN 3')
     const result4 = txc.run('RETURN 4')
 
-    const result = await result4
-      .records()
-      .pipe(
+    const result = await lastValueFrom(
+      result4.records().pipe(
         concat(result3.records()),
         concat(result2.records()),
         concat(result1.records()),
@@ -464,7 +451,7 @@ describe('#integration-rx transaction', () => {
         materialize(),
         toArray()
       )
-      .toPromise()
+    )
     expect(result).toEqual([
       Notification.createNext(4),
       Notification.createNext(3),
@@ -491,20 +478,19 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
     const result = txc.run('RETURN Wrong')
 
-    const messages = await result
-      .records()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const messages = await lastValueFrom(
+      result.records().pipe(materialize(), toArray())
+    )
     expect(messages).toEqual([
       Notification.createError(
         jasmine.stringMatching(/Variable `Wrong` not defined/)
       )
     ])
 
-    const summary = await result.consume().toPromise()
+    const summary = await lastValueFrom(result.consume())
     expect(summary).toBeTruthy()
   })
 
@@ -513,7 +499,7 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     txc.run('RETURN ILLEGAL')
 
@@ -525,15 +511,16 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
     await verifyCanCreateNode(txc, 15)
     await verifyCanCommitOrRollback(txc, commit)
 
-    const result = await txc
-      .run('CREATE ()')
-      .records()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc
+        .run('CREATE ()')
+        .records()
+        .pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.objectContaining({
@@ -550,20 +537,11 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
-    await txc
-      .run('CREATE (n:Node {id: 1})')
-      .consume()
-      .toPromise()
-    await txc
-      .run('CREATE (n:Node {id: 2})')
-      .consume()
-      .toPromise()
-    await txc
-      .run('CREATE (n:Node {id: 1})')
-      .consume()
-      .toPromise()
+    await lastValueFrom(txc.run('CREATE (n:Node {id: 1})').consume())
+    await lastValueFrom(txc.run('CREATE (n:Node {id: 2})').consume())
+    await lastValueFrom(txc.run('CREATE (n:Node {id: 1})').consume())
 
     await verifyCanCommitOrRollback(txc, commit)
     await verifyCommittedOrRollbacked(commit)
@@ -574,21 +552,22 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     const result1 = txc.run('CREATE (n:Node {id: 1})')
     const result2 = txc.run('CREATE (n:Node {id: 2})')
     const result3 = txc.run('CREATE (n:Node {id: 1})')
 
-    const results = await result1
-      .records()
-      .pipe(
-        concat(result2.records()),
-        concat(result3.records()),
-        materialize(),
-        toArray()
-      )
-      .toPromise()
+    const results = await lastValueFrom(
+      result1
+        .records()
+        .pipe(
+          concat(result2.records()),
+          concat(result3.records()),
+          materialize(),
+          toArray()
+        )
+    )
     expect(results).toEqual([Notification.createComplete()])
 
     await verifyCanCommitOrRollback(txc, commit)
@@ -600,21 +579,22 @@ describe('#integration-rx transaction', () => {
       return
     }
 
-    const txc = await session.beginTransaction().toPromise()
+    const txc = await lastValueFrom(session.beginTransaction())
 
     const result1 = txc.run('CREATE (n:Node {id: 1})')
     const result2 = txc.run('CREATE (n:Node {id: 2})')
     const result3 = txc.run('CREATE (n:Node {id: 1})')
 
-    const results = await result1
-      .keys()
-      .pipe(
-        concat(result2.keys()),
-        concat(result3.keys()),
-        materialize(),
-        toArray()
-      )
-      .toPromise()
+    const results = await lastValueFrom(
+      result1
+        .keys()
+        .pipe(
+          concat(result2.keys()),
+          concat(result3.keys()),
+          materialize(),
+          toArray()
+        )
+    )
     expect(results).toEqual([
       Notification.createNext([]),
       Notification.createNext([]),
@@ -627,18 +607,16 @@ describe('#integration-rx transaction', () => {
   }
 
   async function verifyCanCommit (txc) {
-    const result = await txc
-      .commit()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.commit().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([Notification.createComplete()])
   }
 
   async function verifyCanRollback (txc) {
-    const result = await txc
-      .rollback()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc.rollback().pipe(materialize(), toArray())
+    )
     expect(result).toEqual([Notification.createComplete()])
   }
 
@@ -651,15 +629,16 @@ describe('#integration-rx transaction', () => {
   }
 
   async function verifyCanCreateNode (txc, id) {
-    const result = await txc
-      .run('CREATE (n:Node {id: $id}) RETURN n', { id: neo4j.int(id) })
-      .records()
-      .pipe(
-        map(r => r.get('n').properties.id),
-        materialize(),
-        toArray()
-      )
-      .toPromise()
+    const result = await lastValueFrom(
+      txc
+        .run('CREATE (n:Node {id: $id}) RETURN n', { id: neo4j.int(id) })
+        .records()
+        .pipe(
+          map(r => r.get('n').properties.id),
+          materialize(),
+          toArray()
+        )
+    )
     expect(result).toEqual([
       Notification.createNext(neo4j.int(id)),
       Notification.createComplete()
@@ -667,15 +646,16 @@ describe('#integration-rx transaction', () => {
   }
 
   async function verifyCanReturnOne (txc) {
-    const result = await txc
-      .run('RETURN 1')
-      .records()
-      .pipe(
-        map(r => r.get(0)),
-        materialize(),
-        toArray()
-      )
-      .toPromise()
+    const result = await lastValueFrom(
+      txc
+        .run('RETURN 1')
+        .records()
+        .pipe(
+          map(r => r.get(0)),
+          materialize(),
+          toArray()
+        )
+    )
     expect(result).toEqual([
       Notification.createNext(neo4j.int(1)),
       Notification.createComplete()
@@ -683,11 +663,12 @@ describe('#integration-rx transaction', () => {
   }
 
   async function verifyFailsWithWrongQuery (txc) {
-    const result = await txc
-      .run('RETURN')
-      .records()
-      .pipe(materialize(), toArray())
-      .toPromise()
+    const result = await lastValueFrom(
+      txc
+        .run('RETURN')
+        .records()
+        .pipe(materialize(), toArray())
+    )
     expect(result).toEqual([
       Notification.createError(
         jasmine.stringMatching(/Unexpected end of input|Invalid input/)
@@ -707,13 +688,14 @@ describe('#integration-rx transaction', () => {
 
   async function countNodes (id) {
     const session = driver.rxSession()
-    return await session
-      .run('MATCH (n:Node {id: $id}) RETURN count(n)', { id: id })
-      .records()
-      .pipe(
-        map(r => r.get(0).toInt()),
-        concat(session.close())
-      )
-      .toPromise()
+    return await lastValueFrom(
+      session
+        .run('MATCH (n:Node {id: $id}) RETURN count(n)', { id: id })
+        .records()
+        .pipe(
+          map(r => r.get(0).toInt()),
+          concat(session.close())
+        )
+    )
   }
 })

--- a/test/types/driver.test.ts
+++ b/test/types/driver.test.ts
@@ -29,7 +29,7 @@ import Driver, {
 import { Parameters } from '../../types/query-runner'
 import { ServerInfo, Session } from 'neo4j-driver-core'
 import RxSession from '../../types/session-rx'
-import { concat, map, catchError } from 'rxjs/operators'
+import { concatWith as concat, map, catchError } from 'rxjs/operators'
 import { throwError } from 'rxjs'
 
 const dummy: any = null

--- a/test/types/driver.test.ts
+++ b/test/types/driver.test.ts
@@ -141,7 +141,7 @@ rxSession1
   .pipe(
     map(r => r.get(0)),
     concat(rxSession1.close()),
-    catchError(err => rxSession1.close().pipe(concat(throwError(err))))
+    catchError(err => rxSession1.close().pipe(concat(throwError(() => err))))
   )
   .subscribe({
     next: data => console.log(data),

--- a/test/types/session-rx.test.ts
+++ b/test/types/session-rx.test.ts
@@ -27,7 +27,7 @@ import {
   TransactionConfig
 } from 'neo4j-driver-core'
 import { Observable, of, Observer, throwError } from 'rxjs'
-import { concat, finalize, catchError } from 'rxjs/operators'
+import { concatWith as concat, finalize, catchError } from 'rxjs/operators'
 
 const dummy: any = null
 const intValue: Integer = Integer.fromInt(42)

--- a/test/types/session-rx.test.ts
+++ b/test/types/session-rx.test.ts
@@ -112,7 +112,7 @@ result1
   .consume()
   .pipe(
     concat(close1),
-    catchError(err => close1.pipe(concat(throwError(err))))
+    catchError(err => close1.pipe(concat(throwError(() => err))))
   )
   .subscribe(summaryObserver)
 
@@ -123,7 +123,7 @@ result2
   .consume()
   .pipe(
     concat(close1),
-    catchError(err => close1.pipe(concat(throwError(err))))
+    catchError(err => close1.pipe(concat(throwError(() => err))))
   )
   .subscribe(summaryObserver)
 
@@ -138,7 +138,7 @@ result3
   .consume()
   .pipe(
     concat(close1),
-    catchError(err => close1.pipe(concat(throwError(err))))
+    catchError(err => close1.pipe(concat(throwError(() => err))))
   )
   .subscribe(summaryObserver)
 

--- a/test/types/transaction-rx.test.ts
+++ b/test/types/transaction-rx.test.ts
@@ -20,8 +20,8 @@
 import RxTransaction from '../../types/transaction-rx'
 import { Record, ResultSummary } from 'neo4j-driver-core'
 import RxResult from '../../types/result-rx'
-import { Observable, of, Observer, throwError } from 'rxjs'
-import { concat, finalize, catchError } from 'rxjs/operators'
+import { of, Observer } from 'rxjs'
+import { concatWith as concat } from 'rxjs/operators'
 
 const dummy: any = null
 

--- a/types/transaction-rx.d.ts
+++ b/types/transaction-rx.d.ts
@@ -23,9 +23,9 @@ import RxResult from './result-rx'
 declare interface RxTransaction {
   run(query: string, parameters?: Parameters): RxResult
 
-  commit(): Observable<any>
+  commit(): Observable<void>
 
-  rollback(): Observable<any>
+  rollback(): Observable<void>
 }
 
 export default RxTransaction


### PR DESCRIPTION
- Change `throwError` usage to pass error creator
- Replace `flatMap` import with `mergeMap`
- Replace `concat` import with `concatWith`
- Replace `toPromise` with `lastValueFrom`
- Replace `Notification` instances with plain objects
- Replace `publishReplay` + `refCount` with `shareReplay`
- Simplify `RxTransaction` & `RxSession` using `from` & `defer`

I didn't update the lock file because I have a newer version of npm and updated the entire file. Hopefully a maintainer can commit this.
