### PR TITLE
Fix some TypeScript errors found with TypeScript 4.5 / Deno

### DIFF
--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -22,8 +22,8 @@
  * @private
  */
 class Connection {
-  id: string
-  databaseId: string
+  id: string = ""
+  databaseId: string = ""
   server: any
 
   /**

--- a/packages/core/src/internal/connection-holder.ts
+++ b/packages/core/src/internal/connection-holder.ts
@@ -194,7 +194,7 @@ class ConnectionHolder implements ConnectionHolderInterface {
    */
   private _releaseConnection(): Promise<Connection | void> {
     this._connectionPromise = this._connectionPromise
-      .then((connection?: Connection) => {
+      .then((connection?: Connection|void) => {
         if (connection) {
           if (connection.isOpen()) {
             return connection

--- a/packages/core/src/internal/observers.ts
+++ b/packages/core/src/internal/observers.ts
@@ -174,6 +174,6 @@ export class FailedObserver implements ResultStreamObserver {
 
 function apply<T>(thisArg: any, func?: (param: T) => void, param?: T): void {
   if (func) {
-    func.bind(thisArg)(param)
+    func.bind(thisArg)(param as any)
   }
 }

--- a/packages/core/src/internal/transaction-executor.ts
+++ b/packages/core/src/internal/transaction-executor.ts
@@ -30,13 +30,14 @@ type TransactionCreator = () => Transaction
 type TransactionWork<T> = (tx: Transaction) => T | Promise<T>
 type Resolve<T> = (value: T | PromiseLike<T>) => void
 type Reject = (value: any) => void
+type Timeout = ReturnType<typeof setTimeout>
 
 export class TransactionExecutor {
   private _maxRetryTimeMs: number
   private _initialRetryDelayMs: number
   private _multiplier: number
   private _jitterFactor: number
-  private _inFlightTimeoutIds: NodeJS.Timeout[]
+  private _inFlightTimeoutIds: Timeout[]
 
   constructor(
     maxRetryTimeMs?: number | null,

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 import VERSION from './version'
+import { logging } from './logging'
 
 import {
   Neo4jError,
@@ -79,7 +80,6 @@ type EncryptionLevel = coreTypes.EncryptionLevel
 type SessionMode = coreTypes.SessionMode
 type Logger = internal.logger.Logger
 type ConfiguredCustomResolver = internal.resolver.ConfiguredCustomResolver
-type LogLevel = coreTypes.LogLevel
 
 const { READ, WRITE } = coreDriver
 
@@ -326,21 +326,6 @@ function driver (
 }
 
 const USER_AGENT: string = 'neo4j-javascript/' + VERSION
-
-/**
- * Object containing predefined logging configurations. These are expected to be used as values of the driver config's `logging` property.
- * @property {function(level: ?string): object} console the function to create a logging config that prints all messages to `console.log` with
- * timestamp, level and message. It takes an optional `level` parameter which represents the maximum log level to be logged. Default value is 'info'.
- */
-const logging = {
-  console: (level: LogLevel) => {
-    return {
-      level: level,
-      logger: (level: LogLevel, message: string) =>
-        console.log(`${globalThis.Date.now()} ${level.toUpperCase()} ${message}`)
-    }
-  }
-}
 
 /**
  * Object containing constructors for all neo4j types.

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -337,7 +337,7 @@ const logging = {
     return {
       level: level,
       logger: (level: LogLevel, message: string) =>
-        console.log(`${global.Date.now()} ${level.toUpperCase()} ${message}`)
+        console.log(`${globalThis.Date.now()} ${level.toUpperCase()} ${message}`)
     }
   }
 }

--- a/packages/neo4j-driver-lite/src/logging.ts
+++ b/packages/neo4j-driver-lite/src/logging.ts
@@ -1,0 +1,20 @@
+import { types as coreTypes } from 'neo4j-driver-core'
+
+type LogLevel = coreTypes.LogLevel
+
+/**
+ * Object containing predefined logging configurations. These are expected to be used as values of the driver config's `logging` property.
+ * @property {function(level: ?string): object} console the function to create a logging config that prints all messages to `console.log` with
+ * timestamp, level and message. It takes an optional `level` parameter which represents the maximum log level to be logged. Default value is 'info'.
+ */
+export const logging = {
+  console: (level: LogLevel) => {
+    return {
+      level: level,
+      logger: (level: LogLevel, message: string) =>
+        console.log(`${Date.now()} ${level.toUpperCase()} ${message}`)
+        // Note: This 'logging' object is in its own file so we can easily access the global Date object here without conflicting
+        // with the Neo4j Date class, and without relying on 'globalThis' which isn't compatible with Node 10.
+    }
+  }
+}


### PR DESCRIPTION
While I was working on [a Deno driver for Neo4j that uses this codebase](https://deno.land/x/neo4j_lite_client@4.4.1-preview), I ran into some Typescript errors which this PR fixes.

These could be only relevant with the newer version of TypeScript (4.5) or with Deno's stricter `tsconfig` defaults, but I tried to fix them in a way that will work with Node and other versions/configurations of TypeScript without issues.

I'll put explanations of each change inline.