### PR TITLE
teskit-backend: Enabling tests for Result.then

### DIFF
--- a/packages/testkit-backend/src/result-observer.js
+++ b/packages/testkit-backend/src/result-observer.js
@@ -14,6 +14,7 @@ export default class ResultObserver {
     this.onCompleted = this.onCompleted.bind(this)
     this.onError = this.onError.bind(this)
     this._completitionPromise = null
+    this._subscribed = false
   }
 
   onKeys (keys) {
@@ -39,8 +40,13 @@ export default class ResultObserver {
     this._completitionPromise = null
   }
 
+  get result () {
+    return this._result
+  }
+
   // Returns a promise, only one outstanding next!
   next () {
+    this._subscribe()
     return new Promise((resolve, reject) => {
       this._promise = {
         resolve,
@@ -51,6 +57,7 @@ export default class ResultObserver {
   }
 
   completitionPromise () {
+    this._subscribe()
     return new Promise((resolve, reject) => {
       if (this._summary) {
         resolve(this._summary)
@@ -108,6 +115,13 @@ export default class ResultObserver {
   _reject (promise, err) {
     if (promise) {
       promise.reject(err)
+    }
+  }
+
+  _subscribe () {
+    if (!this._subscribed) {
+      this._result.subscribe(this)
+      this._subscribed = true
     }
   }
 }

--- a/packages/testkit-backend/src/skipped-tests.js
+++ b/packages/testkit-backend/src/skipped-tests.js
@@ -94,6 +94,18 @@ const skippedTests = [
     ifEquals(
       'neo4j.sessionrun.TestSessionRun.test_partial_iteration'
     )
+  ),
+  skip(
+    'Driver does not support mixing Result.subscribe with Result.then',
+    ifEquals(
+      'stub.iteration.test_result_list.TestResultList.test_tx_run_result_list_pulls_all_records_at_once_next_before_list'
+    ),
+    ifEquals(
+      'stub.iteration.test_result_list.TestResultList.test_tx_func_result_list_pulls_all_records_at_once_next_before_list'
+    ),
+    ifEquals(
+      'stub.iteration.test_result_list.TestResultList.test_session_run_result_list_pulls_all_records_at_once_next_before_list'
+    )
   )
 ]
 


### PR DESCRIPTION
These changes enable the test relate to consume all records as list in one function call.

The Result implementation in javascript doesn't allow resolve and subscribe at the same result without having strange behaviours. Then, the moment `ResultObserver` subscribes to the `Result` events was moved to the moment someone interacts with some `ResultObserver` method. This also implies in text which call next before list being skipped.