### PR TITLE
Fix connections not being destroyed when released to purged pool

### DIFF
--- a/packages/bolt-connection/test/pool/pool.test.js
+++ b/packages/bolt-connection/test/pool/pool.test.js
@@ -237,7 +237,7 @@ describe('#unit Pool', () => {
     expect(r0.destroyed).toBeTruthy()
   })
 
-  it('destroys resource when key was purged event when key is acquired again', async () => {
+  it('destroys resource when pool is purged even if a new pool is created for the same address', async () => {
     let counter = 0
     const address = ServerAddress.fromUrl('bolt://localhost:7687')
     const pool = new Pool({

--- a/packages/bolt-connection/test/pool/pool.test.js
+++ b/packages/bolt-connection/test/pool/pool.test.js
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import Pool from '../../../bolt-connection/lib/pool/pool'
-import PoolConfig from '../../../bolt-connection/lib/pool/pool-config'
+import Pool from '../../src/pool/pool'
+import PoolConfig from '../../src/pool/pool-config'
 import { newError, error, internal } from 'neo4j-driver-core'
 
 const {
@@ -27,7 +27,7 @@ const {
 
 const { SERVICE_UNAVAILABLE } = error
 
-describe('#unit Pool', async () => {
+describe('#unit Pool', () => {
   it('allocates if pool is empty', async () => {
     // Given
     let counter = 0
@@ -282,11 +282,9 @@ describe('#unit Pool', async () => {
     // Close the pool
     await pool.close()
 
-    await expectAsync(pool.acquire(address)).toBeRejectedWith(
-      jasmine.objectContaining({
-        message: jasmine.stringMatching(/Pool is closed/)
-      })
-    )
+    await expect(pool.acquire(address)).rejects.toMatchObject({
+      message: expect.stringMatching('Pool is closed')
+    })
   })
 
   it('should fail to acquire when closed with idle connections', async () => {
@@ -307,11 +305,9 @@ describe('#unit Pool', async () => {
     // Close the pool
     await pool.close()
 
-    await expectAsync(pool.acquire(address)).toBeRejectedWith(
-      jasmine.objectContaining({
-        message: jasmine.stringMatching(/Pool is closed/)
-      })
-    )
+    await expect(pool.acquire(address)).rejects.toMatchObject({
+      message: expect.stringMatching('Pool is closed')
+    })
   })
   it('purges keys other than the ones to keep', async () => {
     let counter = 0
@@ -561,9 +557,9 @@ describe('#unit Pool', async () => {
     await pool.acquire(address)
     await pool.acquire(address)
 
-    await expectAsync(pool.acquire(address)).toBeRejectedWith(
-      jasmine.stringMatching('acquisition timed out')
-    )
+    await expect(pool.acquire(address)).rejects.toMatchObject({
+      message: expect.stringMatching('acquisition timed out')
+    })
     expectNumberOfAcquisitionRequests(pool, address, 0)
   })
 
@@ -607,11 +603,11 @@ describe('#unit Pool', async () => {
 
     // Let's fulfill the connect promise belonging to the first request.
     conns[0].resolve(conns[0])
-    await expectAsync(req1).toBeResolved()
+    await expect(req1).resolves.toBeDefined()
 
     // Release the connection, it should be picked up by the second request.
     conns[0].release(address, conns[0])
-    await expectAsync(req2).toBeResolved()
+    await expect(req2).resolves.toBeDefined()
 
     // Just to make sure that there hasn't been any new connection.
     expect(conns.length).toEqual(1)

--- a/packages/bolt-connection/test/pool/pool.test.js
+++ b/packages/bolt-connection/test/pool/pool.test.js
@@ -259,7 +259,7 @@ describe('#unit Pool', () => {
     expect(pool.has(address)).toBeFalsy()
     expect(r0.destroyed).toBeFalsy()
 
-    // Acquiring second resolve should recreate the pool
+    // Acquiring second resource should recreate the pool
     const r1 = await pool.acquire(address)
     expect(pool.has(address)).toBeTruthy()
     expect(r1.id).toEqual(1)


### PR DESCRIPTION
This scenario happens when the pull for a given address is purged while a connection stills in use and then another pool for the same address is created. In this case, the connection was being wrongly added to the existing pool.

The correct behaviour is destroy this orphan connections.