### PR TITLE
Make test script handle runs as root

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "clean": "lerna clean -y && lerna run clean",
-    "build": "lerna bootstrap --ci --include-dependencies --stream",
+    "build": "lerna bootstrap --ci",
     "test::unit": "lerna run test::unit --stream",
     "test::integration": "lerna run test::integration --stream",
     "test::browser": "lerna run test::browser --stream",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "clean": "lerna clean -y && lerna run clean",
-    "build": "lerna bootstrap --ci",
+    "build": "lerna bootstrap --ci --concurrency=1",
     "test::unit": "lerna run test::unit --stream",
     "test::integration": "lerna run test::integration --stream",
     "test::browser": "lerna run test::browser --stream",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "clean": "lerna clean -y && lerna run clean",
-    "build": "lerna bootstrap --ci --include-dependencies",
+    "build": "lerna bootstrap --ci --include-dependencies --stream",
     "test::unit": "lerna run test::unit --stream",
     "test::integration": "lerna run test::integration --stream",
     "test::browser": "lerna run test::browser --stream",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "clean": "lerna clean -y && lerna run clean",
-    "build": "lerna bootstrap --ci --concurrency=1",
+    "build": "lerna bootstrap --ci --include-dependencies",
     "test::unit": "lerna run test::unit --stream",
     "test::integration": "lerna run test::integration --stream",
     "test::browser": "lerna run test::browser --stream",

--- a/runTests.sh
+++ b/runTests.sh
@@ -10,7 +10,7 @@ npm run build -- --no-private
 
 # root users could not run the lifecycle scripts
 # so it need will need to run the prepare script 
-if [ "$EUID" -e 0 ]
+if [ "$EUID" -eq 0 ]
   then echo "Running prepare by manually"
   npm run lerna -- run prepare --no-private  
 fi

--- a/runTests.sh
+++ b/runTests.sh
@@ -5,8 +5,6 @@ function finish {
 }
 trap finish EXIT
 
-npm install -g gulp typescript jest
-
 npm ci
 npm run build -- --no-private
 

--- a/runTests.sh
+++ b/runTests.sh
@@ -7,6 +7,7 @@ trap finish EXIT
 
 npm ci
 npm run build -- --no-private
+npm run lerna -- prepare --no-private
 
 if [[ ! -z "$1" ]]; then
   export NEOCTRL_ARGS="$1"

--- a/runTests.sh
+++ b/runTests.sh
@@ -7,7 +7,7 @@ trap finish EXIT
 
 npm ci
 npm run build -- --no-private
-npm run lerna -- prepare --no-private
+npm run lerna -- run prepare --no-private
 
 if [[ ! -z "$1" ]]; then
   export NEOCTRL_ARGS="$1"

--- a/runTests.sh
+++ b/runTests.sh
@@ -7,7 +7,14 @@ trap finish EXIT
 
 npm ci
 npm run build -- --no-private
-npm run lerna -- run prepare --no-private
+
+# root users could not run the lifecycle scripts
+# so it need will need to run the prepare script 
+if [ "$EUID" -e 0 ]
+  then echo "Running prepare by manually"
+  npm run lerna -- run prepare --no-private  
+fi
+
 
 if [[ ! -z "$1" ]]; then
   export NEOCTRL_ARGS="$1"


### PR DESCRIPTION
The NPM lifecycle scripts can not be run by the root user for security reasons. The full build of the driver repo depends on the `prepare` script run during the build (or after it).

The solution for this case is run the prepare script if the current user is the root, the way the driver package will be ready for testing.  