### PR TITLE
Adds optional generic parameter to Node and Relationship

### DIFF
--- a/core/src/graph-types.ts
+++ b/core/src/graph-types.ts
@@ -21,6 +21,7 @@ import { stringify } from './json'
 
 type StandardDate = Date
 type NumberOrInteger = number | Integer | bigint
+type Properties = { [key: string]: any }
 
 const IDENTIFIER_PROPERTY_ATTRIBUTES = {
   value: true,
@@ -43,18 +44,18 @@ function hasIdentifierProperty(obj: any, property: string): boolean {
 /**
  * Class for Node Type.
  */
-class Node<T extends NumberOrInteger = Integer> {
+class Node<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
   identity: T
   labels: string[]
-  properties: any
+  properties: P
   /**
    * @constructor
    * @protected
    * @param {Integer|number} identity - Unique identity
    * @param {Array<string>} labels - Array for all labels
-   * @param {Object} properties - Map with node properties
+   * @param {Properties} properties - Map with node properties
    */
-  constructor(identity: T, labels: string[], properties: any) {
+  constructor(identity: T, labels: string[], properties: P) {
     /**
      * Identity of the node.
      * @type {Integer|number}
@@ -67,7 +68,7 @@ class Node<T extends NumberOrInteger = Integer> {
     this.labels = labels
     /**
      * Properties of the node.
-     * @type {Object}
+     * @type {Properties}
      */
     this.properties = properties
   }
@@ -112,12 +113,12 @@ function isNode(obj: object): boolean {
 /**
  * Class for Relationship Type.
  */
-class Relationship<T extends NumberOrInteger = Integer> {
+class Relationship<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
   identity: T
   start: T
   end: T
   type: string
-  properties: any
+  properties: P
 
   /**
    * @constructor
@@ -126,9 +127,9 @@ class Relationship<T extends NumberOrInteger = Integer> {
    * @param {Integer|number} start - Identity of start Node
    * @param {Integer|number} end - Identity of end Node
    * @param {string} type - Relationship type
-   * @param {Object} properties - Map with relationship properties
+   * @param {Properties} properties - Map with relationship properties
    */
-  constructor(identity: T, start: T, end: T, type: string, properties: any) {
+  constructor(identity: T, start: T, end: T, type: string, properties: P) {
     /**
      * Identity of the relationship.
      * @type {Integer|number}
@@ -151,7 +152,7 @@ class Relationship<T extends NumberOrInteger = Integer> {
     this.type = type
     /**
      * Properties of the relationship.
-     * @type {Object}
+     * @type {Properties}
      */
     this.properties = properties
   }
@@ -194,17 +195,17 @@ function isRelationship(obj: object): boolean {
  * Class for UnboundRelationship Type.
  * @access private
  */
-class UnboundRelationship<T extends NumberOrInteger = Integer> {
+class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
   identity: T
   type: string
-  properties: any
+  properties: P
 
   /**
    * @constructor
    * @protected
    * @param {Integer|number} identity - Unique identity
    * @param {string} type - Relationship type
-   * @param {Object} properties - Map with relationship properties
+   * @param {Properties} properties - Map with relationship properties
    */
   constructor(identity: T, type: string, properties: any) {
     /**
@@ -219,7 +220,7 @@ class UnboundRelationship<T extends NumberOrInteger = Integer> {
     this.type = type
     /**
      * Properties of the relationship.
-     * @type {Object}
+     * @type {Properties}
      */
     this.properties = properties
   }

--- a/test/types/graph-types.test.ts
+++ b/test/types/graph-types.test.ts
@@ -32,54 +32,92 @@ import {
   isUnboundRelationship
 } from 'neo4j-driver-core'
 
-const node1: Node = new Node(int(1), ['Person', 'Employee'], { name: 'Alice' })
+type NodeProperties = { name: string }
+type RelationshipProperties = { since: number }
+
+const node1: Node<Integer, NodeProperties> = new Node(
+  int(1),
+  ['Person', 'Employee'],
+  { name: 'Alice' }
+)
 const node1String: string = node1.toString()
 const node1Id: Integer = node1.identity
 const node1Labels: string[] = node1.labels
-const node1Props: object = node1.properties
+const node1Props: NodeProperties = node1.properties
+const node1PropertyName: string = node1.properties.name
 const isNode1: boolean = node1 instanceof Node
 const isNode1B: boolean = isNode(node1)
 
-const node2: Node<number> = new Node(2, ['Person', 'Employee'], {
-  name: 'Alice'
-})
+const node2: Node<number, NodeProperties> = new Node(
+  2,
+  ['Person', 'Employee'],
+  {
+    name: 'Alice'
+  }
+)
 const node2Id: number = node2.identity
+const node2Props: NodeProperties = node2.properties
+const node2PropertyName: string = node2.properties.name
 
-const rel1: Relationship = new Relationship(int(1), int(2), int(3), 'KNOWS', {
-  since: 12345
-})
+const rel1: Relationship<Integer, RelationshipProperties> = new Relationship(
+  int(1),
+  int(2),
+  int(3),
+  'KNOWS',
+  {
+    since: 12345
+  }
+)
 const rel1String: string = rel1.toString()
 const rel1Id: Integer = rel1.identity
 const rel1Start: Integer = rel1.start
 const rel1End: Integer = rel1.end
 const rel1Type: string = rel1.type
-const rel1Props: object = rel1.properties
+const rel1Props: RelationshipProperties = rel1.properties
+const rel1PropertySince: number = rel1.properties.since
 const isRel1: boolean = rel1 instanceof Relationship
 const isRel1B: boolean = isRelationship(rel1)
 
-const rel2: UnboundRelationship = new UnboundRelationship(int(1), 'KNOWS', {
+const rel2: UnboundRelationship<
+  Integer,
+  RelationshipProperties
+> = new UnboundRelationship(int(1), 'KNOWS', {
   since: 12345
 })
 const rel2String: string = rel2.toString()
 const rel3: Relationship = rel2.bind(int(1), int(2))
 const rel2Id: Integer = rel2.identity
 const rel2Type: string = rel2.type
-const rel2Props: object = rel2.properties
+const rel2Props: RelationshipProperties = rel2.properties
+const rel2PropertySince: number = rel2.properties.since
 const isRel2: boolean = rel2 instanceof UnboundRelationship
 const isRel2B: boolean = isUnboundRelationship(rel2)
 
-const rel4: Relationship<number> = new Relationship(2, 3, 4, 'KNOWS', {
-  since: 12345
-})
+const rel4: Relationship<number, RelationshipProperties> = new Relationship(
+  2,
+  3,
+  4,
+  'KNOWS',
+  {
+    since: 12345
+  }
+)
 const rel4Id: number = rel4.identity
 const rel4Start: number = rel4.start
 const rel4End: number = rel4.end
 const isRel4: boolean = rel4 instanceof Relationship
+const rel4Props: RelationshipProperties = rel4.properties
+const rel4PropertySince: number = rel4.properties.since
 
-const rel5: UnboundRelationship<number> = new UnboundRelationship(5, 'KNOWS', {
+const rel5: UnboundRelationship<
+  number,
+  RelationshipProperties
+> = new UnboundRelationship(5, 'KNOWS', {
   since: 12345
 })
 const rel5Id: number = rel5.identity
+const rel5Props: RelationshipProperties = rel5.properties
+const rel5PropertySince: number = rel5.properties.since
 const rel6 = rel5.bind(24, 42)
 const rel6Id: number = rel6.identity
 const rel6Start: number = rel6.start

--- a/test/types/graph-types.test.ts
+++ b/test/types/graph-types.test.ts
@@ -32,68 +32,69 @@ import {
   isUnboundRelationship
 } from 'neo4j-driver-core'
 
-type NodeProperties = { name: string }
-type RelationshipProperties = { since: number }
-
-const node1: Node<Integer, NodeProperties> = new Node(
-  int(1),
-  ['Person', 'Employee'],
-  { name: 'Alice' }
-)
+const node1: Node = new Node(int(1), ['Person', 'Employee'], { name: 'Alice' })
 const node1String: string = node1.toString()
 const node1Id: Integer = node1.identity
 const node1Labels: string[] = node1.labels
-const node1Props: NodeProperties = node1.properties
-const node1PropertyName: string = node1.properties.name
+const node1Props: object = node1.properties
 const isNode1: boolean = node1 instanceof Node
 const isNode1B: boolean = isNode(node1)
 
-const node2: Node<number, NodeProperties> = new Node(
-  2,
-  ['Person', 'Employee'],
-  {
-    name: 'Alice'
-  }
-)
+const node2: Node<number> = new Node(2, ['Person', 'Employee'], {
+  name: 'Alice'
+})
 const node2Id: number = node2.identity
-const node2Props: NodeProperties = node2.properties
-const node2PropertyName: string = node2.properties.name
 
-const rel1: Relationship<Integer, RelationshipProperties> = new Relationship(
-  int(1),
-  int(2),
-  int(3),
-  'KNOWS',
-  {
-    since: 12345
-  }
-)
+type NodeProps = { name: string }
+const node3: Node<number, NodeProps> = new Node(2, ['Person', 'Employee'], {
+  name: 'Alice'
+})
+const node3Props: NodeProps = node3.properties
+const node3PropertyName: string = node3.properties.name
+
+const rel1: Relationship = new Relationship(int(1), int(2), int(3), 'KNOWS', {
+  since: 12345
+})
 const rel1String: string = rel1.toString()
 const rel1Id: Integer = rel1.identity
 const rel1Start: Integer = rel1.start
 const rel1End: Integer = rel1.end
 const rel1Type: string = rel1.type
-const rel1Props: RelationshipProperties = rel1.properties
-const rel1PropertySince: number = rel1.properties.since
+const rel1Props: object = rel1.properties
 const isRel1: boolean = rel1 instanceof Relationship
 const isRel1B: boolean = isRelationship(rel1)
 
-const rel2: UnboundRelationship<
-  Integer,
-  RelationshipProperties
-> = new UnboundRelationship(int(1), 'KNOWS', {
+const rel2: UnboundRelationship = new UnboundRelationship(int(1), 'KNOWS', {
   since: 12345
 })
 const rel2String: string = rel2.toString()
 const rel3: Relationship = rel2.bind(int(1), int(2))
 const rel2Id: Integer = rel2.identity
 const rel2Type: string = rel2.type
-const rel2Props: RelationshipProperties = rel2.properties
-const rel2PropertySince: number = rel2.properties.since
+const rel2Props: object = rel2.properties
 const isRel2: boolean = rel2 instanceof UnboundRelationship
 const isRel2B: boolean = isUnboundRelationship(rel2)
 
-const rel4: Relationship<number, RelationshipProperties> = new Relationship(
+const rel4: Relationship<number> = new Relationship(2, 3, 4, 'KNOWS', {
+  since: 12345
+})
+const rel4Id: number = rel4.identity
+const rel4Start: number = rel4.start
+const rel4End: number = rel4.end
+const isRel4: boolean = rel4 instanceof Relationship
+
+const rel5: UnboundRelationship<number> = new UnboundRelationship(5, 'KNOWS', {
+  since: 12345
+})
+const rel5Id: number = rel5.identity
+const rel6 = rel5.bind(24, 42)
+const rel6Id: number = rel6.identity
+const rel6Start: number = rel6.start
+const rel6End: number = rel6.end
+const isRel6: boolean = rel6 instanceof UnboundRelationship
+
+type RelationshipProps = { since: number }
+const rel7: Relationship<number, RelationshipProps> = new Relationship(
   2,
   3,
   4,
@@ -102,27 +103,17 @@ const rel4: Relationship<number, RelationshipProperties> = new Relationship(
     since: 12345
   }
 )
-const rel4Id: number = rel4.identity
-const rel4Start: number = rel4.start
-const rel4End: number = rel4.end
-const isRel4: boolean = rel4 instanceof Relationship
-const rel4Props: RelationshipProperties = rel4.properties
-const rel4PropertySince: number = rel4.properties.since
+const rel7Props: RelationshipProps = rel7.properties
+const rel7PropertySince: number = rel7.properties.since
 
-const rel5: UnboundRelationship<
+const rel8: UnboundRelationship<
   number,
-  RelationshipProperties
+  RelationshipProps
 > = new UnboundRelationship(5, 'KNOWS', {
   since: 12345
 })
-const rel5Id: number = rel5.identity
-const rel5Props: RelationshipProperties = rel5.properties
-const rel5PropertySince: number = rel5.properties.since
-const rel6 = rel5.bind(24, 42)
-const rel6Id: number = rel6.identity
-const rel6Start: number = rel6.start
-const rel6End: number = rel6.end
-const isRel6: boolean = rel6 instanceof UnboundRelationship
+const rel8Props: RelationshipProps = rel8.properties
+const rel8PropertySince: number = rel8.properties.since
 
 const pathSegment1: PathSegment = new PathSegment(node1, rel1, node1)
 const pathSegment1Start: Node = pathSegment1.start


### PR DESCRIPTION
This feature helps to pass typings of Node and Relationship properties.

- Generic is optional
- No more local overrides are needed

```
import { IUser } from './interfaces/user.inteface';
import { Node } from 'neo4j-driver';

export class User {
    constructor(private readonly node: Node<number, IUser>) {}

    getPassword(): string {
        return this.node.properties.password;
    }
    // ...
}
```