### PR TITLE
Enables set different Node versions in Testkit Dockerfile

### DIFF
--- a/packages/testkit-backend/package.json
+++ b/packages/testkit-backend/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "scripts": {
     "build": "rollup src/index.js --config rollup.config.js",
-    "start": "node -r esm src/index.js",
+    "start": "node --version | grep -q v10. && node -r esm src/index.js || node --experimental-specifier-resolution=node src/index.js",
     "clean": "rm -fr node_modules public/index.js",
     "prepare": "npm run build"
   },

--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -1,20 +1,31 @@
 FROM ubuntu:20.04
 
+ARG NODE_VERSION=10
+
 ENV DEBIAN_FRONTEND noninteractive
-ENV NODE_OPTIONS --max_old_space_size=4096
+ENV NODE_OPTIONS --max_old_space_size=4096 --use-openssl-ca
+
+# Configuring NodeJS version
+RUN apt-get clean 
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y curl
+
+RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION:=10}.x | sh
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y \
         git \
         curl \
         python3 \
         nodejs \
-        npm \
         firefox \
+        nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g npm@7 \
-    && /bin/bash -c "hash -d npm"
+RUN /bin/bash -c "hash -d npm"
 
 # Enable tls v1.0
 RUN echo "openssl_conf = openssl_configuration\n"|cat - /etc/ssl/openssl.cnf > /tmp/openssl_conf.cnf \
@@ -31,14 +42,20 @@ CipherString = DEFAULT:@SECLEVEL=1" >> /etc/ssl/openssl.cnf
 COPY CAs/* /usr/local/share/ca-certificates/
 # Store custom CAs somewhere where the backend can find them later.
 COPY CustomCAs/* /usr/local/share/custom-ca-certificates/
-RUN update-ca-certificates
+
+RUN update-ca-certificates --verbose
 
 # Creating an user for building the driver and running the tests
 RUN useradd -m driver && echo "driver:driver" | chpasswd && adduser driver sudo
 VOLUME /driver
-RUN chown -Rh driver:driver /driver
+RUN chown -Rh driver:driver /home/driver
+WORKDIR /home/driver
+
 USER driver
 WORKDIR /home/driver
 CMD /bin/bash
 RUN mkdir /home/driver/.npm_global
 RUN npm config set prefix /home/driver/.npm_global
+
+RUN node --version
+RUN npm --version


### PR DESCRIPTION
This change enables testing the driver using different NodeJS versions.