### PR TITLE
testkit: Fix testkit-backend log not being stored in CI

### DIFF
--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
         firefox \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g npm \
+RUN npm install -g npm@7 \
     && /bin/bash -c "hash -d npm"
 RUN npm install -g gulp
 

--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -31,13 +31,3 @@ CipherString = DEFAULT:@SECLEVEL=1" >> /etc/ssl/openssl.cnf
 # Assumes Linux Debian based image.
 COPY CAs/* /usr/local/share/ca-certificates/
 RUN update-ca-certificates
-
-# Creating an user for building the driver and running the tests
-RUN useradd -m driver && echo "driver:driver" | chpasswd && adduser driver sudo
-VOLUME /driver
-RUN chown -Rh driver:driver /driver
-USER driver
-WORKDIR /home/driver
-CMD /bin/bash
-RUN mkdir /home/driver/.npm_global
-RUN npm config set prefix /home/driver/.npm_global

--- a/testkit/backend.py
+++ b/testkit/backend.py
@@ -3,8 +3,10 @@ Executed in Javascript driver container.
 Assumes driver and backend has been built.
 Responsible for starting the test backend.
 """
-from common import run_in_driver_repo
 import os
-
+import subprocess
 if __name__ == "__main__":
-    run_in_driver_repo(["npm", "run", "start-testkit-backend"], env=os.environ)
+    err = open("/artifacts/backenderr.log", "w")
+    out = open("/artifacts/backendout.log", "w")
+    subprocess.check_call(["npm", "run", "start-testkit-backend"],
+                          env=os.environ, stdout=out, stderr=err)

--- a/testkit/build.py
+++ b/testkit/build.py
@@ -2,14 +2,14 @@
 Executed in Javascript driver container.
 Responsible for building driver and test backend.
 """
-from common import run, run_in_driver_repo, DRIVER_REPO
+from common import run, run_in_driver_repo
 import os
+import pathlib
 
 
-def copy_files_to_workdir():
-    run(["mkdir", DRIVER_REPO])
-    run(["cp", "-fr", ".", DRIVER_REPO])
-    run(["chown", "-Rh", "driver:driver", DRIVER_REPO])
+
+def define_npm_home():
+    os.environ["HOME"] = str(pathlib.Path().resolve())
 
 
 def init_monorepo():
@@ -19,10 +19,13 @@ def init_monorepo():
 
 def clean_and_build():
     run_in_driver_repo(["npm", "run", "clean"], env=os.environ)
-    run_in_driver_repo(["npm", "run", "build"], env=os.environ)
+    run_in_driver_repo(["npm", "run", "build", "--",
+                        "--ignore-scripts"], env=os.environ)
+    run_in_driver_repo(["npm", "run", "lerna", "--",
+                        "run", "prepare"], env=os.environ)
 
 
 if __name__ == "__main__":
-    copy_files_to_workdir()
+    define_npm_home()
     init_monorepo()
     clean_and_build()

--- a/testkit/build.py
+++ b/testkit/build.py
@@ -2,10 +2,9 @@
 Executed in Javascript driver container.
 Responsible for building driver and test backend.
 """
-from common import run, run_in_driver_repo
+from common import run_in_driver_repo
 import os
 import pathlib
-
 
 
 def define_npm_home():

--- a/testkit/common.py
+++ b/testkit/common.py
@@ -21,7 +21,7 @@ def run_in(cwd):
 
 
 def run_in_driver_repo(args, env=None):
-    return run(args, env, DRIVER_REPO)
+    return run(args, env)
 
 
 def is_lite():

--- a/testkit/integration.py
+++ b/testkit/integration.py
@@ -17,7 +17,9 @@ if __name__ == "__main__":
     else:
         ignore = "--ignore=neo4j-driver-lite"
 
-    run_in_driver_repo(["npm", "run", "test::integration", "--", ignore])
+    run_in_driver_repo(["npm", "run", "test::integration",
+                        "--", ignore], env=os.environ)
 
     if should_test_browser():
-        run_in_driver_repo(["npm", "run", "test::browser", "--", ignore])
+        run_in_driver_repo(["npm", "run", "test::browser",
+                            "--", ignore], env=os.environ)

--- a/testkit/stress.py
+++ b/testkit/stress.py
@@ -1,4 +1,5 @@
 import os
+from posix import environ
 from common import run_in_driver_repo, is_lite
 
 
@@ -12,4 +13,5 @@ if __name__ == "__main__":
     else:
         ignore = "--ignore=neo4j-driver-lite"
 
-    run_in_driver_repo(["npm", "run", "test::stress", "--", ignore])
+    run_in_driver_repo(["npm", "run", "test::stress",
+                        "--", ignore], env=os.environ)

--- a/testkit/unittests.py
+++ b/testkit/unittests.py
@@ -13,4 +13,5 @@ if __name__ == "__main__":
     else:
         ignore = "--ignore=neo4j-driver-lite"
 
-    run_in_driver_repo(["npm", "run", "test::unit", "--", ignore])
+    run_in_driver_repo(["npm", "run", "test::unit",
+                        "--", ignore], env=os.environ)


### PR DESCRIPTION
During the Lerna introduction, the logs from the backend execution was accidently removed.