### PR TITLE
5.0 fix test failure in some node version

### DIFF
--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -59,6 +59,9 @@ describe('index', () => {
       'RETURN 1'
     )
     expect(result).toBeDefined()
+
+    // Catch the error
+    result.catch(() => {})
   })
 
   it('should export an instanciable Record', () => {


### PR DESCRIPTION
UncatchedException errors were being triggered when non-consumed promises are rejected.