### PR TITLE
testkit: Fix `Unknown request` error path

### DIFF
--- a/packages/testkit-backend/src/backend.js
+++ b/packages/testkit-backend/src/backend.js
@@ -25,7 +25,7 @@ export default class Backend {
       try {
         this._controller.handle(contextId, request)
       } catch (e) {
-        this._channel.writeBackendError(contextId, e)
+        this._channel.writeBackendError(contextId, e.message)
       }
     })
   }

--- a/packages/testkit-backend/src/channel/testkit-protocol.js
+++ b/packages/testkit-backend/src/channel/testkit-protocol.js
@@ -1,5 +1,6 @@
 import readline from 'readline'
 import EventEmitter from 'events'
+import stringify from '../stringify'
 
 export default class Protocol extends EventEmitter {
   constructor (stream) {
@@ -61,7 +62,7 @@ export default class Protocol extends EventEmitter {
 
   serializeResponse (response) {
     console.log('> writing response', response)
-    const responseStr = this._stringify(response)
+    const responseStr = stringify(response)
     return  ['#response begin', responseStr, '#response end'].join('\n') + '\n'
   }
 
@@ -72,9 +73,4 @@ export default class Protocol extends EventEmitter {
     this.emit('request', { name, data })
   }
   
-  _stringify (val) {
-    return JSON.stringify(val, (_, value) =>
-      typeof value === 'bigint' ? `${value}n` : value
-    )
-  }
 }

--- a/packages/testkit-backend/src/controller/local.js
+++ b/packages/testkit-backend/src/controller/local.js
@@ -1,5 +1,6 @@
 import Context from '../context'
 import Controller from './interface'
+import stringify from '../stringify'
 
 
 /**

--- a/packages/testkit-backend/src/stringify.js
+++ b/packages/testkit-backend/src/stringify.js
@@ -1,0 +1,5 @@
+export default function stringify(json) {
+  return JSON.stringify(json, (_, value) =>
+    typeof value === 'bigint' ? `${value}n` : value
+  )
+}


### PR DESCRIPTION
There was two different errors durint the unknown request error treatment.

First, the stringfy function was not define in the LocalController scope. It get solve by extract this function to it own file and import it in the local.js.

Second, the backend was capturing the error in the `request` event and calling `writeBackendError` with the error object instead of the message.