### PR TITLE
Handle AuthorisationExpired during rediscovery

### DIFF
--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -477,7 +477,14 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
   async _createSessionForRediscovery (routerAddress, bookmark, impersonatedUser) {
     try {
       const connection = await this._connectionPool.acquire(routerAddress)
-      const connectionProvider = new SingleConnectionProvider(connection)
+
+      const databaseSpecificErrorHandler = ConnectionErrorHandler.create({
+        errorCode: SESSION_EXPIRED,
+        handleAuthorizationExpired: (error, address) => this._handleAuthorizationExpired(error, address)
+      })
+      
+      const connectionProvider = new SingleConnectionProvider(
+        new DelegateConnection(connection, databaseSpecificErrorHandler))
 
       const protocolVersion = connection.protocol().version
       if (protocolVersion < 4.0) {


### PR DESCRIPTION
The connections to a server should not be sent back to the pool if an AuthenticationExpired failure happens.

Sending the connection back to the pool will make the next work using the connection fails with the same error.

Testing: https://github.com/neo4j-drivers/testkit/pull/288