### PR TITLE
Fix some broken imports

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -21,7 +21,7 @@ import {
   assertTxConfigIsEmpty,
   assertImpersonatedUserIsEmpty
 } from './bolt-protocol-util'
-import { Chunker } from '../channel/chunking'
+import { Chunker } from '../channel'
 import { v1 } from '../packstream'
 import RequestMessage from './request-message'
 import {

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -21,7 +21,7 @@ import {
   assertTxConfigIsEmpty,
   assertImpersonatedUserIsEmpty
 } from './bolt-protocol-util'
-import { Chunker } from '../chunking'
+import { Chunker } from '../channel/chunking'
 import { v1 } from '../packstream'
 import RequestMessage from './request-message'
 import {

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x0.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x0.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import BoltProtocolV3 from './bolt-protocol-v3'
-import RequestMessage, { ALL } from './request-message'
+import RequestMessage from './request-message'
 import { assertImpersonatedUserIsEmpty } from './bolt-protocol-util'
 import {
   ResultStreamObserver,
@@ -28,7 +28,7 @@ import { internal } from 'neo4j-driver-core'
 
 const {
   bookmark: { Bookmark },
-  constants: { BOLT_PROTOCOL_V4_0 },
+  constants: { BOLT_PROTOCOL_V4_0, FETCH_ALL },
   txConfig: { TxConfig }
 } = internal
 
@@ -90,7 +90,7 @@ export default class BoltProtocol extends BoltProtocolV3 {
       afterComplete,
       flush = true,
       reactive = false,
-      fetchSize = ALL
+      fetchSize = FETCH_ALL
     } = {}
   ) {
     const observer = new ResultStreamObserver({

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x1.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import BoltProtocolV4 from './bolt-protocol-v4x0'
-import RequestMessage, { ALL } from './request-message'
+import RequestMessage from './request-message'
 import { LoginObserver } from './stream-observers'
 import { internal } from 'neo4j-driver-core'
 

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x4.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x4.js
@@ -19,11 +19,11 @@
 import BoltProtocolV43 from './bolt-protocol-v4x3'
 
 import { internal } from 'neo4j-driver-core'
-import RequestMessage, { ALL } from './request-message'
+import RequestMessage from './request-message'
 import { RouteObserver, ResultStreamObserver } from './stream-observers'
 
 const {
-  constants: { BOLT_PROTOCOL_V4_4 },
+  constants: { BOLT_PROTOCOL_V4_4, FETCH_ALL },
   bookmark: { Bookmark },
 } = internal
 
@@ -84,7 +84,7 @@ export default class BoltProtocol extends BoltProtocolV43 {
       afterComplete,
       flush = true,
       reactive = false,
-      fetchSize = ALL
+      fetchSize = FETCH_ALL
     } = {}
   ) {
     const observer = new ResultStreamObserver({

--- a/packages/bolt-connection/src/bolt/stream-observers.js
+++ b/packages/bolt-connection/src/bolt/stream-observers.js
@@ -16,10 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { newError, error, Integer, Record, json } from 'neo4j-driver-core'
-import { ALL } from './request-message'
+import { newError, error, Integer, Record, json, internal } from 'neo4j-driver-core'
 import RawRoutingTable from './routing-table-raw'
 
+const {
+  constants: { FETCH_ALL },
+} = internal
 const { PROTOCOL_ERROR } = error
 class StreamObserver {
   onNext (rawRecord) {}
@@ -59,7 +61,7 @@ class ResultStreamObserver extends StreamObserver {
     reactive = false,
     moreFunction,
     discardFunction,
-    fetchSize = ALL,
+    fetchSize = FETCH_ALL,
     beforeError,
     afterError,
     beforeKeys,
@@ -367,7 +369,7 @@ class ResultStreamObserver extends StreamObserver {
 
   _setupAuoPull (fetchSize) {
     this._autoPull = true
-    if (fetchSize === ALL) {
+    if (fetchSize === FETCH_ALL) {
       this._lowRecordWatermark = Number.MAX_VALUE // we shall always lower than this number to enable auto pull
       this._highRecordWatermark = Number.MAX_VALUE // we shall never reach this number to disable auto pull
     } else {

--- a/packages/bolt-connection/src/connection/connection.js
+++ b/packages/bolt-connection/src/connection/connection.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { ResultStreamObserver, BoltProtocol } from '..bolt'
+import { ResultStreamObserver, BoltProtocol } from '../bolt'
 
 export default class Connection {
   /**

--- a/packages/bolt-connection/src/rediscovery/rediscovery.js
+++ b/packages/bolt-connection/src/rediscovery/rediscovery.js
@@ -18,7 +18,7 @@
  */
 import RoutingTable from './routing-table'
 import { RawRoutingTable } from '../bolt'
-import { newError, error, Session, ServerAddress } from 'neo4j-driver-core'
+import { newError, error, Session } from 'neo4j-driver-core'
 
 const { SERVICE_UNAVAILABLE } = error
 const PROCEDURE_NOT_FOUND_CODE = 'Neo.ClientError.Procedure.ProcedureNotFound'

--- a/packages/core/src/internal/observers.ts
+++ b/packages/core/src/internal/observers.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { observer } from '.'
 import Record from '../record'
 import ResultSummary from '../result-summary'
 


### PR DESCRIPTION
While I was working on [a Deno driver for Neo4j that uses this codebase](https://deno.land/x/neo4j_lite_client@4.4.1-preview), I found that Deno was detecting some invalid imports in the code.

In particular, a few places in the code try to import a constant called `ALL` from [`bolt/request-message.js`](https://github.com/neo4j/neo4j-javascript-driver/blob/4.4/packages/bolt-connection/src/bolt/request-message.js), but that constant [was renamed a year ago](https://github.com/neo4j/neo4j-javascript-driver/pull/659) to `FETCH_ALL`.

I'm not sure why the existing tooling didn't catch this import error or why Node/TypeScript didn't complain about it.

For the other changes, I'll add an inline comment in this PR to explain them.