### PR TITLE
Allow tx timeout to be 0 and send it

### DIFF
--- a/packages/bolt-connection/src/bolt/request-message.js
+++ b/packages/bolt-connection/src/bolt/request-message.js
@@ -286,7 +286,7 @@ function buildTxMetadata (bookmark, txConfig, database, mode, impersonatedUser) 
   if (!bookmark.isEmpty()) {
     metadata.bookmarks = bookmark.values()
   }
-  if (txConfig.timeout != null) {
+  if (txConfig.timeout !== null) {
     metadata.tx_timeout = txConfig.timeout
   }
   if (txConfig.metadata) {

--- a/packages/bolt-connection/src/bolt/request-message.js
+++ b/packages/bolt-connection/src/bolt/request-message.js
@@ -256,7 +256,7 @@ export default class RequestMessage {
     if ( databaseContext.databaseName ) {
       dbContext.db = databaseContext.databaseName
     }
-    
+
     if ( databaseContext.impersonatedUser ) {
       dbContext.imp_user = databaseContext.impersonatedUser
     }
@@ -286,7 +286,7 @@ function buildTxMetadata (bookmark, txConfig, database, mode, impersonatedUser) 
   if (!bookmark.isEmpty()) {
     metadata.bookmarks = bookmark.values()
   }
-  if (txConfig.timeout) {
+  if (txConfig.timeout != null) {
     metadata.tx_timeout = txConfig.timeout
   }
   if (txConfig.metadata) {

--- a/packages/core/src/internal/tx-config.ts
+++ b/packages/core/src/internal/tx-config.ts
@@ -67,9 +67,6 @@ function extractTimeout(config: any): Integer | null {
   if (util.isObject(config) && (config.timeout || config.timeout === 0)) {
     util.assertNumberOrInteger(config.timeout, 'Transaction timeout')
     const timeout = int(config.timeout)
-    if (timeout.isZero()) {
-      throw newError('Transaction timeout should not be zero')
-    }
     if (timeout.isNegative()) {
       throw newError('Transaction timeout should not be negative')
     }

--- a/packages/neo4j-driver/test/bolt-v3.test.js
+++ b/packages/neo4j-driver/test/bolt-v3.test.js
@@ -23,7 +23,7 @@ import sharedNeo4j from './internal/shared-neo4j'
 const TX_CONFIG_WITH_METADATA = { metadata: { a: 1, b: 2 } }
 const TX_CONFIG_WITH_TIMEOUT = { timeout: 42 }
 
-const INVALID_TIMEOUT_VALUES = [0, -1, -42, '15 seconds', [1, 2, 3]]
+const INVALID_TIMEOUT_VALUES = [-1, -42, '15 seconds', [1, 2, 3]]
 const INVALID_METADATA_VALUES = [
   'metadata',
   ['1', '2', '3'],

--- a/packages/neo4j-driver/test/internal/tx-config.test.js
+++ b/packages/neo4j-driver/test/internal/tx-config.test.js
@@ -52,7 +52,7 @@ describe('#unit TxConfig', () => {
   })
 
   it('should fail to construct with invalid timeout', () => {
-    const invalidTimeoutValues = ['15s', [15], {}, 0, int(0), -42, int(-42)]
+    const invalidTimeoutValues = ['15s', [15], {}, -42, int(-42)]
 
     invalidTimeoutValues.forEach(invalidValue =>
       expect(() => new TxConfig({ timeout: invalidValue })).toThrow()
@@ -60,9 +60,11 @@ describe('#unit TxConfig', () => {
   })
 
   it('should construct with valid timeout', () => {
+    testConfigCreationWithTimeout(0)
     testConfigCreationWithTimeout(1)
     testConfigCreationWithTimeout(42000)
 
+    testConfigCreationWithTimeout(int(0))
     testConfigCreationWithTimeout(int(1))
     testConfigCreationWithTimeout(int(424242))
   })

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -153,7 +153,14 @@ export function SessionRun (context, data, wire) {
   Promise.all(observers.map(obs => obs.completitionPromise()))
     .catch(_ => null)
     .then(_ => {
-      const result = session.run(cypher, params, { metadata, timeout })
+      let result
+      try {
+        result = session.run(cypher, params, { metadata, timeout })
+      } catch (e) {
+        console.log('got some err: ' + JSON.stringify(e))
+        wire.writeError(e)
+        return
+      }
       const resultObserver = new ResultObserver({ sessionId, result })
       const id = context.addResultObserver(resultObserver)
       wire.writeResponse('Result', { id })
@@ -261,7 +268,14 @@ export function RetryableNegative (context, data, wire) {
 export function SessionBeginTransaction (context, data, wire) {
   const { sessionId, txMeta: metadata, timeout } = data
   const session = context.getSession(sessionId)
-  const tx = session.beginTransaction({ metadata, timeout })
+  let tx
+  try {
+    tx = session.beginTransaction({ metadata, timeout })
+  } catch (e) {
+    console.log('got some err: ' + JSON.stringify(e))
+    wire.writeError(e)
+    return
+  }
   const id = context.addTx(tx, sessionId)
   wire.writeResponse('Transaction', { id })
 }


### PR DESCRIPTION
Altering TestKit back end to treat exceptions on session.run and tx.run
as `DriverError`s