### PR TITLE
Connection errors should be thrown with the root cause

### DIFF
--- a/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -84,6 +84,10 @@ export default class BoltProtocol {
     return BOLT_PROTOCOL_V1
   }
 
+  get currentFailure () {
+    return this._responseHandler.currentFailure
+  }
+
   /**
    * Get the packer.
    * @return {Packer} the protocol's packer.

--- a/bolt-connection/src/bolt/response-handler.js
+++ b/bolt-connection/src/bolt/response-handler.js
@@ -146,6 +146,10 @@ export default class ResponseHandler {
     }
   }
 
+  get currentFailure () {
+    return this._currentFailure
+  }
+
   /*
    * Pop next pending observer form the list of observers and make it current observer.
    * @protected

--- a/bolt-connection/src/connection/connection-channel.js
+++ b/bolt-connection/src/connection/connection-channel.js
@@ -270,7 +270,7 @@ export default class ChannelConnection extends Connection {
    */
   _handleFatalError (error) {
     this._isBroken = true
-    this._error = this.handleAndTransformError(error, this._address)
+    this._error = this.handleAndTransformError(this._protocol.currentFailure || error, this._address)
 
     if (this._log.isErrorEnabled()) {
       this._log.error(

--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
         firefox \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g npm \
+RUN npm install -g npm@7 \
     && /bin/bash -c 'hash -d npm'
 RUN npm install -g gulp
 


### PR DESCRIPTION
Suppressing the original failure could make the retry logic doesn't work as expected and the wrong report could masquerade the issue making it difficult to react on errors.