### PR TITLE
Introducing protocol 4.4 and User Impersonation

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-util.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-util.js
@@ -67,7 +67,7 @@ function assertImpersonatedUserIsEmpty (impersonatedUser, onProtocolError = () =
   if (impersonatedUser) {
     const error = newError(
       'Driver is connected to the database that does not support user impersonation. ' +
-        'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+        'Please upgrade to neo4j 4.4.0 or later in order to use this functionality. ' +
         `Trying to impersonate ${impersonatedUser}.`
     )
 

--- a/packages/bolt-connection/src/bolt/bolt-protocol-util.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-util.js
@@ -57,4 +57,25 @@ function assertDatabaseIsEmpty (database, onProtocolError = () => {}, observer) 
   }
 }
 
-export { assertDatabaseIsEmpty, assertTxConfigIsEmpty }
+/**
+ * Asserts that the passed-in impersonated user is empty
+ * @param {string} impersonatedUser 
+ * @param {function (err:Error)} onProtocolError Called when it does have impersonated user set
+ * @param {any} observer
+ */
+function assertImpersonatedUserIsEmpty (impersonatedUser, onProtocolError = () => {}, observer) {
+  if (impersonatedUser) {
+    const error = newError(
+      'Driver is connected to the database that does not support user impersonation. ' +
+        'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+        `Trying to impersonate ${impersonatedUser}.`
+    )
+
+    // unsupported API was used, consider this a fatal error for the current connection
+    onProtocolError(error.message)
+    observer.onError(error)
+    throw error
+  }
+}
+
+export { assertDatabaseIsEmpty, assertTxConfigIsEmpty, assertImpersonatedUserIsEmpty }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -18,7 +18,8 @@
  */
 import {
   assertDatabaseIsEmpty,
-  assertTxConfigIsEmpty
+  assertTxConfigIsEmpty,
+  assertImpersonatedUserIsEmpty
 } from './bolt-protocol-util'
 import { Chunker } from '../chunking'
 import { v1 } from '../packstream'
@@ -143,6 +144,7 @@ export default class BoltProtocol {
    * @param {TxConfig} param.txConfig the configuration.
    * @param {string} param.database the target database name.
    * @param {string} param.mode the access mode.
+   * @param {string} param.impersonatedUser the impersonated user
    * @param {function(err: Error)} param.beforeError the callback to invoke before handling the error.
    * @param {function(err: Error)} param.afterError the callback to invoke after handling the error.
    * @param {function()} param.beforeComplete the callback to invoke before handling the completion.
@@ -154,6 +156,7 @@ export default class BoltProtocol {
     txConfig,
     database,
     mode,
+    impersonatedUser,
     beforeError,
     afterError,
     beforeComplete,
@@ -167,6 +170,7 @@ export default class BoltProtocol {
         txConfig: txConfig,
         database,
         mode,
+        impersonatedUser,
         beforeError,
         afterError,
         beforeComplete,
@@ -248,6 +252,7 @@ export default class BoltProtocol {
    * @param {Bookmark} param.bookmark the bookmark.
    * @param {TxConfig} param.txConfig the transaction configuration.
    * @param {string} param.database the target database name.
+   * @param {string} param.impersonatedUser the impersonated user
    * @param {string} param.mode the access mode.
    * @param {function(keys: string[])} param.beforeKeys the callback to invoke before handling the keys.
    * @param {function(keys: string[])} param.afterKeys the callback to invoke after handling the keys.
@@ -266,6 +271,7 @@ export default class BoltProtocol {
       txConfig,
       database,
       mode,
+      impersonatedUser,
       beforeKeys,
       afterKeys,
       beforeError,
@@ -289,6 +295,8 @@ export default class BoltProtocol {
     assertTxConfigIsEmpty(txConfig, this._onProtocolError, observer)
     // passing in a database name on this protocol version throws an error
     assertDatabaseIsEmpty(database, this._onProtocolError, observer)
+    // passing impersonated user on this protocol version throws an error
+    assertImpersonatedUserIsEmpty(impersonatedUser, this._onProtocolError, observer)
 
     this.write(RequestMessage.run(query, parameters), observer, false)
     this.write(RequestMessage.pullAll(), observer, flush)

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v3.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v3.js
@@ -18,7 +18,7 @@
  */
 import BoltProtocolV2 from './bolt-protocol-v2'
 import RequestMessage from './request-message'
-import { assertDatabaseIsEmpty } from './bolt-protocol-util'
+import { assertDatabaseIsEmpty, assertImpersonatedUserIsEmpty } from './bolt-protocol-util'
 import {
   StreamObserver,
   LoginObserver,
@@ -78,6 +78,7 @@ export default class BoltProtocol extends BoltProtocolV2 {
     bookmark,
     txConfig,
     database,
+    impersonatedUser,
     mode,
     beforeError,
     afterError,
@@ -95,6 +96,8 @@ export default class BoltProtocol extends BoltProtocolV2 {
 
     // passing in a database name on this protocol version throws an error
     assertDatabaseIsEmpty(database, this._onProtocolError, observer)
+    // passing impersonated user on this protocol version throws an error
+    assertImpersonatedUserIsEmpty(impersonatedUser, this._onProtocolError, observer)
 
     this.write(
       RequestMessage.begin({ bookmark, txConfig, mode }),
@@ -152,6 +155,7 @@ export default class BoltProtocol extends BoltProtocolV2 {
       bookmark,
       txConfig,
       database,
+      impersonatedUser,
       mode,
       beforeKeys,
       afterKeys,
@@ -174,6 +178,8 @@ export default class BoltProtocol extends BoltProtocolV2 {
 
     // passing in a database name on this protocol version throws an error
     assertDatabaseIsEmpty(database, this._onProtocolError, observer)
+    // passing impersonated user on this protocol version throws an error
+    assertImpersonatedUserIsEmpty(impersonatedUser, this._onProtocolError, observer)
 
     this.write(
       RequestMessage.runWithMetadata(query, parameters, {

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x0.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x0.js
@@ -18,6 +18,7 @@
  */
 import BoltProtocolV3 from './bolt-protocol-v3'
 import RequestMessage, { ALL } from './request-message'
+import { assertImpersonatedUserIsEmpty } from './bolt-protocol-util'
 import {
   ResultStreamObserver,
   ProcedureRouteObserver
@@ -44,6 +45,7 @@ export default class BoltProtocol extends BoltProtocolV3 {
     bookmark,
     txConfig,
     database,
+    impersonatedUser,
     mode,
     beforeError,
     afterError,
@@ -58,6 +60,9 @@ export default class BoltProtocol extends BoltProtocolV3 {
       afterComplete
     })
     observer.prepareToHandleSingleResponse()
+
+    // passing impersonated user on this protocol version throws an error
+    assertImpersonatedUserIsEmpty(impersonatedUser, this._onProtocolError, observer)
 
     this.write(
       RequestMessage.begin({ bookmark, txConfig, database, mode }),
@@ -75,6 +80,7 @@ export default class BoltProtocol extends BoltProtocolV3 {
       bookmark,
       txConfig,
       database,
+      impersonatedUser,
       mode,
       beforeKeys,
       afterKeys,
@@ -100,6 +106,9 @@ export default class BoltProtocol extends BoltProtocolV3 {
       beforeComplete,
       afterComplete
     })
+
+    // passing impersonated user on this protocol version throws an error
+    assertImpersonatedUserIsEmpty(impersonatedUser, this._onProtocolError, observer)
 
     const flushRun = reactive
     this.write(

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x4.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x4.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ import BoltProtocolV43 from './bolt-protocol-v4x3'
+ 
+ import { internal } from 'neo4j-driver-core'
+ 
+ const {
+   constants: { BOLT_PROTOCOL_V4_4 }
+ } = internal
+ 
+ export default class BoltProtocol extends BoltProtocolV43 {
+   get version () {
+     return BOLT_PROTOCOL_V4_4
+   }
+  
+ }
+ 

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x4.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x4.js
@@ -16,34 +16,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- import BoltProtocolV43 from './bolt-protocol-v4x3'
- 
- import { internal } from 'neo4j-driver-core'
- import RequestMessage, { ALL }  from './request-message'
- import { RouteObserver, ResultStreamObserver } from './stream-observers'
- 
- const {
-    constants: { BOLT_PROTOCOL_V4_4 },
-    bookmark: { Bookmark },
- } = internal
- 
- export default class BoltProtocol extends BoltProtocolV43 {
-   get version () {
-     return BOLT_PROTOCOL_V4_4
-   }
-  
-   /**
-   * Request routing information
-   *
-   * @param {Object} param -
-   * @param {object} param.routingContext The routing context used to define the routing table.
-   *  Multi-datacenter deployments is one of its use cases
-   * @param {string} param.databaseName The database name
-   * @param {Bookmark} params.sessionContext.bookmark The bookmark used for request the routing table
-   * @param {function(err: Error)} param.onError
-   * @param {function(RawRoutingTable)} param.onCompleted
-   * @returns {RouteObserver} the route observer
-   */
+import BoltProtocolV43 from './bolt-protocol-v4x3'
+
+import { internal } from 'neo4j-driver-core'
+import RequestMessage, { ALL } from './request-message'
+import { RouteObserver, ResultStreamObserver } from './stream-observers'
+
+const {
+  constants: { BOLT_PROTOCOL_V4_4 },
+  bookmark: { Bookmark },
+} = internal
+
+export default class BoltProtocol extends BoltProtocolV43 {
+  get version() {
+    return BOLT_PROTOCOL_V4_4
+  }
+
+  /**
+  * Request routing information
+  *
+  * @param {Object} param -
+  * @param {object} param.routingContext The routing context used to define the routing table.
+  *  Multi-datacenter deployments is one of its use cases
+  * @param {string} param.databaseName The database name
+  * @param {Bookmark} params.sessionContext.bookmark The bookmark used for request the routing table
+  * @param {function(err: Error)} param.onError
+  * @param {function(RawRoutingTable)} param.onCompleted
+  * @returns {RouteObserver} the route observer
+  */
   requestRoutingInformation ({
     routingContext = {},
     databaseName = null,
@@ -149,6 +149,5 @@
 
     return observer
   }
-  
- }
- 
+
+}

--- a/packages/bolt-connection/src/bolt/create.js
+++ b/packages/bolt-connection/src/bolt/create.js
@@ -166,7 +166,8 @@ function createProtocol (
         serversideRouting
       )
     case 4.4:
-      return new BoltProtocolV4x4(server,
+      return new BoltProtocolV4x4(
+        server,
         chunker,
         packingConfig,
         createResponseHandler,

--- a/packages/bolt-connection/src/bolt/create.js
+++ b/packages/bolt-connection/src/bolt/create.js
@@ -25,6 +25,7 @@ import BoltProtocolV4x0 from './bolt-protocol-v4x0'
 import BoltProtocolV4x1 from './bolt-protocol-v4x1'
 import BoltProtocolV4x2 from './bolt-protocol-v4x2'
 import BoltProtocolV4x3 from './bolt-protocol-v4x3'
+import BoltProtocolV4x4 from './bolt-protocol-v4x4'
 import { Chunker, Dechunker } from '../channel'
 import ResponseHandler from './response-handler'
 
@@ -157,6 +158,15 @@ function createProtocol (
     case 4.3:
       return new BoltProtocolV4x3(
         server,
+        chunker,
+        packingConfig,
+        createResponseHandler,
+        log,
+        onProtocolError,
+        serversideRouting
+      )
+    case 4.4:
+      return new BoltProtocolV4x4(server,
         chunker,
         packingConfig,
         createResponseHandler,

--- a/packages/bolt-connection/src/bolt/handshake.js
+++ b/packages/bolt-connection/src/bolt/handshake.js
@@ -76,7 +76,7 @@ function parseNegotiatedResponse (buffer) {
  */
 function newHandshakeBuffer () {
   return createHandshakeMessage([
-    [version(4, 3), version(4, 2)],
+    [version(4, 4), version(4, 2)],
     version(4, 1),
     version(4, 0),
     version(3, 0)

--- a/packages/bolt-connection/src/bolt/request-message.js
+++ b/packages/bolt-connection/src/bolt/request-message.js
@@ -160,7 +160,7 @@ export default class RequestMessage {
    * @param {TxConfig} txConfig the configuration.
    * @param {string} database the database name.
    * @param {string} mode the access mode.
-   * @param {string} impersonatedUser the impersonated user mode.
+   * @param {string} impersonatedUser the impersonated user.
    * @return {RequestMessage} new RUN message with additional metadata.
    */
   static runWithMetadata (

--- a/packages/bolt-connection/src/bolt/request-message.js
+++ b/packages/bolt-connection/src/bolt/request-message.js
@@ -124,10 +124,11 @@ export default class RequestMessage {
    * @param {TxConfig} txConfig the configuration.
    * @param {string} database the database name.
    * @param {string} mode the access mode.
+   * @param {string} impersonatedUser the impersonated user mode.
    * @return {RequestMessage} new BEGIN message.
    */
-  static begin ({ bookmark, txConfig, database, mode } = {}) {
-    const metadata = buildTxMetadata(bookmark, txConfig, database, mode)
+  static begin ({ bookmark, txConfig, database, mode, impersonatedUser } = {}) {
+    const metadata = buildTxMetadata(bookmark, txConfig, database, mode, impersonatedUser)
     return new RequestMessage(
       BEGIN,
       [metadata],
@@ -159,14 +160,15 @@ export default class RequestMessage {
    * @param {TxConfig} txConfig the configuration.
    * @param {string} database the database name.
    * @param {string} mode the access mode.
+   * @param {string} impersonatedUser the impersonated user mode.
    * @return {RequestMessage} new RUN message with additional metadata.
    */
   static runWithMetadata (
     query,
     parameters,
-    { bookmark, txConfig, database, mode } = {}
+    { bookmark, txConfig, database, mode, impersonatedUser } = {}
   ) {
-    const metadata = buildTxMetadata(bookmark, txConfig, database, mode)
+    const metadata = buildTxMetadata(bookmark, txConfig, database, mode, impersonatedUser)
     return new RequestMessage(
       RUN,
       [query, parameters, metadata],
@@ -267,9 +269,10 @@ export default class RequestMessage {
  * @param {TxConfig} txConfig the configuration.
  * @param {string} database the database name.
  * @param {string} mode the access mode.
+ * @param {string} impersonatedUser the impersonated user mode.
  * @return {Object} a metadata object.
  */
-function buildTxMetadata (bookmark, txConfig, database, mode) {
+function buildTxMetadata (bookmark, txConfig, database, mode, impersonatedUser) {
   const metadata = {}
   if (!bookmark.isEmpty()) {
     metadata.bookmarks = bookmark.values()
@@ -282,6 +285,9 @@ function buildTxMetadata (bookmark, txConfig, database, mode) {
   }
   if (database) {
     metadata.db = assertString(database, 'database')
+  }
+  if (impersonatedUser) {
+    metadata.imp_user = assertString(impersonatedUser, 'impersonatedUser')
   }
   if (mode === ACCESS_MODE_READ) {
     metadata.mode = READ_MODE

--- a/packages/bolt-connection/src/bolt/request-message.js
+++ b/packages/bolt-connection/src/bolt/request-message.js
@@ -237,6 +237,28 @@ export default class RequestMessage {
         )} ${databaseName}`
     )
   }
+
+  /**
+   * Generate the ROUTE message, this message is used to fetch the routing table from the server
+   *
+   * @param {object} routingContext The routing context used to define the routing table. Multi-datacenter deployments is one of its use cases
+   * @param {string[]} bookmarks The list of the bookmark should be used
+   * @param {object} databaseContext The context inforamtion of the database to get the routing table for.
+   * @param {string} databaseContext.databaseName The name of the database to get the routing table.
+   * @param {string} databaseContext.impersonatedUser The name of the user it should it's impersonation to get the routing table.
+   * @return {RequestMessage} the ROUTE message.
+   */
+   static routeV4x4 (routingContext = {}, bookmarks = [], databaseContext = {}) {
+    const dbContext = { db: databaseContext.databaseName, imp_user: databaseContext.impersonatedUser }
+    return new RequestMessage(
+      ROUTE,
+      [routingContext, bookmarks, dbContext],
+      () =>
+        `ROUTE ${json.stringify(routingContext)} ${json.stringify(
+          bookmarks
+        )} ${json.stringify(dbContext)}`
+    )
+  }
 }
 
 /**

--- a/packages/bolt-connection/src/bolt/request-message.js
+++ b/packages/bolt-connection/src/bolt/request-message.js
@@ -247,7 +247,7 @@ export default class RequestMessage {
    * @param {string[]} bookmarks The list of the bookmark should be used
    * @param {object} databaseContext The context inforamtion of the database to get the routing table for.
    * @param {string} databaseContext.databaseName The name of the database to get the routing table.
-   * @param {string} databaseContext.impersonatedUser The name of the user it should it's impersonation to get the routing table.
+   * @param {string} databaseContext.impersonatedUser The name of the user to impersonation when getting the routing table.
    * @return {RequestMessage} the ROUTE message.
    */
    static routeV4x4 (routingContext = {}, bookmarks = [], databaseContext = {}) {

--- a/packages/bolt-connection/src/bolt/request-message.js
+++ b/packages/bolt-connection/src/bolt/request-message.js
@@ -124,7 +124,7 @@ export default class RequestMessage {
    * @param {TxConfig} txConfig the configuration.
    * @param {string} database the database name.
    * @param {string} mode the access mode.
-   * @param {string} impersonatedUser the impersonated user mode.
+   * @param {string} impersonatedUser the impersonated user.
    * @return {RequestMessage} new BEGIN message.
    */
   static begin ({ bookmark, txConfig, database, mode, impersonatedUser } = {}) {

--- a/packages/bolt-connection/src/bolt/request-message.js
+++ b/packages/bolt-connection/src/bolt/request-message.js
@@ -251,7 +251,16 @@ export default class RequestMessage {
    * @return {RequestMessage} the ROUTE message.
    */
    static routeV4x4 (routingContext = {}, bookmarks = [], databaseContext = {}) {
-    const dbContext = { db: databaseContext.databaseName, imp_user: databaseContext.impersonatedUser }
+    const dbContext = {}
+
+    if ( databaseContext.databaseName ) {
+      dbContext.db = databaseContext.databaseName
+    }
+    
+    if ( databaseContext.impersonatedUser ) {
+      dbContext.imp_user = databaseContext.impersonatedUser
+    }
+
     return new RequestMessage(
       ROUTE,
       [routingContext, bookmarks, dbContext],

--- a/packages/bolt-connection/src/bolt/routing-table-raw.js
+++ b/packages/bolt-connection/src/bolt/routing-table-raw.js
@@ -147,6 +147,10 @@ class RecordRawRoutingTable extends RawRoutingTable {
     return this._record.get('servers')
   }
 
+  get db () {
+    return this._record.has('db') ? this._record.get('db') : null
+  }
+
   get isNull () {
     return this._record === null
   }

--- a/packages/bolt-connection/src/bolt/routing-table-raw.js
+++ b/packages/bolt-connection/src/bolt/routing-table-raw.js
@@ -65,6 +65,15 @@ export default class RawRoutingTable {
   }
 
   /**
+   * Get raw db
+   *
+   * @returns {string?} The database name
+   */
+   get db () {
+    throw new Error('Not implemented')
+  }
+
+  /**
    *
    * @typedef {Object} ServerRole
    * @property {string} role the role of the address on the cluster
@@ -101,6 +110,10 @@ class ResponseRawRoutingTable extends RawRoutingTable {
 
   get servers () {
     return this._response.rt.servers
+  }
+
+  get db () {
+    return this._response.rt.db
   }
 
   get isNull () {

--- a/packages/bolt-connection/src/bolt/routing-table-raw.js
+++ b/packages/bolt-connection/src/bolt/routing-table-raw.js
@@ -69,7 +69,7 @@ export default class RawRoutingTable {
    *
    * @returns {string?} The database name
    */
-   get db () {
+  get db () {
     throw new Error('Not implemented')
   }
 

--- a/packages/bolt-connection/src/connection-provider/connection-provider-direct.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-direct.js
@@ -26,7 +26,7 @@ import {
 import { internal, error } from 'neo4j-driver-core'
 
 const {
-  constants: { BOLT_PROTOCOL_V4_0, BOLT_PROTOCOL_V3 }
+  constants: { BOLT_PROTOCOL_V4_0, BOLT_PROTOCOL_V3, BOLT_PROTOCOL_V4_4 }
 } = internal
 
 const { SERVICE_UNAVAILABLE, newError } = error
@@ -95,6 +95,12 @@ export default class DirectConnectionProvider extends PooledConnectionProvider {
   async supportsTransactionConfig () {
     return await this._hasProtocolVersion(
       version => version >= BOLT_PROTOCOL_V3
+    )
+  }
+
+  async supportsUserImpersonation () {
+    return await this._hasProtocolVersion(
+      version => version >= BOLT_PROTOCOL_V4_4
     )
   }
 }

--- a/packages/bolt-connection/src/connection-provider/connection-provider-direct.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-direct.js
@@ -26,7 +26,7 @@ import {
 import { internal, error } from 'neo4j-driver-core'
 
 const {
-  constants: { BOLT_PROTOCOL_V4_0, BOLT_PROTOCOL_V3, BOLT_PROTOCOL_V4_4 }
+  constants: { BOLT_PROTOCOL_V3, BOLT_PROTOCOL_V4_0, BOLT_PROTOCOL_V4_4 }
 } = internal
 
 const { SERVICE_UNAVAILABLE, newError } = error

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -36,7 +36,8 @@ const {
     ACCESS_MODE_READ: READ,
     ACCESS_MODE_WRITE: WRITE,
     BOLT_PROTOCOL_V3,
-    BOLT_PROTOCOL_V4_0
+    BOLT_PROTOCOL_V4_0,
+    BOLT_PROTOCOL_V4_4
   }
 } = internal
 
@@ -223,6 +224,12 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
       version => version >= BOLT_PROTOCOL_V3
     )
   }
+
+  async supportsUserImpersonation () {
+    return await this._hasProtocolVersion(
+      version => version >= BOLT_PROTOCOL_V4_4
+    )
+  }  
 
   forget (address, database) {
     this._routingTableRegistry.apply(database, {

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -178,6 +178,15 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     }
   }
 
+  /**
+   * Resolve database name
+   * @param {string|undefined|null} database Database name
+   * @return {string} the resolved db name
+  **/
+  resolveDatabaseName(database) {
+    return this._routingTableRegistry.get(database || DEFAULT_DB_NAME, { routingTableDatabase: database }).routingTableDatabase
+  }
+
   async _hasProtocolVersion (versionPredicate) {
     const addresses = await this._resolveSeedRouter(this._seedRouter)
 

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -563,8 +563,6 @@ class RoutingTableRegistry {
   /**
    * Put a routing table in the registry
    *
-   * @param {string|impersonatedUser} impersonatedUser The impersonated User
-   * @param {string} database The database name
    * @param {RoutingTable} table The routing table
    * @returns {RoutingTableRegistry} this
    */
@@ -577,7 +575,6 @@ class RoutingTableRegistry {
    * Apply function in the routing table for an specific database. If the database name is not defined, the function will
    * be applied for each element
    *
-   * @param {string|impersonatedUser} impersonatedUser The impersonated User
    * @param {string} database The database name
    * @param {object} callbacks The actions
    * @param {function (RoutingTable)} callbacks.applyWhenExists Call when the db exists or when the database property is not informed
@@ -587,7 +584,7 @@ class RoutingTableRegistry {
   apply (database, { applyWhenExists, applyWhenDontExists = () => {} } = {}) {
     if (this._tables.has(database)) {
       applyWhenExists(this._tables.get(database))
-    } else if (typeof db === 'string' || db === null) {
+    } else if (typeof database === 'string' || database === null) {
       applyWhenDontExists()
     } else {
       this._forEach(applyWhenExists)

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -673,6 +673,6 @@ class DatabaseNameRegistry {
   }
 
   resolveName(impersonatedUser, database) {
-    return database === DEFAULT_DB_NAME? this._homedbs.get(impersonatedUser) : database
+    return database === DEFAULT_DB_NAME ? this._homedbs.get(impersonatedUser) : database
   }
 }

--- a/packages/bolt-connection/src/rediscovery/rediscovery.js
+++ b/packages/bolt-connection/src/rediscovery/rediscovery.js
@@ -38,15 +38,17 @@ export default class Rediscovery {
    * @param {Session} session the session to use.
    * @param {string} database the database for which to lookup routing table.
    * @param {ServerAddress} routerAddress the URL of the router.
+   * @param {string} impersonatedUser The impersonated user
    * @return {Promise<RoutingTable>} promise resolved with new routing table or null when connection error happened.
    */
-  lookupRoutingTableOnRouter (session, database, routerAddress) {
+  lookupRoutingTableOnRouter (session, database, routerAddress, impersonatedUser) {
     return session._acquireConnection(connection => {
       return this._requestRawRoutingTable(
         connection,
         session,
         database,
-        routerAddress
+        routerAddress,
+        impersonatedUser
       ).then(rawRoutingTable => {
         if (rawRoutingTable.isNull) {
           return null
@@ -60,11 +62,12 @@ export default class Rediscovery {
     })
   }
 
-  _requestRawRoutingTable (connection, session, database, routerAddress) {
+  _requestRawRoutingTable (connection, session, database, routerAddress, impersonatedUser) {
     return new Promise((resolve, reject) => {
       connection.protocol().requestRoutingInformation({
         routingContext: this._routingContext,
         databaseName: database,
+        impersonatedUser,
         sessionContext: {
           bookmark: session._lastBookmark,
           mode: session._mode,

--- a/packages/bolt-connection/src/rediscovery/routing-table.js
+++ b/packages/bolt-connection/src/rediscovery/routing-table.js
@@ -38,7 +38,6 @@ const MIN_ROUTERS = 1
  */
 export default class RoutingTable {
   constructor ({
-    routingTableDatabase,
     database,
     routers,
     readers,
@@ -46,8 +45,7 @@ export default class RoutingTable {
     expirationTime,
     ttl
   } = {}) {
-    this.routingTableDatabase = routingTableDatabase
-    this.database = database
+    this.database = database || null
     this.databaseName = database || 'default database'
     this.routers = routers || []
     this.readers = readers || []
@@ -149,7 +147,6 @@ export function createValidRoutingTable (
   routerAddress,
   rawRoutingTable
 ) {
-  const routingTableDatabase = rawRoutingTable.db
   const ttl = rawRoutingTable.ttl
   const expirationTime = calculateExpirationTime(rawRoutingTable, routerAddress)
   const { routers, readers, writers } = parseServers(
@@ -161,8 +158,7 @@ export function createValidRoutingTable (
   assertNonEmpty(readers, 'readers', routerAddress)
 
   return new RoutingTable({
-    routingTableDatabase,
-    database,
+    database: database || rawRoutingTable.db,
     routers,
     readers,
     writers,

--- a/packages/bolt-connection/src/rediscovery/routing-table.js
+++ b/packages/bolt-connection/src/rediscovery/routing-table.js
@@ -38,6 +38,7 @@ const MIN_ROUTERS = 1
  */
 export default class RoutingTable {
   constructor ({
+    routingTableDatabase,
     database,
     routers,
     readers,
@@ -45,6 +46,7 @@ export default class RoutingTable {
     expirationTime,
     ttl
   } = {}) {
+    this.routingTableDatabase = routingTableDatabase
     this.database = database
     this.databaseName = database || 'default database'
     this.routers = routers || []
@@ -137,7 +139,7 @@ function removeFromArray (array, element) {
 /**
  * Create a valid routing table from a raw object
  *
- * @param {string} database the database name. It is used for logging purposes
+ * @param {string} db the database name. It is used for logging purposes
  * @param {ServerAddress} routerAddress The router address, it is used for loggin purposes
  * @param {RawRoutingTable} rawRoutingTable Method used to get the raw routing table to be processed
  * @param {RoutingTable} The valid Routing Table
@@ -147,6 +149,7 @@ export function createValidRoutingTable (
   routerAddress,
   rawRoutingTable
 ) {
+  const routingTableDatabase = rawRoutingTable.db
   const ttl = rawRoutingTable.ttl
   const expirationTime = calculateExpirationTime(rawRoutingTable, routerAddress)
   const { routers, readers, writers } = parseServers(
@@ -158,6 +161,7 @@ export function createValidRoutingTable (
   assertNonEmpty(readers, 'readers', routerAddress)
 
   return new RoutingTable({
+    routingTableDatabase,
     database,
     routers,
     readers,

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v1.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v1.test.js
@@ -288,7 +288,7 @@ describe('#unit BoltProtocolV1', () => {
 
       expect(() => fn(protocol)).toThrowError(
         'Driver is connected to the database that does not support user impersonation. ' +
-          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          'Please upgrade to neo4j 4.4.0 or later in order to use this functionality. ' +
           `Trying to impersonate ${impersonatedUser}.`
       )
     }

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v1.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v1.test.js
@@ -277,6 +277,47 @@ describe('#unit BoltProtocolV1', () => {
     })
   })
 
+  describe('Bolt v4.4', () => {
+    /**
+     * @param {string} impersonatedUser The impersonated user.
+     * @param {function(protocol: BoltProtocolV1)} fn 
+     */
+    function verifyImpersonationNotSupportedErrror (impersonatedUser, fn) {
+      const recorder = new utils.MessageRecordingConnection()
+      const protocol = new BoltProtocolV1(recorder, null, false)
+
+      expect(() => fn(protocol)).toThrowError(
+        'Driver is connected to the database that does not support user impersonation. ' +
+          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          `Trying to impersonate ${impersonatedUser}.`
+      )
+    }
+
+    describe('beginTransaction', () => {
+      function verifyBeginTransaction(impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.beginTransaction({ impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyBeginTransaction('test')
+      })
+    })
+
+    describe('run', () => {
+      function verifyRun (impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.run('query', {}, { impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyRun('test')
+      })
+    })
+  })
+
   describe('unpacker configuration', () => {
     test.each([
       [false, false],

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v2.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v2.test.js
@@ -51,4 +51,45 @@ describe('#unit BoltProtocolV2', () => {
       }
     )
   })
+
+  describe('Bolt v4.4', () => {
+    /**
+     * @param {string} impersonatedUser The impersonated user.
+     * @param {function(protocol: BoltProtocolV2)} fn 
+     */
+    function verifyImpersonationNotSupportedErrror (impersonatedUser, fn) {
+      const recorder = new utils.MessageRecordingConnection()
+      const protocol = new BoltProtocolV2(recorder, null, false)
+
+      expect(() => fn(protocol)).toThrowError(
+        'Driver is connected to the database that does not support user impersonation. ' +
+          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          `Trying to impersonate ${impersonatedUser}.`
+      )
+    }
+
+    describe('beginTransaction', () => {
+      function verifyBeginTransaction(impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.beginTransaction({ impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyBeginTransaction('test')
+      })
+    })
+
+    describe('run', () => {
+      function verifyRun (impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.run('query', {}, { impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyRun('test')
+      })
+    })
+  })
 })

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v2.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v2.test.js
@@ -63,7 +63,7 @@ describe('#unit BoltProtocolV2', () => {
 
       expect(() => fn(protocol)).toThrowError(
         'Driver is connected to the database that does not support user impersonation. ' +
-          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          'Please upgrade to neo4j 4.4.0 or later in order to use this functionality. ' +
           `Trying to impersonate ${impersonatedUser}.`
       )
     }

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v3.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v3.test.js
@@ -245,7 +245,7 @@ describe('#unit BoltProtocolV3', () => {
 
       expect(() => fn(protocol)).toThrowError(
         'Driver is connected to the database that does not support user impersonation. ' +
-          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          'Please upgrade to neo4j 4.4.0 or later in order to use this functionality. ' +
           `Trying to impersonate ${impersonatedUser}.`
       )
     }

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v3.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v3.test.js
@@ -234,6 +234,47 @@ describe('#unit BoltProtocolV3', () => {
     })
   })
 
+  describe('Bolt v4.4', () => {
+    /**
+     * @param {string} impersonatedUser The impersonated user.
+     * @param {function(protocol: BoltProtocolV3)} fn 
+     */
+    function verifyImpersonationNotSupportedErrror (impersonatedUser, fn) {
+      const recorder = new utils.MessageRecordingConnection()
+      const protocol = new BoltProtocolV3(recorder, null, false)
+
+      expect(() => fn(protocol)).toThrowError(
+        'Driver is connected to the database that does not support user impersonation. ' +
+          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          `Trying to impersonate ${impersonatedUser}.`
+      )
+    }
+
+    describe('beginTransaction', () => {
+      function verifyBeginTransaction(impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.beginTransaction({ impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyBeginTransaction('test')
+      })
+    })
+
+    describe('run', () => {
+      function verifyRun (impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.run('query', {}, { impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyRun('test')
+      })
+    })
+  })
+
   describe('unpacker configuration', () => {
     test.each([
       [false, false],

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x0.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x0.test.js
@@ -152,6 +152,47 @@ describe('#unit BoltProtocolV4x0', () => {
       { ...sessionContext, txConfig: TxConfig.empty() }
     ])
   })
+  
+  describe('Bolt v4.4', () => {
+    /**
+     * @param {string} impersonatedUser The impersonated user.
+     * @param {function(protocol: BoltProtocolV4x0)} fn 
+     */
+    function verifyImpersonationNotSupportedErrror (impersonatedUser, fn) {
+      const recorder = new utils.MessageRecordingConnection()
+      const protocol = new BoltProtocolV4x0(recorder, null, false)
+
+      expect(() => fn(protocol)).toThrowError(
+        'Driver is connected to the database that does not support user impersonation. ' +
+          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          `Trying to impersonate ${impersonatedUser}.`
+      )
+    }
+
+    describe('beginTransaction', () => {
+      function verifyBeginTransaction(impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.beginTransaction({ impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyBeginTransaction('test')
+      })
+    })
+
+    describe('run', () => {
+      function verifyRun (impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.run('query', {}, { impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyRun('test')
+      })
+    })
+  })
 
   describe('unpacker configuration', () => {
     test.each([

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x0.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x0.test.js
@@ -164,7 +164,7 @@ describe('#unit BoltProtocolV4x0', () => {
 
       expect(() => fn(protocol)).toThrowError(
         'Driver is connected to the database that does not support user impersonation. ' +
-          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          'Please upgrade to neo4j 4.4.0 or later in order to use this functionality. ' +
           `Trying to impersonate ${impersonatedUser}.`
       )
     }

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x1.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x1.test.js
@@ -32,7 +32,7 @@ describe('#unit BoltProtocolV4x1', () => {
 
       expect(() => fn(protocol)).toThrowError(
         'Driver is connected to the database that does not support user impersonation. ' +
-          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          'Please upgrade to neo4j 4.4.0 or later in order to use this functionality. ' +
           `Trying to impersonate ${impersonatedUser}.`
       )
     }

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x1.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x1.test.js
@@ -18,8 +18,50 @@
  */
 
 import BoltProtocolV4x1 from '../../src/bolt/bolt-protocol-v4x1'
+import utils from '../test-utils'
 
 describe('#unit BoltProtocolV4x1', () => {
+  describe('Bolt v4.4', () => {
+    /**
+     * @param {string} impersonatedUser The impersonated user.
+     * @param {function(protocol: BoltProtocolV4x1)} fn 
+     */
+    function verifyImpersonationNotSupportedErrror (impersonatedUser, fn) {
+      const recorder = new utils.MessageRecordingConnection()
+      const protocol = new BoltProtocolV4x1(recorder, null, false)
+
+      expect(() => fn(protocol)).toThrowError(
+        'Driver is connected to the database that does not support user impersonation. ' +
+          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          `Trying to impersonate ${impersonatedUser}.`
+      )
+    }
+
+    describe('beginTransaction', () => {
+      function verifyBeginTransaction(impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.beginTransaction({ impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyBeginTransaction('test')
+      })
+    })
+
+    describe('run', () => {
+      function verifyRun (impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.run('query', {}, { impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyRun('test')
+      })
+    })
+  })
+
   describe('unpacker configuration', () => {
     test.each([
       [false, false],

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x2.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x2.test.js
@@ -18,8 +18,49 @@
  */
 
 import BoltProtocolV4x2 from '../../src/bolt/bolt-protocol-v4x2'
+import utils from '../test-utils'
 
 describe('#unit BoltProtocolV4x2', () => {
+  describe('Bolt v4.4', () => {
+    /**
+     * @param {string} impersonatedUser The impersonated user.
+     * @param {function(protocol: BoltProtocolV4x2)} fn 
+     */
+    function verifyImpersonationNotSupportedErrror (impersonatedUser, fn) {
+      const recorder = new utils.MessageRecordingConnection()
+      const protocol = new BoltProtocolV4x2(recorder, null, false)
+
+      expect(() => fn(protocol)).toThrowError(
+        'Driver is connected to the database that does not support user impersonation. ' +
+          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          `Trying to impersonate ${impersonatedUser}.`
+      )
+    }
+
+    describe('beginTransaction', () => {
+      function verifyBeginTransaction(impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.beginTransaction({ impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyBeginTransaction('test')
+      })
+    })
+
+    describe('run', () => {
+      function verifyRun (impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.run('query', {}, { impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyRun('test')
+      })
+    })
+  })
   describe('unpacker configuration', () => {
     test.each([
       [false, false],

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x2.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x2.test.js
@@ -32,7 +32,7 @@ describe('#unit BoltProtocolV4x2', () => {
 
       expect(() => fn(protocol)).toThrowError(
         'Driver is connected to the database that does not support user impersonation. ' +
-          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          'Please upgrade to neo4j 4.4.0 or later in order to use this functionality. ' +
           `Trying to impersonate ${impersonatedUser}.`
       )
     }

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
@@ -238,6 +238,47 @@ describe('#unit BoltProtocolV4x3', () => {
     expect(protocol.flushes).toEqual([true])
   })
 
+  describe('Bolt v4.4', () => {
+    /**
+     * @param {string} impersonatedUser The impersonated user.
+     * @param {function(protocol: BoltProtocolV4x3)} fn 
+     */
+    function verifyImpersonationNotSupportedErrror (impersonatedUser, fn) {
+      const recorder = new utils.MessageRecordingConnection()
+      const protocol = new BoltProtocolV4x3(recorder, null, false)
+
+      expect(() => fn(protocol)).toThrowError(
+        'Driver is connected to the database that does not support user impersonation. ' +
+          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          `Trying to impersonate ${impersonatedUser}.`
+      )
+    }
+
+    describe('beginTransaction', () => {
+      function verifyBeginTransaction(impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.beginTransaction({ impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyBeginTransaction('test')
+      })
+    })
+
+    describe('run', () => {
+      function verifyRun (impersonatedUser) {
+        verifyImpersonationNotSupportedErrror(
+          impersonatedUser,
+          protocol => protocol.run('query', {}, { impersonatedUser }))
+      }
+
+      it('should throw error when impersonatedUser is set', () => {
+        verifyRun('test')
+      })
+    })
+  })
+
   describe('unpacker configuration', () => {
     test.each([
       [false, false],

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
@@ -249,7 +249,7 @@ describe('#unit BoltProtocolV4x3', () => {
 
       expect(() => fn(protocol)).toThrowError(
         'Driver is connected to the database that does not support user impersonation. ' +
-          'Please upgrade to neo4j 4.0.0 or later in order to use this functionality. ' +
+          'Please upgrade to neo4j 4.4.0 or later in order to use this functionality. ' +
           `Trying to impersonate ${impersonatedUser}.`
       )
     }

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BoltProtocolV4x4 from '../../src/bolt/bolt-protocol-v4x4'
+import RequestMessage from '../../src/bolt/request-message'
+import utils from '../test-utils'
+import { RouteObserver } from '../../src/bolt/stream-observers'
+import { internal } from 'neo4j-driver-core'
+
+const WRITE = 'WRITE'
+
+const {
+  txConfig: { TxConfig },
+  bookmark: { Bookmark }
+} = internal
+
+describe('#unit BoltProtocolV4x4', () => {
+  beforeEach(() => {
+    expect.extend(utils.matchers)
+  })
+
+  it('should request routing information', () => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+    const routingContext = { someContextParam: 'value' }
+    const databaseName = 'name'
+
+    const observer = protocol.requestRoutingInformation({
+      routingContext,
+      databaseName
+    })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.route(routingContext, [], databaseName)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(observer).toEqual(expect.any(RouteObserver))
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  it('should request routing information sending bookmarks', () => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+    const routingContext = { someContextParam: 'value' }
+    const listOfBookmarks = ['a', 'b', 'c']
+    const bookmark = new Bookmark(listOfBookmarks)
+    const databaseName = 'name'
+
+    const observer = protocol.requestRoutingInformation({
+      routingContext,
+      databaseName,
+      sessionContext: { bookmark }
+    })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.route(routingContext, listOfBookmarks, databaseName)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(observer).toEqual(expect.any(RouteObserver))
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  it('should run a query', () => {
+    const database = 'testdb'
+    const bookmark = new Bookmark([
+      'neo4j:bookmark:v1:tx1',
+      'neo4j:bookmark:v1:tx2'
+    ])
+    const txConfig = new TxConfig({
+      timeout: 5000,
+      metadata: { x: 1, y: 'something' }
+    })
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const query = 'RETURN $x, $y'
+    const parameters = { x: 'x', y: 'y' }
+
+    const observer = protocol.run(query, parameters, {
+      bookmark,
+      txConfig,
+      database,
+      mode: WRITE
+    })
+
+    protocol.verifyMessageCount(2)
+
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.runWithMetadata(query, parameters, {
+        bookmark,
+        txConfig,
+        database,
+        mode: WRITE
+      })
+    )
+    expect(protocol.messages[1]).toBeMessage(RequestMessage.pull())
+    expect(protocol.observers).toEqual([observer, observer])
+    expect(protocol.flushes).toEqual([false, true])
+  })
+  it('should begin a transaction', () => {
+    const database = 'testdb'
+    const bookmark = new Bookmark([
+      'neo4j:bookmark:v1:tx1',
+      'neo4j:bookmark:v1:tx2'
+    ])
+    const txConfig = new TxConfig({
+      timeout: 5000,
+      metadata: { x: 1, y: 'something' }
+    })
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const observer = protocol.beginTransaction({
+      bookmark,
+      txConfig,
+      database,
+      mode: WRITE
+    })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.begin({ bookmark, txConfig, database, mode: WRITE })
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  it('should return correct bolt version number', () => {
+    const protocol = new BoltProtocolV4x4(null, null, false)
+
+    expect(protocol.version).toBe(4.4)
+  })
+
+  it('should update metadata', () => {
+    const metadata = { t_first: 1, t_last: 2, db_hits: 3, some_other_key: 4 }
+    const protocol = new BoltProtocolV4x4(null, null, false)
+
+    const transformedMetadata = protocol.transformMetadata(metadata)
+
+    expect(transformedMetadata).toEqual({
+      result_available_after: 1,
+      result_consumed_after: 2,
+      db_hits: 3,
+      some_other_key: 4
+    })
+  })
+
+  it('should initialize connection', () => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello(clientName, authToken)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  it('should begin a transaction', () => {
+    const bookmark = new Bookmark([
+      'neo4j:bookmark:v1:tx1',
+      'neo4j:bookmark:v1:tx2'
+    ])
+    const txConfig = new TxConfig({
+      timeout: 5000,
+      metadata: { x: 1, y: 'something' }
+    })
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const observer = protocol.beginTransaction({
+      bookmark,
+      txConfig,
+      mode: WRITE
+    })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.begin({ bookmark, txConfig, mode: WRITE })
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  it('should commit', () => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const observer = protocol.commitTransaction()
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(RequestMessage.commit())
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  it('should rollback', () => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const observer = protocol.rollbackTransaction()
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(RequestMessage.rollback())
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  describe('unpacker configuration', () => {
+    test.each([
+      [false, false],
+      [false, true],
+      [true, false],
+      [true, true]
+    ])(
+      'should create unpacker with disableLosslessIntegers=%p and useBigInt=%p',
+      (disableLosslessIntegers, useBigInt) => {
+        const protocol = new BoltProtocolV4x4(null, null, {
+          disableLosslessIntegers,
+          useBigInt
+        })
+        expect(protocol._unpacker._disableLosslessIntegers).toBe(
+          disableLosslessIntegers
+        )
+        expect(protocol._unpacker._useBigInt).toBe(useBigInt)
+      }
+    )
+  })
+})

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
@@ -49,7 +49,28 @@ describe('#unit BoltProtocolV4x4', () => {
 
     protocol.verifyMessageCount(1)
     expect(protocol.messages[0]).toBeMessage(
-      RequestMessage.route(routingContext, [], databaseName)
+      RequestMessage.routeV4x4(routingContext, [], { databaseName, impersonatedUser: null })
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(observer).toEqual(expect.any(RouteObserver))
+    expect(protocol.flushes).toEqual([true])
+  })
+
+  it('should request routing information', () => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+    const routingContext = { someContextParam: 'value' }
+    const databaseName = 'name'
+
+    const observer = protocol.requestRoutingInformation({
+      routingContext,
+      databaseName
+    })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.routeV4x4(routingContext, [], { databaseName, impersonatedUser: null })
     )
     expect(protocol.observers).toEqual([observer])
     expect(observer).toEqual(expect.any(RouteObserver))
@@ -73,7 +94,7 @@ describe('#unit BoltProtocolV4x4', () => {
 
     protocol.verifyMessageCount(1)
     expect(protocol.messages[0]).toBeMessage(
-      RequestMessage.route(routingContext, listOfBookmarks, databaseName)
+      RequestMessage.routeV4x4(routingContext, listOfBookmarks, { databaseName, impersonatedUser: null})
     )
     expect(protocol.observers).toEqual([observer])
     expect(observer).toEqual(expect.any(RouteObserver))

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
@@ -56,27 +56,6 @@ describe('#unit BoltProtocolV4x4', () => {
     expect(protocol.flushes).toEqual([true])
   })
 
-  it('should request routing information', () => {
-    const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV4x4(recorder, null, false)
-    utils.spyProtocolWrite(protocol)
-    const routingContext = { someContextParam: 'value' }
-    const databaseName = 'name'
-
-    const observer = protocol.requestRoutingInformation({
-      routingContext,
-      databaseName
-    })
-
-    protocol.verifyMessageCount(1)
-    expect(protocol.messages[0]).toBeMessage(
-      RequestMessage.routeV4x4(routingContext, [], { databaseName, impersonatedUser: null })
-    )
-    expect(protocol.observers).toEqual([observer])
-    expect(observer).toEqual(expect.any(RouteObserver))
-    expect(protocol.flushes).toEqual([true])
-  })
-
   it('should request routing information sending bookmarks', () => {
     const recorder = new utils.MessageRecordingConnection()
     const protocol = new BoltProtocolV4x4(recorder, null, false)

--- a/packages/bolt-connection/test/bolt/index.test.js
+++ b/packages/bolt-connection/test/bolt/index.test.js
@@ -29,6 +29,7 @@ import BoltProtocolV4x0 from '../../src/bolt/bolt-protocol-v4x0'
 import BoltProtocolV4x1 from '../../src/bolt/bolt-protocol-v4x1'
 import BoltProtocolV4x2 from '../../src/bolt/bolt-protocol-v4x2'
 import BoltProtocolV4x3 from '../../src/bolt/bolt-protocol-v4x3'
+import BoltProtocolV4x4 from '../../src/bolt/bolt-protocol-v4x4'
 
 const {
   logger: { Logger }
@@ -42,13 +43,13 @@ describe('#unit Bolt', () => {
       const writtenBuffer = channel.written[0]
 
       const boltMagicPreamble = '60 60 b0 17'
-      const protocolVersion4x3to4x2 = '00 01 03 04'
+      const protocolVersion4x4to4x2 = '00 02 04 04'
       const protocolVersion4x1 = '00 00 01 04'
       const protocolVersion4x0 = '00 00 00 04'
       const protocolVersion3 = '00 00 00 03'
 
       expect(writtenBuffer.toHex()).toEqual(
-        `${boltMagicPreamble} ${protocolVersion4x3to4x2} ${protocolVersion4x1} ${protocolVersion4x0} ${protocolVersion3}`
+        `${boltMagicPreamble} ${protocolVersion4x4to4x2} ${protocolVersion4x1} ${protocolVersion4x0} ${protocolVersion3}`
       )
     })
 
@@ -301,7 +302,8 @@ describe('#unit Bolt', () => {
         v(4.0, BoltProtocolV4x0),
         v(4.1, BoltProtocolV4x1),
         v(4.2, BoltProtocolV4x2),
-        v(4.3, BoltProtocolV4x3)
+        v(4.3, BoltProtocolV4x3),
+        v(4.4, BoltProtocolV4x4)
       ]
 
       availableProtocols.forEach(lambda)

--- a/packages/bolt-connection/test/bolt/request-message.test.js
+++ b/packages/bolt-connection/test/bolt/request-message.test.js
@@ -266,4 +266,33 @@ describe('#unit RequestMessage', () => {
       )
     })
   })
+
+  describe('BoltV4.4', () => {
+    it('should create ROUTE message', () => {
+      const requestContext = { someValue: '1234' }
+      const bookmarks = ['a', 'b']
+      const databaseName = 'user_db'
+      const impersonatedUser = "user"
+
+      const message = RequestMessage.routeV4x4(requestContext, bookmarks, { databaseName, impersonatedUser })
+
+      expect(message.signature).toEqual(0x66)
+      expect(message.fields).toEqual([requestContext, bookmarks, { db: databaseName, imp_user: impersonatedUser }])
+      expect(message.toString()).toEqual(
+        `ROUTE ${json.stringify(requestContext)} ${json.stringify(
+          bookmarks
+        )} ${json.stringify({ db: databaseName, imp_user: impersonatedUser })}`
+      )
+    })
+
+    it('should create ROUTE message with default values', () => {
+      const message = RequestMessage.routeV4x4()
+
+      expect(message.signature).toEqual(0x66)
+      expect(message.fields).toEqual([{}, [], {}])
+      expect(message.toString()).toEqual(
+        `ROUTE ${json.stringify({})} ${json.stringify([])} ${json.stringify({})}`
+      )
+    })
+  })
 })

--- a/packages/bolt-connection/test/bolt/request-message.test.js
+++ b/packages/bolt-connection/test/bolt/request-message.test.js
@@ -175,7 +175,7 @@ describe('#unit RequestMessage', () => {
   })
 
   describe('BoltV4', () => {
-    function verify (message, signature, metadata, name) {
+    function verify(message, signature, metadata, name) {
       expect(message.signature).toEqual(signature)
       expect(message.fields).toEqual([metadata])
       expect(message.toString()).toEqual(`${name} ${json.stringify(metadata)}`)
@@ -291,7 +291,7 @@ describe('#unit RequestMessage', () => {
       expect(message.signature).toEqual(0x66)
       expect(message.fields).toEqual([{}, [], {}])
       expect(message.toString()).toEqual(
-        `ROUTE ${json.stringify({})} ${json.stringify([])} ${json.stringify({ })}`
+        `ROUTE ${json.stringify({})} ${json.stringify([])} ${json.stringify({})}`
       )
     })
 
@@ -303,9 +303,9 @@ describe('#unit RequestMessage', () => {
         ])
         const impersonatedUser = 'the impostor'
         const txConfig = new TxConfig({ timeout: 42, metadata: { key: 42 } })
-  
+
         const message = RequestMessage.begin({ bookmark, txConfig, mode, impersonatedUser })
-  
+
         const expectedMetadata = {
           bookmarks: bookmark.values(),
           tx_timeout: int(42),
@@ -315,7 +315,7 @@ describe('#unit RequestMessage', () => {
         if (mode === READ) {
           expectedMetadata.mode = 'r'
         }
-  
+
         expect(message.signature).toEqual(0x11)
         expect(message.fields).toEqual([expectedMetadata])
         expect(message.toString()).toEqual(
@@ -332,15 +332,15 @@ describe('#unit RequestMessage', () => {
         ])
         const mode = WRITE
         const txConfig = new TxConfig({ timeout: 42, metadata: { key: 42 } })
-  
+
         const message = RequestMessage.begin({ bookmark, txConfig, mode, impersonatedUser })
-  
+
         const expectedMetadata = {
           bookmarks: bookmark.values(),
           tx_timeout: int(42),
           tx_metadata: { key: 42 }
         }
-  
+
         expect(message.signature).toEqual(0x11)
         expect(message.fields).toEqual([expectedMetadata])
         expect(message.toString()).toEqual(
@@ -363,14 +363,14 @@ describe('#unit RequestMessage', () => {
           metadata: { a: 'a', b: 'b' }
         })
         const impersonatedUser = 'the impostor'
-  
+
         const message = RequestMessage.runWithMetadata(query, parameters, {
           bookmark,
           txConfig,
           mode,
           impersonatedUser
         })
-  
+
         const expectedMetadata = {
           bookmarks: bookmark.values(),
           tx_timeout: int(999),
@@ -380,7 +380,7 @@ describe('#unit RequestMessage', () => {
         if (mode === READ) {
           expectedMetadata.mode = 'r'
         }
-  
+
         expect(message.signature).toEqual(0x10)
         expect(message.fields).toEqual([query, parameters, expectedMetadata])
         expect(message.toString()).toEqual(
@@ -389,44 +389,44 @@ describe('#unit RequestMessage', () => {
           )}`
         )
       })
-  })
-
-  it('should create RUN message without impersonated user if it is not supplied or null', () => {
-    ;[undefined, null].forEach(impersonatedUser => {
-      const mode = WRITE
-      const query = 'RETURN $x'
-      const parameters = { x: 42 }
-      const bookmark = new Bookmark([
-        'neo4j:bookmark:v1:tx1',
-        'neo4j:bookmark:v1:tx10',
-        'neo4j:bookmark:v1:tx100'
-      ])
-      const txConfig = new TxConfig({
-        timeout: 999,
-        metadata: { a: 'a', b: 'b' }
-      })
-
-      const message = RequestMessage.runWithMetadata(query, parameters, {
-        bookmark,
-        txConfig,
-        mode,
-        impersonatedUser
-      })
-
-      const expectedMetadata = {
-        bookmarks: bookmark.values(),
-        tx_timeout: int(999),
-        tx_metadata: { a: 'a', b: 'b' }
-      }
-
-      expect(message.signature).toEqual(0x10)
-      expect(message.fields).toEqual([query, parameters, expectedMetadata])
-      expect(message.toString()).toEqual(
-        `RUN ${query} ${json.stringify(parameters)} ${json.stringify(
-          expectedMetadata
-        )}`
-      )
     })
-})
-})
+
+    it('should create RUN message without impersonated user if it is not supplied or null', () => {
+      ;[undefined, null].forEach(impersonatedUser => {
+        const mode = WRITE
+        const query = 'RETURN $x'
+        const parameters = { x: 42 }
+        const bookmark = new Bookmark([
+          'neo4j:bookmark:v1:tx1',
+          'neo4j:bookmark:v1:tx10',
+          'neo4j:bookmark:v1:tx100'
+        ])
+        const txConfig = new TxConfig({
+          timeout: 999,
+          metadata: { a: 'a', b: 'b' }
+        })
+
+        const message = RequestMessage.runWithMetadata(query, parameters, {
+          bookmark,
+          txConfig,
+          mode,
+          impersonatedUser
+        })
+
+        const expectedMetadata = {
+          bookmarks: bookmark.values(),
+          tx_timeout: int(999),
+          tx_metadata: { a: 'a', b: 'b' }
+        }
+
+        expect(message.signature).toEqual(0x10)
+        expect(message.fields).toEqual([query, parameters, expectedMetadata])
+        expect(message.toString()).toEqual(
+          `RUN ${query} ${json.stringify(parameters)} ${json.stringify(
+            expectedMetadata
+          )}`
+        )
+      })
+    })
+  })
 })

--- a/packages/bolt-connection/test/bolt/request-message.test.js
+++ b/packages/bolt-connection/test/bolt/request-message.test.js
@@ -291,7 +291,7 @@ describe('#unit RequestMessage', () => {
       expect(message.signature).toEqual(0x66)
       expect(message.fields).toEqual([{}, [], {}])
       expect(message.toString()).toEqual(
-        `ROUTE ${json.stringify({})} ${json.stringify([])} ${json.stringify({})}`
+        `ROUTE ${json.stringify({})} ${json.stringify([])} ${json.stringify({ })}`
       )
     })
 

--- a/packages/bolt-connection/test/bolt/routing-table-raw.test.js
+++ b/packages/bolt-connection/test/bolt/routing-table-raw.test.js
@@ -29,11 +29,12 @@ describe('#unit RawRoutingTable', () => {
       shouldReturnNullRawRoutingTable(() => RawRoutingTable.ofRecord(null))
     })
 
-    describe('when record has servers and ttl', () => {
+    describe('when record has servers, db and ttl', () => {
       it('should return isNull equals false', () => {
         const record = newRecord({
           ttl: 123,
-          servers: [{ role: 'READ', addresses: ['127.0.0.1'] }]
+          servers: [{ role: 'READ', addresses: ['127.0.0.1'] }],
+          db: 'homedb'
         })
         const result = RawRoutingTable.ofRecord(record)
         expect(result.isNull).toEqual(false)
@@ -42,21 +43,33 @@ describe('#unit RawRoutingTable', () => {
       it('should return the ttl', () => {
         const record = newRecord({
           ttl: 123,
-          servers: [{ role: 'READ', addresses: ['127.0.0.1'] }]
+          servers: [{ role: 'READ', addresses: ['127.0.0.1'] }],
+          db: 'homedb'
         })
         const result = RawRoutingTable.ofRecord(record)
         expect(result.ttl).toEqual(123)
       })
 
-      it('should return the ttl', () => {
+      it('should return the servers', () => {
         const record = newRecord({
           ttl: 123,
-          servers: [{ role: 'READ', addresses: ['127.0.0.1'] }]
+          servers: [{ role: 'READ', addresses: ['127.0.0.1'] }],
+          db: 'homedb'
         })
         const result = RawRoutingTable.ofRecord(record)
         expect(result.servers).toEqual([
           { role: 'READ', addresses: ['127.0.0.1'] }
         ])
+      })
+
+      it('should return the db', () => {
+        const record = newRecord({
+          ttl: 123,
+          servers: [{ role: 'READ', addresses: ['127.0.0.1'] }],
+          db: 'homedb'
+        })
+        const result = RawRoutingTable.ofRecord(record)
+        expect(result.db).toEqual('homedb')
       })
     })
 
@@ -119,6 +132,18 @@ describe('#unit RawRoutingTable', () => {
         expect(() => result.servers).toThrow()
       })
     })
+
+    describe('when record does not have db name', () => {
+      it('should return db equals null', () => {
+        const record = newRecord({
+          ttl: 123,
+          noServers: [{ role: 'READ', addresses: ['127.0.0.1'] }]
+        })
+        const result = RawRoutingTable.ofRecord(record)
+        expect(result.db).toEqual(null)
+      })
+
+    })
   })
 
   describe('ofMessageResponse', () => {
@@ -144,7 +169,7 @@ describe('#unit RawRoutingTable', () => {
       expect(result.ttl).toEqual(123)
     })
 
-    it('should return the ttl', () => {
+    it('should return the servers', () => {
       const response = newResponse({
         ttl: 123,
         servers: [{ role: 'READ', addresses: ['127.0.0.1'] }]
@@ -153,6 +178,16 @@ describe('#unit RawRoutingTable', () => {
       expect(result.servers).toEqual([
         { role: 'READ', addresses: ['127.0.0.1'] }
       ])
+    })
+
+    it('should return the db', () => {
+      const response = newResponse({
+        ttl: 123,
+        servers: [{ role: 'READ', addresses: ['127.0.0.1'] }],
+        db: 'homedb'
+      })
+      const result = RawRoutingTable.ofMessageResponse(response)
+      expect(result.db).toEqual('homedb')
     })
   })
 
@@ -174,6 +209,13 @@ describe('#unit RawRoutingTable', () => {
       expect(() => {
         const servers = subject().servers
         fail(`it should not return ${servers}`)
+      }).toThrow(new Error('Not implemented'))
+    })
+
+    it('should not implement db', () => {
+      expect(() => {
+        const db = subject().db
+        fail(`it should not return ${db}`)
       }).toThrow(new Error('Not implemented'))
     })
   }

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -757,7 +757,8 @@ describe('#unit RoutingConnectionProvider', () => {
           null,
           [serverA, serverB],
           [serverC, serverD],
-          [serverE, serverF]
+          [serverE, serverF],
+          user
         )
         expectPoolToNotContain(pool, [
           server1,
@@ -794,7 +795,8 @@ describe('#unit RoutingConnectionProvider', () => {
           null,
           [],
           [server4, server5],
-          [server6, server7]
+          [server6, server7],
+          user
         )
         done()
       })
@@ -823,7 +825,8 @@ describe('#unit RoutingConnectionProvider', () => {
           null,
           [],
           [server4, server5],
-          [server6, server7]
+          [server6, server7],
+          user
         )
         done()
       })
@@ -874,7 +877,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB, serverC],
               [serverD, serverE],
-              [serverF, serverG]
+              [serverF, serverG],
+              user
             )
             done()
           })
@@ -926,7 +930,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC, serverD],
-              [serverE, serverF]
+              [serverE, serverF],
+              user
             )
             done()
           })
@@ -978,7 +983,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC],
-              [serverD, serverE]
+              [serverD, serverE],
+              user
             )
             done()
           })
@@ -1031,7 +1037,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [], // all routers were forgotten because they failed
               [server4, server5],
-              [server6]
+              [server6],
+              user
             )
 
             done()
@@ -1084,7 +1091,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [], // all routers were forgotten because they failed
               [server3],
-              [server4]
+              [server4],
+              user
             )
 
             done()
@@ -1126,7 +1134,8 @@ describe('#unit RoutingConnectionProvider', () => {
           null,
           [], // all known seed servers failed to return routing tables and were forgotten
           [server4],
-          [server5]
+          [server5],
+          user
         )
 
         connectionProvider
@@ -1139,7 +1148,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [], // all known seed servers failed to return routing tables and were forgotten
               [server4],
-              [server5]
+              [server5],
+              user
             )
 
             done()
@@ -1189,7 +1199,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC],
-              [serverD]
+              [serverD],
+              user
             )
             done()
           })
@@ -1238,7 +1249,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC, serverD],
-              [serverF, serverE]
+              [serverF, serverE],
+              user
             )
             done()
           })
@@ -1289,7 +1301,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB, serverC],
               [serverD, serverE],
-              [serverF]
+              [serverF],
+              user
             )
             done()
           })
@@ -1356,7 +1369,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC, serverD],
-              [serverE, serverF]
+              [serverE, serverF],
+              user
             )
             done()
           })
@@ -1639,7 +1653,8 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC, serverD],
-              []
+              [],
+              user
             )
 
             connectionProvider
@@ -1652,7 +1667,8 @@ describe('#unit RoutingConnectionProvider', () => {
                   null,
                   [serverAA, serverBB],
                   [serverCC, serverDD],
-                  [serverEE]
+                  [serverEE],
+                  user
                 )
 
                 done()

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -77,7 +77,7 @@ describe('#unit RoutingConnectionProvider', () => {
     ['the-impostor']
   ]
 
-  it.each(usersDataSet)('can forget address [user=%s]', user => {
+  it('can forget address', () => {
     const connectionProvider = newRoutingConnectionProvider([
       newRoutingTable(
         null,
@@ -87,19 +87,18 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     ])
 
-    connectionProvider.forget(user, server2)
+    connectionProvider.forget(server2)
 
     expectRoutingTable(
       connectionProvider,
       null,
       [server1, server2],
       [server3],
-      [server4],
-      user
+      [server4]
     )
   }, 10000)
 
-  it.each(usersDataSet)('can not forget unknown address [user=%s]', user => {
+  it('can not forget unknown address', () => {
     const connectionProvider = newRoutingConnectionProvider([
       newRoutingTable(
         null,
@@ -109,19 +108,18 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     ])
 
-    connectionProvider.forget(user, server42)
+    connectionProvider.forget(server42)
 
     expectRoutingTable(
       connectionProvider,
       null,
       [server1, server2],
       [server3, server4],
-      [server5, server6],
-      user
+      [server5, server6]
     )
   }, 10000)
 
-  it.each(usersDataSet)('purges connections when address is forgotten [user=%s]', user => {
+  it('purges connections when address is forgotten', () => {
     const pool = newPool()
 
     pool.acquire(server1)
@@ -141,14 +139,14 @@ describe('#unit RoutingConnectionProvider', () => {
       pool
     )
 
-    connectionProvider.forget(user, server1)
-    connectionProvider.forget(user, server5)
+    connectionProvider.forget(server1)
+    connectionProvider.forget(server5)
 
     expectPoolToContain(pool, [server3])
     expectPoolToNotContain(pool, [server1, server5])
   }, 10000)
 
-  it.each(usersDataSet)('can forget writer address [user=%s]', user => {
+  it('can forget writer address', () => {
     const connectionProvider = newRoutingConnectionProvider([
       newRoutingTable(
         null,
@@ -158,19 +156,18 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     ])
 
-    connectionProvider.forgetWriter(user, server2)
+    connectionProvider.forgetWriter(server2)
 
     expectRoutingTable(
       connectionProvider,
       null,
       [server1, server2],
       [server3, server2],
-      [server4],
-      user
+      [server4]
     )
   }, 10000)
 
-  it.each(usersDataSet)('can not forget unknown writer address [user=%s]', user => {
+  it('can not forget unknown writer address', () => {
     const connectionProvider = newRoutingConnectionProvider([
       newRoutingTable(
         null,
@@ -180,15 +177,14 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     ])
 
-    connectionProvider.forgetWriter(user, server42)
+    connectionProvider.forgetWriter(server42)
 
     expectRoutingTable(
       connectionProvider,
       null,
       [server1, server2],
       [server3, server4],
-      [server5, server6],
-      user
+      [server5, server6]
     )
   }, 10000)
 
@@ -757,8 +753,7 @@ describe('#unit RoutingConnectionProvider', () => {
           null,
           [serverA, serverB],
           [serverC, serverD],
-          [serverE, serverF],
-          user
+          [serverE, serverF]
         )
         expectPoolToNotContain(pool, [
           server1,
@@ -795,8 +790,7 @@ describe('#unit RoutingConnectionProvider', () => {
           null,
           [],
           [server4, server5],
-          [server6, server7],
-          user
+          [server6, server7]
         )
         done()
       })
@@ -825,8 +819,7 @@ describe('#unit RoutingConnectionProvider', () => {
           null,
           [],
           [server4, server5],
-          [server6, server7],
-          user
+          [server6, server7]
         )
         done()
       })
@@ -877,8 +870,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB, serverC],
               [serverD, serverE],
-              [serverF, serverG],
-              user
+              [serverF, serverG]
             )
             done()
           })
@@ -930,8 +922,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC, serverD],
-              [serverE, serverF],
-              user
+              [serverE, serverF]
             )
             done()
           })
@@ -983,8 +974,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC],
-              [serverD, serverE],
-              user
+              [serverD, serverE]
             )
             done()
           })
@@ -1037,8 +1027,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [], // all routers were forgotten because they failed
               [server4, server5],
-              [server6],
-              user
+              [server6]
             )
 
             done()
@@ -1091,8 +1080,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [], // all routers were forgotten because they failed
               [server3],
-              [server4],
-              user
+              [server4]
             )
 
             done()
@@ -1134,8 +1122,7 @@ describe('#unit RoutingConnectionProvider', () => {
           null,
           [], // all known seed servers failed to return routing tables and were forgotten
           [server4],
-          [server5],
-          user
+          [server5]
         )
 
         connectionProvider
@@ -1148,8 +1135,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [], // all known seed servers failed to return routing tables and were forgotten
               [server4],
-              [server5],
-              user
+              [server5]
             )
 
             done()
@@ -1199,8 +1185,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC],
-              [serverD],
-              user
+              [serverD]
             )
             done()
           })
@@ -1249,8 +1234,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC, serverD],
-              [serverF, serverE],
-              user
+              [serverF, serverE]
             )
             done()
           })
@@ -1301,8 +1285,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB, serverC],
               [serverD, serverE],
-              [serverF],
-              user
+              [serverF]
             )
             done()
           })
@@ -1369,8 +1352,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC, serverD],
-              [serverE, serverF],
-              user
+              [serverE, serverF]
             )
             done()
           })
@@ -1653,8 +1635,7 @@ describe('#unit RoutingConnectionProvider', () => {
               null,
               [serverA, serverB],
               [serverC, serverD],
-              [],
-              user
+              []
             )
 
             connectionProvider
@@ -1667,8 +1648,7 @@ describe('#unit RoutingConnectionProvider', () => {
                   null,
                   [serverAA, serverBB],
                   [serverCC, serverDD],
-                  [serverEE],
-                  user
+                  [serverEE]
                 )
 
                 done()
@@ -1960,16 +1940,14 @@ describe('#unit RoutingConnectionProvider', () => {
         'databaseA',
         [server1, server2, server3],
         [server1, server2],
-        [server3],
-        user
+        [server3]
       )
       expectRoutingTable(
         connectionProvider,
         'databaseB',
         [serverA, serverB, serverC],
         [serverB],
-        [serverC],
-        user
+        [serverC]
       )
     }, 10000)
 
@@ -2010,16 +1988,14 @@ describe('#unit RoutingConnectionProvider', () => {
         'databaseA',
         [server1, server2, server3],
         [server1, server2],
-        [server3],
-        user
+        [server3]
       )
       expectRoutingTable(
         connectionProvider,
         'databaseB',
         [serverA, serverB, serverC],
         [serverB],
-        [serverC],
-        user
+        [serverC]
       )
     }, 10000)
 
@@ -2060,16 +2036,14 @@ describe('#unit RoutingConnectionProvider', () => {
         'databaseA',
         [server1, server2, server3],
         [server1, server2],
-        [server3],
-        user
+        [server3]
       )
       expectRoutingTable(
         connectionProvider,
         null,
         [serverA, serverB, serverC],
         [serverB],
-        [serverC],
-        user
+        [serverC]
       )
     })
 
@@ -2109,16 +2083,14 @@ describe('#unit RoutingConnectionProvider', () => {
         'databaseA',
         [server1, server2, server3],
         [server1, server2],
-        [server3],
-        user
+        [server3]
       )
       expectRoutingTable(
         connectionProvider,
         null,
         [serverA, serverB, serverC],
         [serverB],
-        [serverC],
-        user
+        [serverC]
       )
     })
 
@@ -2159,16 +2131,14 @@ describe('#unit RoutingConnectionProvider', () => {
         'databaseA',
         [server1, server2, server3],
         [server1, server2],
-        [server3],
-        user
+        [server3]
       )
       expectRoutingTable(
         connectionProvider,
         'databaseB',
         [serverA, serverB, serverC],
         [serverA, serverB],
-        [serverC],
-        user
+        [serverC]
       )
     }, 10000)
 
@@ -2215,16 +2185,14 @@ describe('#unit RoutingConnectionProvider', () => {
           'databaseA',
           [server1, server2, server3],
           [server1, server2],
-          [server3],
-          user
+          [server3]
         )
         expectRoutingTable(
           connectionProvider,
           'databaseB',
           [server1, server2, server3],
           [server1, server3],
-          [server2],
-          user
+          [server2]
         )
 
         // make routing table for databaseA to report true for isExpiredFor(4000)
@@ -2246,16 +2214,14 @@ describe('#unit RoutingConnectionProvider', () => {
           'databaseA',
           [server1, server2, server3],
           [server1, server2],
-          [server3],
-          user
+          [server3]
         )
         expectRoutingTable(
           connectionProvider,
           'databaseC',
           [server1, server2, server3],
           [server2, server3],
-          [server1],
-          user
+          [server1]
         )
         expectNoRoutingTable(connectionProvider, 'databaseB', user)
       } finally {
@@ -2263,219 +2229,177 @@ describe('#unit RoutingConnectionProvider', () => {
       }
     }, 10000)
 
-    it.each(usersDataSet)('should resolve the home database name for the user=%s', (user) => {
+    it.each(usersDataSet)('should resolve the home database name for the user=%s', async (user) => {
       const pool = newPool()
       const connectionProvider = newRoutingConnectionProvider(
-        [
-          newRoutingTableWithUser(
-            {
+        [],
+        pool,
+        { 
+          null: {
+            'server-non-existing-seed-router:7687': newRoutingTableWithUser(
+              {
+                database: null, 
               database: null, 
-              routers: [server1, server2, server3],
-              readers: [server1, server2],
-              writers: [server3],
-              user,
-              routingTableDatabase: 'homedb'
-            }
-          )
-        ],
-        pool
+                database: null, 
+                routers: [server1, server2, server3],
+                readers: [server1, server2],
+                writers: [server3],
+                user,
+                routingTableDatabase: 'homedb'
+              }
+            )
+          } 
+        }
       )
 
-      const resolvedName = connectionProvider.resolveDatabaseName({ database: null, impersonatedUser: user })
+      const connection = await connectionProvider.acquireConnection({ impersonatedUser: user, accessMode: READ })
 
-      expect(resolvedName).toBe('homedb')
+      expect(connection.address).toEqual(server1)
 
       expectRoutingTable(
         connectionProvider,
-        null,
+        'homedb',
         [server1, server2, server3],
         [server1, server2],
-        [server3],
-        user,
-        'homedb'
+        [server3]
       )
     })
 
-    it.each(usersDataSet)('should resolve the non default database name for the user=%s with the informed name', (user) => {
+    it.each(usersDataSet)('should acquire the non default database name for the user=%s with the informed name', async (user) => {
       const pool = newPool()
       const connectionProvider = newRoutingConnectionProvider(
-        [
-          newRoutingTableWithUser(
-            {
+        [],
+        pool,
+        { 
+          'databaseA': {
+            'server-non-existing-seed-router:7687': newRoutingTableWithUser(
+              {
+                database: 'databaseA', 
               database: 'databaseA', 
-              routers: [server1, server2, server3],
-              readers: [server1, server2],
-              writers: [server3],
-              user,
-              routingTableDatabase: 'homedb'
-            }
-          )
-        ],
-        pool
+                database: 'databaseA', 
+                routers: [server1, server3],
+                readers: [server1],
+                writers: [server3],
+                user,
+                routingTableDatabase: 'homedb'
+              }
+            )
+          },
+          'databaseB': {
+            'server-non-existing-seed-router:7687': newRoutingTableWithUser(
+              {
+                database: 'homedb', 
+                routers: [server2, server3],
+                readers: [server2],
+                writers: [server3],
+                user,
+                routingTableDatabase: 'homedb'
+              }
+            )
+          } 
+        }
       )
 
-      const resolvedName = connectionProvider.resolveDatabaseName({ database: 'databaseA', impersonatedUser: user })
+      const connection = await connectionProvider.acquireConnection({ database: 'databaseA', impersonatedUser: user, accessMode: READ })
 
-      expect(resolvedName).toBe('databaseA')
+      expect(connection.address).toEqual(server1)
 
       expectRoutingTable(
         connectionProvider,
         'databaseA',
-        [server1, server2, server3],
-        [server1, server2],
-        [server3],
-        user,
-        'homedb'
+        [server1, server3],
+        [server1],
+        [server3]
       )
     })
 
     it.each(usersDataSet)('should be able to acquire connection for homedb using it name', async (user) => {
       const pool = newPool()
       const connectionProvider = newRoutingConnectionProvider(
-        [
-          newRoutingTableWithUser(
-            {
+        [],
+        pool,
+        {
+          null: {
+            'server-non-existing-seed-router:7687': newRoutingTableWithUser({
+                database: null, 
               database: null, 
-              routers: [server1, server2, server3],
-              readers: [server1, server2],
-              writers: [server3],
-              user,
-              routingTableDatabase: 'homedb'
-
-            }
-          )
-        ],
-        pool
+                database: null, 
+                routers: [server1, server2, server3],
+                readers: [server1, server2],
+                writers: [server3],
+                user,
+                routingTableDatabase: 'homedb'
+            })
+          }
+        }
       )
 
+      await connectionProvider.acquireConnection({ accessMode: READ, impersonatedUser: user, accessMode: WRITE })
       const connection = await connectionProvider.acquireConnection({ accessMode: READ, database: 'homedb', impersonatedUser: user })
 
       expect(connection.address).toEqual(server1)
       expect(pool.has(server1)).toBeTruthy()
     })
 
-    it('should resolve different dbs for different users', () => {
-      const user1 = 'the-impostor-number-1'
-      const user2 = 'the-impostor-number-2'
-      const defaultUser = undefined
-
-      const pool = newPool()
-      const connectionProvider = newRoutingConnectionProvider(
-        [
-          newRoutingTableWithUser(
-            {
-              database: null, 
-              routers: [server1],
-              readers: [server1],
-              writers: [server1],
-              user: user1,
-              routingTableDatabase: 'homedb1'
-            }
-          ),
-
-          newRoutingTableWithUser(
-            {
-              database: null, 
-              routers: [server2],
-              readers: [server2],
-              writers: [server2],
-              user: user2,
-              routingTableDatabase: 'homedb2'
-            }
-          ),
-
-          newRoutingTableWithUser(
-            {
-              database: null, 
-              routers: [server3],
-              readers: [server3],
-              writers: [server3],
-              user: defaultUser,
-              routingTableDatabase: 'default-home-db'
-            }
-          )
-        ],
-        pool
-      )
-
-      expect(connectionProvider.resolveDatabaseName({ database: null, impersonatedUser: user1 })).toBe('homedb1')
-      expect(connectionProvider.resolveDatabaseName({ database: null, impersonatedUser: user2 })).toBe('homedb2')
-      expect(connectionProvider.resolveDatabaseName({ database: null, impersonatedUser: defaultUser })).toBe('default-home-db')
-
-      expectRoutingTable(
-        connectionProvider,
-        null,
-        [server1],
-        [server1],
-        [server1],
-        user1,
-        'homedb1'
-      )
-
-      expectRoutingTable(
-        connectionProvider,
-        null,
-        [server2],
-        [server2],
-        [server2],
-        user2,
-        'homedb2'
-      )
-
-      expectRoutingTable(
-        connectionProvider,
-        null,
-        [server3],
-        [server3],
-        [server3],
-        defaultUser,
-        'default-home-db'
-      )
-    })
 
     it('should be to acquire connection other users homedb using it name', async () => {
       const user1 = 'the-impostor-number-1'
       const user2 = 'the-impostor-number-2'
       const defaultUser = undefined
+      const expirationTime = int(Date.now()).add(60000)
 
       const pool = newPool()
       const connectionProvider = newRoutingConnectionProvider(
-        [
-          newRoutingTableWithUser(
-            {
-              database: null, 
-              routers: [server1],
-              readers: [server1],
-              writers: [server1],
-              user: user1,
-              routingTableDatabase: 'homedb1'
-            }
-          ),
+        [],
+        pool,
+        {
+          null: {
+            'server-non-existing-seed-router:7687': [
+              newRoutingTableWithUser(
+                {
+                  database: null,
+                  routers: [server1],
+                  readers: [server1],
+                  writers: [server1],
+                  user: user1,
+                  expirationTime,
+                  routingTableDatabase: 'homedb1'
+                }
+              ),
 
-          newRoutingTableWithUser(
-            {
-              database: null, 
-              routers: [server2],
-              readers: [server2],
-              writers: [server2],
-              user: user2,
-              routingTableDatabase: 'homedb2'
-            }
-          ),
+              newRoutingTableWithUser(
+                {
+                  database: null,
+                  routers: [server2],
+                  readers: [server2],
+                  writers: [server2],
+                  expirationTime,
+                  user: user2,
+                  routingTableDatabase: 'homedb2'
+                }
+              ),
 
-          newRoutingTableWithUser(
-            {
-              database: null, 
-              routers: [server3],
-              readers: [server3],
-              writers: [server3],
-              user: defaultUser,
-              routingTableDatabase: 'default-home-db'
-            }
-          )
-        ],
-        pool
+              newRoutingTableWithUser(
+                {
+                  database: null,
+                  routers: [server3],
+                  readers: [server3],
+                  writers: [server3],
+                  expirationTime,
+                  user: defaultUser,
+                  routingTableDatabase: 'default-home-db'
+                }
+              )
+            ]
+          },
+          "kakakaka": {}
+        },
       )
+
+      await connectionProvider.acquireConnection({ accessMode: WRITE, impersonatedUser: user2 })
+      await connectionProvider.acquireConnection({ accessMode: WRITE, impersonatedUser: user1 })
+      await connectionProvider.acquireConnection({ accessMode: WRITE })
+
 
       const defaultConnToHomeDb1 = await connectionProvider.acquireConnection({ accessMode: READ, database: 'homedb1' })
       expect(defaultConnToHomeDb1.address).toEqual(server1)
@@ -2500,6 +2424,7 @@ describe('#unit RoutingConnectionProvider', () => {
       const user2ConnToHomeDb1 = await connectionProvider.acquireConnection({ accessMode: READ, database: 'homedb1', impersonatedUser: user2 })
       expect(user2ConnToHomeDb1.address).toEqual(server1)
       expect(pool.has(server1)).toBeTruthy()
+
     })
 
   })
@@ -2540,7 +2465,7 @@ function newRoutingConnectionProviderWithSeedRouter (
   })
   connectionProvider._connectionPool = pool
   routingTables.forEach(r => {
-    connectionProvider._routingTableRegistry.register(r.user, r.database, r)
+    connectionProvider._routingTableRegistry.register(r)
   })
   connectionProvider._rediscovery = new FakeRediscovery(routerToRoutingTable)
   connectionProvider._hostNameResolver = new FakeDnsResolver(seedRouterResolved)
@@ -2558,7 +2483,6 @@ function newRoutingTableWithUser ({
   expirationTime = Integer.MAX_VALUE,
   routingTableDatabase,
   user
-
 }) {
   const routingTable = newRoutingTable(database, routers, readers, writers, expirationTime, routingTableDatabase)
   routingTable.user = user
@@ -2573,14 +2497,14 @@ function newRoutingTable (
   expirationTime = Integer.MAX_VALUE,
   routingTableDatabase
 ) {
-  return new RoutingTable({
-    database,
+  var routingTable = new  RoutingTable({
+    database: database || routingTableDatabase,
     routers,
     readers,
     writers,
-    expirationTime,
-    routingTableDatabase
+    expirationTime
   })
+  return routingTable
 }
 
 function setupRoutingConnectionProviderToRememberRouters (
@@ -2609,20 +2533,17 @@ function expectRoutingTable (
   database,
   routers,
   readers,
-  writers,
-  impersonatedUser,
-  routingTableDatabase
+  writers
 ) {
-  const routingTable = connectionProvider._routingTableRegistry.get(impersonatedUser, database)
+  const routingTable = connectionProvider._routingTableRegistry.get(database)
   expect(routingTable.database).toEqual(database)
   expect(routingTable.routers).toEqual(routers)
   expect(routingTable.readers).toEqual(readers)
   expect(routingTable.writers).toEqual(writers)
-  expect(routingTable.routingTableDatabase).toEqual(routingTableDatabase)
 }
 
-function expectNoRoutingTable (connectionProvider, database, impersonatedUser) {
-  expect(connectionProvider._routingTableRegistry.get(impersonatedUser, database)).toBeFalsy()
+function expectNoRoutingTable (connectionProvider, database) {
+  expect(connectionProvider._routingTableRegistry.get(database)).toBeFalsy()
 }
 
 function expectPoolToContain (pool, addresses) {
@@ -2667,10 +2588,15 @@ class FakeRediscovery {
     this._routerToRoutingTable = routerToRoutingTable
   }
 
-  lookupRoutingTableOnRouter (ignored, database, router) {
+  lookupRoutingTableOnRouter (ignored, database, router, user) {
     const table = this._routerToRoutingTable[database || null]
     if (table) {
-      return Promise.resolve(table[router.asKey()])
+      let routingTables = table[router.asKey()]
+      let routingTable = routingTables
+      if (routingTables instanceof Array) {
+        routingTable = routingTables.find(rt => rt.user === user)
+      }
+      return Promise.resolve(routingTable)
     }
     return Promise.resolve(null)
   }

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2317,14 +2317,12 @@ describe('#unit RoutingConnectionProvider', () => {
         {
           null: {
             'server-non-existing-seed-router:7687': newRoutingTableWithUser({
-                database: null, 
-              database: null, 
-                database: null, 
-                routers: [server1, server2, server3],
-                readers: [server1, server2],
-                writers: [server3],
-                user,
-                routingTableDatabase: 'homedb'
+              database: null,
+              routers: [server1, server2, server3],
+              readers: [server1, server2],
+              writers: [server3],
+              user,
+              routingTableDatabase: 'homedb'
             })
           }
         }

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -81,7 +81,7 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     ])
 
-    connectionProvider.forget(server2)
+    connectionProvider.forget(null, server2)
 
     expectRoutingTable(
       connectionProvider,
@@ -102,7 +102,7 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     ])
 
-    connectionProvider.forget(server42)
+    connectionProvider.forget(null, server42)
 
     expectRoutingTable(
       connectionProvider,
@@ -133,8 +133,8 @@ describe('#unit RoutingConnectionProvider', () => {
       pool
     )
 
-    connectionProvider.forget(server1)
-    connectionProvider.forget(server5)
+    connectionProvider.forget(null, server1)
+    connectionProvider.forget(null, server5)
 
     expectPoolToContain(pool, [server3])
     expectPoolToNotContain(pool, [server1, server5])
@@ -150,7 +150,7 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     ])
 
-    connectionProvider.forgetWriter(server2)
+    connectionProvider.forgetWriter(null, server2)
 
     expectRoutingTable(
       connectionProvider,
@@ -171,7 +171,7 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     ])
 
-    connectionProvider.forgetWriter(server42)
+    connectionProvider.forgetWriter(null, server42)
 
     expectRoutingTable(
       connectionProvider,
@@ -2235,7 +2235,7 @@ function newRoutingConnectionProviderWithSeedRouter (
   })
   connectionProvider._connectionPool = pool
   routingTables.forEach(r => {
-    connectionProvider._routingTableRegistry.register(r.database, r)
+    connectionProvider._routingTableRegistry.register(null, r.database, r)
   })
   connectionProvider._rediscovery = new FakeRediscovery(routerToRoutingTable)
   connectionProvider._hostNameResolver = new FakeDnsResolver(seedRouterResolved)
@@ -2289,7 +2289,7 @@ function expectRoutingTable (
   readers,
   writers
 ) {
-  const routingTable = connectionProvider._routingTableRegistry.get(database)
+  const routingTable = connectionProvider._routingTableRegistry.get(null, database)
   expect(routingTable.database).toEqual(database)
   expect(routingTable.routers).toEqual(routers)
   expect(routingTable.readers).toEqual(readers)
@@ -2297,7 +2297,7 @@ function expectRoutingTable (
 }
 
 function expectNoRoutingTable (connectionProvider, database) {
-  expect(connectionProvider._routingTableRegistry.get(database)).toBeFalsy()
+  expect(connectionProvider._routingTableRegistry.get(null, database)).toBeFalsy()
 }
 
 function expectPoolToContain (pool, addresses) {

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2275,7 +2275,6 @@ describe('#unit RoutingConnectionProvider', () => {
               writers: [server3],
               user,
               routingTableDatabase: 'homedb'
-
             }
           )
         ],

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2457,12 +2457,12 @@ describe('#unit RoutingConnectionProvider', () => {
         {
           'databaseA': {
             'server-non-existing-seed-router:7687': newRoutingTableWithUser({
-                database: 'databaseA', 
-                routers: [server1, server2, server3],
-                readers: [server1, server2],
-                writers: [server3],
-                user,
-                routingTableDatabase: 'databaseB'
+              database: 'databaseA',
+              routers: [server1, server2, server3],
+              readers: [server1, server2],
+              writers: [server3],
+              user,
+              routingTableDatabase: 'databaseB'
             })
           }
         }

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2432,12 +2432,12 @@ describe('#unit RoutingConnectionProvider', () => {
         {
           null: {
             'server-non-existing-seed-router:7687': newRoutingTableWithUser({
-                database: null, 
-                routers: [server1, server2, server3],
-                readers: [server1, server2],
-                writers: [server3],
-                user,
-                routingTableDatabase: 'homedb'
+              database: null,
+              routers: [server1, server2, server3],
+              readers: [server1, server2],
+              writers: [server3],
+              user,
+              routingTableDatabase: 'homedb'
             })
           }
         }

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2444,7 +2444,6 @@ describe('#unit RoutingConnectionProvider', () => {
         pool
       )
 
-
       const defaultConnToHomeDb1 = await connectionProvider.acquireConnection({ accessMode: READ, database: 'homedb1' })
       expect(defaultConnToHomeDb1.address).toEqual(server1)
       expect(pool.has(server1)).toBeTruthy()

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2296,6 +2296,39 @@ describe('#unit RoutingConnectionProvider', () => {
       )
     })
 
+    it.each(usersDataSet)('should resolve the non default database name for the user=%s with the informed name', (user) => {
+      const pool = newPool()
+      const connectionProvider = newRoutingConnectionProvider(
+        [
+          newRoutingTableWithUser(
+            {
+              database: 'databaseA', 
+              routers: [server1, server2, server3],
+              readers: [server1, server2],
+              writers: [server3],
+              user,
+              routingTableDatabase: 'homedb'
+            }
+          )
+        ],
+        pool
+      )
+
+      const resolvedName = connectionProvider.resolveDatabaseName({ database: 'databaseA', impersonatedUser: user })
+
+      expect(resolvedName).toBe('databaseA')
+
+      expectRoutingTable(
+        connectionProvider,
+        'databaseA',
+        [server1, server2, server3],
+        [server1, server2],
+        [server3],
+        user,
+        'homedb'
+      )
+    })
+
     it.each(usersDataSet)('should be able to acquire connection for homedb using it name', async (user) => {
       const pool = newPool()
       const connectionProvider = newRoutingConnectionProvider(

--- a/packages/bolt-connection/test/rediscovery/rediscovery.test.js
+++ b/packages/bolt-connection/test/rediscovery/rediscovery.test.js
@@ -48,6 +48,7 @@ describe('#unit Rediscovery', () => {
 
       const expectedRoutingTable = new RoutingTable({
         database: 'db',
+        ttl,
         expirationTime: calculateExpirationTime(Date.now(), ttl),
         routers: [ServerAddress.fromUrl('bolt://localhost:7687')],
         writers: [ServerAddress.fromUrl('bolt://localhost:7686')],

--- a/packages/core/src/connection-provider.ts
+++ b/packages/core/src/connection-provider.ts
@@ -49,6 +49,15 @@ class ConnectionProvider {
   }
 
   /**
+   * Resolve database name
+   * @param {string|undefined|null} database Database name
+   * @return {string} the resolved db name
+   */
+  resolveDatabaseName(database?: string): string | undefined | null {
+    return database
+  }
+
+  /**
    * This method checks whether the backend database supports multi database functionality
    * by checking protocol handshake result.
    *
@@ -74,7 +83,7 @@ class ConnectionProvider {
    *
    * @returns {Promise<boolean>}
    */
-   supportsUserImpersonation(): Promise<boolean> {
+  supportsUserImpersonation(): Promise<boolean> {
     throw Error('Not implemented')
   }
 

--- a/packages/core/src/connection-provider.ts
+++ b/packages/core/src/connection-provider.ts
@@ -39,21 +39,26 @@ class ConnectionProvider {
    * @param {string} param.accessMode - the access mode for the to-be-acquired connection
    * @param {string} param.database - the target database for the to-be-acquired connection
    * @param {Bookmark} param.bookmarks - the bookmarks to send to routing discovery
+   * @param {string} param.impersonatedUser - the impersonated user
    */
   acquireConnection(params?: {
     accessMode?: string
     database?: string
-    bookmarks: bookmark.Bookmark
+    bookmarks: bookmark.Bookmark,
+    impersonatedUser?: string
   }): Promise<Connection> {
     throw Error('Not implemented')
   }
 
   /**
    * Resolve database name
+   * 
+   * @param {object} param - object parameter
    * @param {string|undefined|null} database Database name
-   * @return {string} the resolved db name
+   * @param {string|undefined|null} impersonatedUser The user which is being impersonated
+   * @return {string|undefined|null} the resolved db name
    */
-  resolveDatabaseName(database?: string): string | undefined | null {
+  resolveDatabaseName({ database }: { database?: string, impersonatedUser?: string }): string | undefined | null {
     return database
   }
 

--- a/packages/core/src/connection-provider.ts
+++ b/packages/core/src/connection-provider.ts
@@ -37,11 +37,11 @@ class ConnectionProvider {
    * synchronize on creation of databases and is never used in direct drivers.
    *
    * @param {object} param - object parameter
-   * @param {string} param.accessMode - the access mode for the to-be-acquired connection
-   * @param {string} param.database - the target database for the to-be-acquired connection
-   * @param {Bookmark} param.bookmarks - the bookmarks to send to routing discovery
-   * @param {string} param.impersonatedUser - the impersonated user
-   * @param {function (params:string?)} params.onDatabaseNameResolved - Callback called when the database name get resolved
+   * @property {string} param.accessMode - the access mode for the to-be-acquired connection
+   * @property {string} param.database - the target database for the to-be-acquired connection
+   * @property {Bookmark} param.bookmarks - the bookmarks to send to routing discovery
+   * @property {string} param.impersonatedUser - the impersonated user
+   * @property {function (databaseName:string?)} param.onDatabaseNameResolved - Callback called when the database name get resolved
    */
   acquireConnection(param?: {
     accessMode?: string

--- a/packages/core/src/connection-provider.ts
+++ b/packages/core/src/connection-provider.ts
@@ -20,6 +20,7 @@
 import Connection from './connection'
 import { bookmark } from './internal'
 
+
 /**
  * Inteface define a common way to acquire a connection
  *
@@ -40,26 +41,16 @@ class ConnectionProvider {
    * @param {string} param.database - the target database for the to-be-acquired connection
    * @param {Bookmark} param.bookmarks - the bookmarks to send to routing discovery
    * @param {string} param.impersonatedUser - the impersonated user
+   * @param {function (params:string?)} params.onDatabaseNameResolved - Callback called when the database name get resolved
    */
-  acquireConnection(params?: {
+  acquireConnection(param?: {
     accessMode?: string
     database?: string
     bookmarks: bookmark.Bookmark,
-    impersonatedUser?: string
+    impersonatedUser?: string,
+    onDatabaseNameResolved?: (databaseName?: string) => void
   }): Promise<Connection> {
     throw Error('Not implemented')
-  }
-
-  /**
-   * Resolve database name
-   * 
-   * @param {object} param - object parameter
-   * @param {string|undefined|null} database Database name
-   * @param {string|undefined|null} impersonatedUser The user which is being impersonated
-   * @return {string|undefined|null} the resolved db name
-   */
-  resolveDatabaseName({ database }: { database?: string, impersonatedUser?: string }): string | undefined | null {
-    return database
   }
 
   /**

--- a/packages/core/src/connection-provider.ts
+++ b/packages/core/src/connection-provider.ts
@@ -69,6 +69,16 @@ class ConnectionProvider {
   }
 
   /**
+   * This method checks whether the backend database supports transaction config functionality
+   * by checking protocol handshake result.
+   *
+   * @returns {Promise<boolean>}
+   */
+   supportsUserImpersonation(): Promise<boolean> {
+    throw Error('Not implemented')
+  }
+
+  /**
    * Closes this connection provider along with its internals (connections, pools, etc.)
    *
    * @returns {Promise<void>}

--- a/packages/core/src/internal/connection-holder.ts
+++ b/packages/core/src/internal/connection-holder.ts
@@ -87,11 +87,13 @@ class ConnectionHolder implements ConnectionHolderInterface {
 
   /**
    * @constructor
-   * @param {string} mode - the access mode for new connection holder.
-   * @param {string} database - the target database name.
-   * @param {Bookmark} bookmark - the last bookmark
-   * @param {ConnectionProvider} connectionProvider - the connection provider to acquire connections from.
-   * @param {string?} impersonatedUser - the user which will be impersonated
+   * @param {object} params
+   * @property {string} params.mode - the access mode for new connection holder.
+   * @property {string} params.database - the target database name.
+   * @property {Bookmark} params.bookmark - the last bookmark
+   * @property {ConnectionProvider} params.connectionProvider - the connection provider to acquire connections from.
+   * @property {string?} params.impersonatedUser - the user which will be impersonated
+   * @property {function(databaseName:string)} params.onDatabaseNameResolved - callback called when the database name is resolved
    */
   constructor({
     mode = ACCESS_MODE_WRITE,

--- a/packages/core/src/internal/connection-holder.ts
+++ b/packages/core/src/internal/connection-holder.ts
@@ -129,6 +129,14 @@ class ConnectionHolder implements ConnectionHolderInterface {
     return this._referenceCount
   }
 
+  /**
+   * Resolve database name
+   * @return {string} the resolved db name
+   */
+  resolveDatabaseName(): string | undefined | null {
+    return this._connectionProvider?.resolveDatabaseName(this._database) || this._database
+  }
+
   initializeConnection(): boolean {
     if (this._referenceCount === 0 && this._connectionProvider) {
       this._connectionPromise = this._connectionProvider.acquireConnection({
@@ -288,6 +296,6 @@ class EmptyConnectionHolder extends ConnectionHolder {
 const EMPTY_CONNECTION_HOLDER: EmptyConnectionHolder = new EmptyConnectionHolder()
 
 // eslint-disable-next-line handle-callback-err
-function ignoreError(error: Error) {}
+function ignoreError(error: Error) { }
 
 export { ConnectionHolder, ReadOnlyConnectionHolder, EMPTY_CONNECTION_HOLDER }

--- a/packages/core/src/internal/constants.ts
+++ b/packages/core/src/internal/constants.ts
@@ -31,6 +31,7 @@ const BOLT_PROTOCOL_V4_0: number = 4.0
 const BOLT_PROTOCOL_V4_1: number = 4.1
 const BOLT_PROTOCOL_V4_2: number = 4.2
 const BOLT_PROTOCOL_V4_3: number = 4.3
+const BOLT_PROTOCOL_V4_4: number = 4.4
 
 export {
   FETCH_ALL,
@@ -44,5 +45,6 @@ export {
   BOLT_PROTOCOL_V4_0,
   BOLT_PROTOCOL_V4_1,
   BOLT_PROTOCOL_V4_2,
-  BOLT_PROTOCOL_V4_3
+  BOLT_PROTOCOL_V4_3,
+  BOLT_PROTOCOL_V4_4
 }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -100,13 +100,15 @@ class Session {
       mode: ACCESS_MODE_READ,
       database,
       bookmark,
-      connectionProvider
+      connectionProvider,
+      impersonatedUser
     })
     this._writeConnectionHolder = new ConnectionHolder({
       mode: ACCESS_MODE_WRITE,
       database,
       bookmark,
-      connectionProvider
+      connectionProvider,
+      impersonatedUser
     })
     this._open = true
     this._hasTx = false
@@ -257,6 +259,7 @@ class Session {
 
     const tx = new Transaction({
       connectionHolder,
+      impersonatedUser: this._impersonatedUser,
       onClose: this._transactionClosed.bind(this),
       onBookmark: this._updateBookmark.bind(this),
       onConnection: this._assertSessionIsOpen.bind(this),

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -146,7 +146,7 @@ class Session {
         bookmark: this._lastBookmark,
         txConfig: autoCommitTxConfig,
         mode: this._mode,
-        database: this._database,
+        database: this._connectionHolderWithMode(this._mode).resolveDatabaseName(), // TODO: Cleanup it || BIGMONTZ
         impersonatedUser: this._impersonatedUser,
         afterComplete: this._onComplete,
         reactive: this._reactive,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -57,6 +57,7 @@ class Session {
   private _hasTx: boolean
   private _lastBookmark: Bookmark
   private _transactionExecutor: TransactionExecutor
+  private _impersonatedUser?: string
   private _onComplete: (meta: any) => void
 
   /**
@@ -70,6 +71,7 @@ class Session {
    * @param {Object} args.config={} - This driver configuration.
    * @param {boolean} args.reactive - Whether this session should create reactive streams
    * @param {number} args.fetchSize - Defines how many records is pulled in each pulling batch
+   * @param {string} args.impersonatedUser - The username which the user wants to impersonate for the duration of the session.
    */
   constructor({
     mode,
@@ -78,7 +80,8 @@ class Session {
     database,
     config,
     reactive,
-    fetchSize
+    fetchSize,
+    impersonatedUser
   }: {
     mode: SessionMode
     connectionProvider: ConnectionProvider
@@ -86,7 +89,8 @@ class Session {
     database: string
     config: any
     reactive: boolean
-    fetchSize: number
+    fetchSize: number,
+    impersonatedUser?: string
   }) {
     this._mode = mode
     this._database = database
@@ -106,6 +110,7 @@ class Session {
     })
     this._open = true
     this._hasTx = false
+    this._impersonatedUser = impersonatedUser
     this._lastBookmark = bookmark || Bookmark.empty()
     this._transactionExecutor = _createTransactionExecutor(config)
     this._onComplete = this._onCompleteCallback.bind(this)
@@ -142,6 +147,7 @@ class Session {
         txConfig: autoCommitTxConfig,
         mode: this._mode,
         database: this._database,
+        impersonatedUser: this._impersonatedUser,
         afterComplete: this._onComplete,
         reactive: this._reactive,
         fetchSize: this._fetchSize

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -148,7 +148,7 @@ class Session {
         bookmark: this._lastBookmark,
         txConfig: autoCommitTxConfig,
         mode: this._mode,
-        database: this._connectionHolderWithMode(this._mode).resolveDatabaseName(), // TODO: Cleanup it || BIGMONTZ
+        database: this._connectionHolderWithMode(this._mode).resolveDatabaseName(),
         impersonatedUser: this._impersonatedUser,
         afterComplete: this._onComplete,
         reactive: this._reactive,

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -52,6 +52,7 @@ class Transaction {
   private _onComplete: (metadata: any) => void
   private _fetchSize: number
   private _results: any[]
+  private _impersonatedUser?: string
 
   /**
    * @constructor
@@ -62,6 +63,7 @@ class Transaction {
    * is not yet released.
    * @param {boolean} reactive whether this transaction generates reactive streams
    * @param {number} fetchSize - the record fetch size in each pulling batch.
+   * @param {string} args.impersonatedUser - The username which the user wants to impersonate for the duration of the session.
    */
   constructor({
     connectionHolder,
@@ -69,7 +71,8 @@ class Transaction {
     onBookmark,
     onConnection,
     reactive,
-    fetchSize
+    fetchSize,
+    impersonatedUser
   }: {
     connectionHolder: ConnectionHolder
     onClose: () => void
@@ -77,6 +80,7 @@ class Transaction {
     onConnection: () => void
     reactive: boolean
     fetchSize: number
+    impersonatedUser?: string
   }) {
     this._connectionHolder = connectionHolder
     this._reactive = reactive
@@ -88,6 +92,7 @@ class Transaction {
     this._onComplete = this._onCompleteCallback.bind(this)
     this._fetchSize = fetchSize
     this._results = []
+    this._impersonatedUser = impersonatedUser
   }
 
   /**
@@ -107,6 +112,7 @@ class Transaction {
             txConfig: txConfig,
             mode: this._connectionHolder.mode(),
             database: this._connectionHolder.database(),
+            impersonatedUser: this._impersonatedUser,
             beforeError: this._onError,
             afterComplete: this._onComplete
           })
@@ -289,7 +295,7 @@ const _states = {
         onComplete,
         onConnection,
         reactive,
-        fetchSize
+        fetchSize,
       }: StateTransitionParams
     ): any => {
       // RUN in explicit transaction can't contain bookmarks and transaction configuration
@@ -305,7 +311,7 @@ const _states = {
               beforeError: onError,
               afterComplete: onComplete,
               reactive: reactive,
-              fetchSize: fetchSize
+              fetchSize: fetchSize,
             })
           } else {
             throw newError('No connection available')

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -111,7 +111,7 @@ class Transaction {
             bookmark: bookmark,
             txConfig: txConfig,
             mode: this._connectionHolder.mode(),
-            database: this._connectionHolder.database(),
+            database: this._connectionHolder.resolveDatabaseName(), // TODO: Cleanup it || BIGMONTZ
             impersonatedUser: this._impersonatedUser,
             beforeError: this._onError,
             afterComplete: this._onComplete

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -111,7 +111,7 @@ class Transaction {
             bookmark: bookmark,
             txConfig: txConfig,
             mode: this._connectionHolder.mode(),
-            database: this._connectionHolder.resolveDatabaseName(), // TODO: Cleanup it || BIGMONTZ
+            database: this._connectionHolder.resolveDatabaseName(),
             impersonatedUser: this._impersonatedUser,
             beforeError: this._onError,
             afterComplete: this._onComplete

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -111,7 +111,7 @@ class Transaction {
             bookmark: bookmark,
             txConfig: txConfig,
             mode: this._connectionHolder.mode(),
-            database: this._connectionHolder.resolveDatabaseName(),
+            database: this._connectionHolder.database(),
             impersonatedUser: this._impersonatedUser,
             beforeError: this._onError,
             afterComplete: this._onComplete

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -63,7 +63,7 @@ class Transaction {
    * is not yet released.
    * @param {boolean} reactive whether this transaction generates reactive streams
    * @param {number} fetchSize - the record fetch size in each pulling batch.
-   * @param {string} args.impersonatedUser - The username which the user wants to impersonate for the duration of the session.
+   * @param {string} impersonatedUser - The name of the user which should be impersonated for the duration of the session.
    */
   constructor({
     connectionHolder,

--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -216,7 +216,6 @@ describe('index', () => {
       connectionProvider: {
         acquireConnection: () => Promise.reject(Error('something wrong')),
         close: () => Promise.resolve(),
-        resolveDatabaseName: ({ database }: { database?: string, impersonatedUser?: string }) => database,
         supportsMultiDb: () => Promise.resolve(true),
         supportsTransactionConfig: () => Promise.resolve(true),
         supportsUserImpersonation: () => Promise.resolve(true)

--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -216,7 +216,7 @@ describe('index', () => {
       connectionProvider: {
         acquireConnection: () => Promise.reject(Error('something wrong')),
         close: () => Promise.resolve(),
-        resolveDatabaseName: database => database,
+        resolveDatabaseName: ({database}: {database?:string, impersonatedUser?: string}) => database,
         supportsMultiDb: () => Promise.resolve(true),
         supportsTransactionConfig: () => Promise.resolve(true),
         supportsUserImpersonation: () => Promise.resolve(true)

--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -216,7 +216,7 @@ describe('index', () => {
       connectionProvider: {
         acquireConnection: () => Promise.reject(Error('something wrong')),
         close: () => Promise.resolve(),
-        resolveDatabaseName: ({database}: {database?:string, impersonatedUser?: string}) => database,
+        resolveDatabaseName: ({ database }: { database?: string, impersonatedUser?: string }) => database,
         supportsMultiDb: () => Promise.resolve(true),
         supportsTransactionConfig: () => Promise.resolve(true),
         supportsUserImpersonation: () => Promise.resolve(true)

--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -216,6 +216,7 @@ describe('index', () => {
       connectionProvider: {
         acquireConnection: () => Promise.reject(Error('something wrong')),
         close: () => Promise.resolve(),
+        resolveDatabaseName: database => database,
         supportsMultiDb: () => Promise.resolve(true),
         supportsTransactionConfig: () => Promise.resolve(true),
         supportsUserImpersonation: () => Promise.resolve(true)

--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -217,7 +217,8 @@ describe('index', () => {
         acquireConnection: () => Promise.reject(Error('something wrong')),
         close: () => Promise.resolve(),
         supportsMultiDb: () => Promise.resolve(true),
-        supportsTransactionConfig: () => Promise.resolve(true)
+        supportsTransactionConfig: () => Promise.resolve(true),
+        supportsUserImpersonation: () => Promise.resolve(true)
       }
     })
     expect(session).toBeDefined()

--- a/packages/neo4j-driver/src/driver.js
+++ b/packages/neo4j-driver/src/driver.js
@@ -54,7 +54,7 @@ class Driver extends CoreDriver {
    * @param {string|string[]} param.bookmarks - The initial reference or references to some previous transactions. Value is optional and
    * absence indicates that the bookmarks do not exist or are unknown.
    * @param {string} param.database - The database this session will operate on.
-   * @param {string} param.impersonatedUser - The username which the user wants to impersonate for the duration of the session.
+   * @param {string} param.impersonatedUser - The name of the user which should be impersonated for the duration of the session.
    * @returns {RxSession} new reactive session.
    */
   rxSession ({

--- a/packages/neo4j-driver/src/driver.js
+++ b/packages/neo4j-driver/src/driver.js
@@ -54,19 +54,22 @@ class Driver extends CoreDriver {
    * @param {string|string[]} param.bookmarks - The initial reference or references to some previous transactions. Value is optional and
    * absence indicates that the bookmarks do not exist or are unknown.
    * @param {string} param.database - The database this session will operate on.
+   * @param {string} param.impersonatedUser - The username which the user wants to impersonate for the duration of the session.
    * @returns {RxSession} new reactive session.
    */
   rxSession ({
     defaultAccessMode = WRITE,
     bookmarks,
     database = '',
-    fetchSize
+    fetchSize,
+    impersonatedUser
   } = {}) {
     return new RxSession({
       session: this._newSession({
         defaultAccessMode,
         bookmarks,
         database,
+        impersonatedUser,
         reactive: true,
         fetchSize: validateFetchSizeValue(fetchSize, this._config.fetchSize)
       }),

--- a/packages/neo4j-driver/test/internal/node/direct.driver.boltkit.test.js
+++ b/packages/neo4j-driver/test/internal/node/direct.driver.boltkit.test.js
@@ -158,7 +158,7 @@ describe('#stub-direct direct driver with stub server', () => {
     }, 60000)
   })
 
-  describe('should report whether usr impersonation is supported', () => {
+  describe('should report whether user impersonation is supported', () => {
     async function verifySupportsUserImpersonation (version, expected) {
       if (!boltStub.supported) {
         return

--- a/packages/neo4j-driver/test/internal/routing-table.test.js
+++ b/packages/neo4j-driver/test/internal/routing-table.test.js
@@ -278,6 +278,38 @@ describe('#unit RoutingTable', () => {
 
       expect(result.expirationTime).toEqual(Integer.MAX_VALUE)
     })
+    ;[
+      [undefined, undefined, null],
+      [undefined, null, null],
+      [undefined, 'homedb2', 'homedb2'],
+      [null, undefined, null],
+      [null, null, null],
+      [null, 'homedb2', 'homedb2'],
+      ['homedb', undefined, 'homedb'],
+      ['homedb', null, 'homedb'],
+      ['homedb', 'homedb2', 'homedb']
+    ].forEach(([database, databaseInMetadata, expected]) => {
+      it(`should return resolve correctly the database [database=${database}, databaseInMetadata=${databaseInMetadata}]`, () => {
+        const routers = ['router:7699']
+        const readers = ['reader1:7699', 'reader2:7699']
+        const writers = ['writer1:7693', 'writer2:7692', 'writer3:7629']
+
+        const result = RoutingTable.fromRawRoutingTable(
+          database,
+          ServerAddress.fromUrl('localhost:7687'),
+          RawRoutingTable.ofMessageResponse(
+            newMetadata({
+              routers,
+              readers,
+              writers,
+              database: databaseInMetadata
+            })
+          )
+        )
+
+        expect(result.database).toEqual(expected)
+      })
+    })
 
     it('should return Integer.MAX_VALUE as expirationTime when ttl is negative', async () => {
       const ttl = int(-2)
@@ -479,7 +511,8 @@ describe('#unit RoutingTable', () => {
       routers = [],
       readers = [],
       writers = [],
-      extra = []
+      extra = [],
+      database = undefined
     } = {}) {
       const routersField = {
         role: 'ROUTE',
@@ -496,7 +529,8 @@ describe('#unit RoutingTable', () => {
       return {
         rt: {
           ttl,
-          servers: [routersField, readersField, writersField, ...extra]
+          servers: [routersField, readersField, writersField, ...extra],
+          db: database
         }
       }
     }

--- a/packages/neo4j-driver/test/resources/boltstub/v4.4/supports_protocol_version.script
+++ b/packages/neo4j-driver/test/resources/boltstub/v4.4/supports_protocol_version.script
@@ -1,0 +1,2 @@
+!: AUTO GOODBYE
+!: BOLT 4.4

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -265,7 +265,8 @@ export function GetFeatures (_context, _params, wire) {
       'Feature:Auth:Kerberos',
       'Feature:Auth:Bearer',
       'AuthorizationExpiredTreatment',
-      'ConfHint:connection.recv_timeout_seconds'
+      'ConfHint:connection.recv_timeout_seconds',
+      'Feature:Bolt:4.4'
     ]
   })
 }

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -63,7 +63,7 @@ export function DriverClose (context, data, wire) {
 }
 
 export function NewSession (context, data, wire) {
-  let { driverId, accessMode, bookmarks, database, fetchSize } = data
+  let { driverId, accessMode, bookmarks, database, fetchSize, impersonatedUser } = data
   switch (accessMode) {
     case 'r':
       accessMode = neo4j.session.READ
@@ -80,7 +80,8 @@ export function NewSession (context, data, wire) {
     defaultAccessMode: accessMode,
     bookmarks,
     database,
-    fetchSize
+    fetchSize,
+    impersonatedUser
   })
   const id = context.addSession(session)
   wire.writeResponse('Session', { id })
@@ -266,7 +267,8 @@ export function GetFeatures (_context, _params, wire) {
       'Feature:Auth:Bearer',
       'AuthorizationExpiredTreatment',
       'ConfHint:connection.recv_timeout_seconds',
-      'Feature:Bolt:4.4'
+      'Feature:Bolt:4.4',
+      'Feature:Impersonation'
     ]
   })
 }

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -307,7 +307,7 @@ export function GetRoutingTable (context, { driverId, database }, wire) {
     driver &&
     driver._getOrCreateConnectionProvider() &&
     driver._getOrCreateConnectionProvider()._routingTableRegistry &&
-    driver._getOrCreateConnectionProvider()._routingTableRegistry.get(database)
+    driver._getOrCreateConnectionProvider()._routingTableRegistry.get(null, database)
 
   if (routingTable) {
     wire.writeResponse('RoutingTable', {


### PR DESCRIPTION
Users can, when they have been granted explicit permission, run transactions against the database as different users. When impersonating a user, the query is run as the complete security context of the impersonated user and not the authenticated user (e.g. home database, permissions etc).

- [x] Create protocol 4.4 version
- [x] Add protocol to the handshake
- [x] Change the messages RUN, BEGIN and ROUTE to support the impersonation parameter
- [x] Add support to the impersonation into the driver surface
- [x] Add special treatments for the default/home database