### PR TITLE
Introducing Bearer tokens and SSO support

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -296,6 +296,10 @@ export default class BoltProtocol {
     return observer
   }
 
+  get currentFailure () {
+    return this._responseHandler.currentFailure
+  }
+
   /**
    * Send a RESET through the underlying connection.
    * @param {Object} param

--- a/packages/bolt-connection/src/bolt/response-handler.js
+++ b/packages/bolt-connection/src/bolt/response-handler.js
@@ -86,6 +86,10 @@ export default class ResponseHandler {
     )
   }
 
+  get currentFailure () {
+    return this._currentFailure
+  }
+
   handleResponse (msg) {
     const payload = msg.fields[0]
 
@@ -186,4 +190,5 @@ export default class ResponseHandler {
   _resetFailure () {
     this._currentFailure = null
   }
+
 }

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -270,7 +270,7 @@ export default class ChannelConnection extends Connection {
    */
   _handleFatalError (error) {
     this._isBroken = true
-    this._error = this.handleAndTransformError(error, this._address)
+    this._error = this.handleAndTransformError(this._protocol.currentFailure || error, this._address)
 
     if (this._log.isErrorEnabled()) {
       this._log.error(

--- a/packages/bolt-connection/src/connection/connection-error-handler.js
+++ b/packages/bolt-connection/src/connection/connection-error-handler.js
@@ -77,7 +77,10 @@ export default class ConnectionErrorHandler {
 }
 
 function isAutorizationExpiredError (error) {
-  return error && error.code === 'Neo.ClientError.Security.AuthorizationExpired'
+  return error && ( 
+      error.code === 'Neo.ClientError.Security.AuthorizationExpired' ||
+      error.code === 'Neo.ClientError.Security.TokenExpired'
+  )
 }
 
 function isAvailabilityError (error) {

--- a/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
@@ -119,7 +119,7 @@ it('should purge connections for address when TokenExpired happens', async () =>
   expect(pool.purge).toHaveBeenCalledWith(address)
 })
 
-it('should purge not change error when TokenExpired happens', async () => {
+it('should not change error when TokenExpired happens', async () => {
   const address = ServerAddress.fromUrl('localhost:123')
   const pool = newPool()
   const connectionProvider = newDirectConnectionProvider(address, pool)

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -1532,7 +1532,7 @@ describe('#unit RoutingConnectionProvider', () => {
     expect(pool.purge).toHaveBeenCalledWith(server2)
   })
 
-  it('should purge not change error when TokenExpired happens', async () => {
+  it('should not change error when TokenExpired happens', async () => {
     const pool = newPool()
 
     jest.spyOn(pool, 'purge')
@@ -1788,7 +1788,7 @@ describe('#unit RoutingConnectionProvider', () => {
       expect(pool.purge).toHaveBeenCalledWith(server2)
     })
 
-    it('should purge not change error when TokenExpired happens', async () => {
+    it('should not change error when TokenExpired happens', async () => {
       const pool = newPool()
 
       const connectionProvider = newRoutingConnectionProvider(

--- a/packages/bolt-connection/test/connection/connection-error-handler.test.js
+++ b/packages/bolt-connection/test/connection/connection-error-handler.test.js
@@ -140,6 +140,68 @@ describe('#unit ConnectionErrorHandler', () => {
     expect(addresses).toEqual([])
   })
 
+
+  it('should handle and transform token expired error', () => {
+    const errors = []
+    const addresses = []
+    const transformedError = newError('Message', 'Code')
+    const handler = ConnectionErrorHandler.create({
+      errorCode: SERVICE_UNAVAILABLE,
+      handleAuthorizationExpired: (error, address) => {
+        errors.push(error)
+        addresses.push(address)
+        return transformedError
+      }
+    })
+
+    const error1 = newError(
+      'C',
+      'Neo.ClientError.Security.TokenExpired'
+    )
+
+    const errorTransformed1 = handler.handleAndTransformError(
+      error1,
+      ServerAddress.fromUrl('localhost:0')
+    )
+
+    expect(errorTransformed1).toEqual(transformedError)
+
+    expect(addresses).toEqual([ServerAddress.fromUrl('localhost:0')])
+  })
+
+  it('should return original erro if token expired handler is not informed', () => {
+    const errors = []
+    const addresses = []
+    const transformedError = newError('Message', 'Code')
+    const handler = ConnectionErrorHandler.create({
+      errorCode: SERVICE_UNAVAILABLE,
+      handleUnavailability: (error, address) => {
+        errors.push(error)
+        addresses.push(address)
+        return transformedError
+      },
+      handleWriteFailure: (error, address) => {
+        errors.push(error)
+        addresses.push(address)
+        return transformedError
+      }
+    })
+
+    const error1 = newError(
+      'C',
+      'Neo.ClientError.Security.TokenExpired'
+    )
+
+    const errorTransformed1 = handler.handleAndTransformError(
+      error1,
+      ServerAddress.fromUrl('localhost:0')
+    )
+
+    expect(errorTransformed1).toEqual(error1)
+
+    expect(addresses).toEqual([])
+  })
+
   it('should handle and transform failure to write errors', () => {
     const errors = []
     const addresses = []

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,4 +1,23 @@
 /**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @property {function(username: string, password: string, realm: ?string)} basic the function to create a
  * basic authentication token.
  * @property {function(base64EncodedTicket: string)} kerberos the function to create a Kerberos authentication token.

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,0 +1,63 @@
+/**
+ * @property {function(username: string, password: string, realm: ?string)} basic the function to create a
+ * basic authentication token.
+ * @property {function(base64EncodedTicket: string)} kerberos the function to create a Kerberos authentication token.
+ * Accepts a single string argument - base64 encoded Kerberos ticket.
+ * @property {function(base64EncodedTicket: string)} bearer the function to create a Bearer authentication token.
+ * Accepts a single string argument - base64 encoded Bearer ticket.
+ * @property {function(principal: string, credentials: string, realm: string, scheme: string, parameters: ?object)} custom
+ * the function to create a custom authentication token.
+ */
+ const auth = {
+  basic: (username: string, password: string, realm?: string) => {
+    if (realm) {
+      return {
+        scheme: 'basic',
+        principal: username,
+        credentials: password,
+        realm: realm
+      }
+    } else {
+      return { scheme: 'basic', principal: username, credentials: password }
+    }
+  },
+  kerberos: (base64EncodedTicket: string) => {
+    return {
+      scheme: 'kerberos',
+      principal: '', // This empty string is required for backwards compatibility.
+      credentials: base64EncodedTicket
+    }
+  },
+  bearer: (base64EncodedToken: string) => {
+    return {
+      scheme: 'bearer',
+      credentials: base64EncodedToken
+    }
+  },
+  custom: (
+    principal: string,
+    credentials: string,
+    realm: string,
+    scheme: string,
+    parameters?: string
+  ) => {
+    if (parameters) {
+      return {
+        scheme: scheme,
+        principal: principal,
+        credentials: credentials,
+        realm: realm,
+        parameters: parameters
+      }
+    } else {
+      return {
+        scheme: scheme,
+        principal: principal,
+        credentials: credentials,
+        realm: realm
+      }
+    }
+  }
+}
+
+export default auth

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ import Connection from './connection'
 import Transaction from './transaction'
 import Session, { TransactionConfig } from './session'
 import Driver, * as driver from './driver'
+import auth from './auth'
 import * as types from './types'
 import * as json from './json'
 import * as internal from './internal' // todo: removed afterwards
@@ -138,7 +139,8 @@ const forExport = {
   Connection,
   types,
   driver,
-  json
+  json,
+  auth
 }
 
 export {
@@ -199,7 +201,8 @@ export {
   Driver,
   types,
   driver,
-  json
+  json,
+  auth
 }
 
 export default forExport

--- a/packages/core/test/auth.test.ts
+++ b/packages/core/test/auth.test.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import auth from '../src/auth'
 
 describe('auth', () => {

--- a/packages/core/test/auth.test.ts
+++ b/packages/core/test/auth.test.ts
@@ -1,0 +1,9 @@
+import auth from '../src/auth'
+
+describe('auth', () => {
+
+  test('.bearer()', () => {
+    expect(auth.bearer('==Qyahiadakkda')).toEqual({ scheme: 'bearer', credentials: '==Qyahiadakkda' } )
+  })
+  
+})

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -64,7 +64,8 @@ import {
   ServerInfo,
   Connection,
   driver as coreDriver,
-  types as coreTypes
+  types as coreTypes,
+  auth
 } from 'neo4j-driver-core'
 import {
   DirectConnectionProvider,
@@ -324,65 +325,6 @@ function driver (
   }
 }
 
-/**
- * @property {function(username: string, password: string, realm: ?string)} basic the function to create a
- * basic authentication token.
- * @property {function(base64EncodedTicket: string)} kerberos the function to create a Kerberos authentication token.
- * Accepts a single string argument - base64 encoded Kerberos ticket.
- * @property {function(principal: string, credentials: string, realm: string, scheme: string, parameters: ?object)} custom
- * the function to create a custom authentication token.
- */
-const auth = {
-  basic: (username: string, password: string, realm?: string) => {
-    if (realm) {
-      return {
-        scheme: 'basic',
-        principal: username,
-        credentials: password,
-        realm: realm
-      }
-    } else {
-      return { scheme: 'basic', principal: username, credentials: password }
-    }
-  },
-  kerberos: (base64EncodedTicket: string) => {
-    return {
-      scheme: 'kerberos',
-      principal: '', // This empty string is required for backwards compatibility.
-      credentials: base64EncodedTicket
-    }
-  },
-  bearer: (base64EncodedToken: string) => {
-    return {
-      scheme: 'bearer',
-      credentials: base64EncodedToken
-    }
-  },
-  custom: (
-    principal: string,
-    credentials: string,
-    realm: string,
-    scheme: string,
-    parameters?: string
-  ) => {
-    if (parameters) {
-      return {
-        scheme: scheme,
-        principal: principal,
-        credentials: credentials,
-        realm: realm,
-        parameters: parameters
-      }
-    } else {
-      return {
-        scheme: scheme,
-        principal: principal,
-        credentials: credentials,
-        realm: realm
-      }
-    }
-  }
-}
 const USER_AGENT: string = 'neo4j-javascript/' + VERSION
 
 /**

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -352,6 +352,12 @@ const auth = {
       credentials: base64EncodedTicket
     }
   },
+  bearer: (base64EncodedToken: string) => {
+    return {
+      scheme: 'bearer',
+      credentials: base64EncodedToken
+    }
+  },
   custom: (
     principal: string,
     credentials: string,

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -51,7 +51,8 @@ import {
   Record,
   ResultSummary,
   Result,
-  ConnectionProvider
+  ConnectionProvider,
+  auth
 } from 'neo4j-driver-core'
 import {
   DirectConnectionProvider,
@@ -291,59 +292,6 @@ function driver (url, authToken, config = {}) {
   }
 }
 
-/**
- * @property {function(username: string, password: string, realm: ?string)} basic the function to create a
- * basic authentication token.
- * @property {function(base64EncodedTicket: string)} kerberos the function to create a Kerberos authentication token.
- * Accepts a single string argument - base64 encoded Kerberos ticket.
- * @property {function(principal: string, credentials: string, realm: string, scheme: string, parameters: ?object)} custom
- * the function to create a custom authentication token.
- */
-const auth = {
-  basic: (username, password, realm = undefined) => {
-    if (realm) {
-      return {
-        scheme: 'basic',
-        principal: username,
-        credentials: password,
-        realm: realm
-      }
-    } else {
-      return { scheme: 'basic', principal: username, credentials: password }
-    }
-  },
-  kerberos: base64EncodedTicket => {
-    return {
-      scheme: 'kerberos',
-      principal: '', // This empty string is required for backwards compatibility.
-      credentials: base64EncodedTicket
-    }
-  },
-  bearer: base64EncodedToken => {
-    return {
-      scheme: 'bearer',
-      credentials: base64EncodedToken
-    }
-  },
-  custom: (principal, credentials, realm, scheme, parameters = undefined) => {
-    if (parameters) {
-      return {
-        scheme: scheme,
-        principal: principal,
-        credentials: credentials,
-        realm: realm,
-        parameters: parameters
-      }
-    } else {
-      return {
-        scheme: scheme,
-        principal: principal,
-        credentials: credentials,
-        realm: realm
-      }
-    }
-  }
-}
 const USER_AGENT = 'neo4j-javascript/' + VERSION
 
 /**

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -319,6 +319,12 @@ const auth = {
       credentials: base64EncodedTicket
     }
   },
+  bearer: base64EncodedToken => {
+    return {
+      scheme: 'bearer',
+      credentials: base64EncodedToken
+    }
+  },
   custom: (principal, credentials, realm, scheme, parameters = undefined) => {
     if (parameters) {
       return {

--- a/packages/neo4j-driver/test/types/index.test.ts
+++ b/packages/neo4j-driver/test/types/index.test.ts
@@ -39,6 +39,7 @@ const basicAuthToken1: AuthToken = auth.basic('neo4j', 'password')
 const basicAuthToken2: AuthToken = auth.basic('neo4j', 'password', 'realm')
 
 const kerberosAuthToken1: AuthToken = auth.kerberos('base64EncodedTicket')
+const bearerAuthToken1: AuthToken = auth.bearer('base64EncodedToken')
 
 const customAuthToken1: AuthToken = auth.custom(
   'neo4j',

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -80,6 +80,8 @@ declare const auth: {
 
   kerberos: (base64EncodedTicket: string) => AuthToken
 
+  bearer: (base64EncodedToken: string) => AuthToken
+
   custom: (
     principal: string,
     credentials: string,

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -22,6 +22,8 @@ export function NewDriver (context, data, { writeResponse }) {
     case 'kerberos':
       parsedAuthToken = neo4j.auth.kerberos(authToken.credentials)
       break
+    case 'bearer':
+      parsedAuthToken = neo4j.auth.bearer(authToken.credentials)
     default:
       parsedAuthToken = neo4j.auth.custom(
         authToken.principal,
@@ -261,6 +263,7 @@ export function GetFeatures (_context, _params, wire) {
     features: [
       'Feature:Auth:Custom',
       'Feature:Auth:Kerberos',
+      'Feature:Auth:Bearer',
       'AuthorizationExpiredTreatment',
       'ConfHint:connection.recv_timeout_seconds'
     ]


### PR DESCRIPTION
This change provides an utility function to easy create auth token object for `bearer` tokens.

The error handling related with this kind of token usage is also implemented. When a `Neo.ClientError.Security.TokenExpired` error happens, the adress should be purged from the pool and the caller should be notified - no retry should be performed.