### PR TITLE
Fix minimum supported TLS feature

### DIFF
--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -8,7 +8,7 @@ const SUPPORTED_TLS = (() => {
   const min = Number(tls.DEFAULT_MIN_VERSION.split('TLSv')[1])
   const max = Number(tls.DEFAULT_MAX_VERSION.split('TLSv')[1])
   const result = [];
-  for (let version = min; version <= max; version = Number((version + 0.1).toFixed(1)) ) {
+  for (let version = min > 1 ? min : 1.1; version <= max; version = Number((version + 0.1).toFixed(1)) ) {
     result.push(`Feature:TLS:${version.toFixed(1)}`)
   }
   return result;


### PR DESCRIPTION
Testkit only supports 1.1 or later