### PR TITLE
Introduce `.peek()` to the Async Iterator API

### DIFF
--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -260,10 +260,10 @@ class Result implements Promise<QueryResult> {
     return {
       next: async () => {
         if (state.finished) {
-          return { done: true, value: state.summary!! }
+          return { done: true, value: state.summary! }
         }
         await controlFlow()
-        const next = await state.queuedObserver!!.dequeue()
+        const next = await state.queuedObserver!.dequeue()
         if (next.done) {
           state.finished = next.done
           state.summary = next.value
@@ -278,10 +278,10 @@ class Result implements Promise<QueryResult> {
       },
       peek: async () => {
         if (state.finished) {
-          return { done: true, value: state.summary!! }
+          return { done: true, value: state.summary! }
         }
         await controlFlow()
-        return await state.queuedObserver!!.head()
+        return await state.queuedObserver!.head()
       }
     }
   }

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -19,7 +19,7 @@
 
 import ResultSummary from './result-summary'
 import Record from './record'
-import { Query } from './types'
+import { Query, PeekableAsyncIterator } from './types'
 import { observer, util, connectionHolder } from './internal'
 
 const { EMPTY_CONNECTION_HOLDER } = connectionHolder
@@ -106,6 +106,7 @@ interface ResultObserver {
  */
  interface QueuedResultObserver extends ResultObserver {
   dequeue (): Promise<QueuedResultElement>
+  head (): Promise<QueuedResultElement>
   get size (): number
 }
 
@@ -239,35 +240,68 @@ class Result implements Promise<QueryResult> {
    * *Should not be combined with {@link Result#subscribe} or ${@link Result#then} functions.*
    *
    * @public
-   * @returns {AsyncIterator<Record, ResultSummary>} The async iterator for the Results
+   * @returns {PeekableAsyncIterator<Record, ResultSummary>} The async iterator for the Results
    */
-  async* [Symbol.asyncIterator](): AsyncIterator<Record, ResultSummary> {
-    const queuedObserver = this._createQueuedResultObserver()
+  [Symbol.asyncIterator](): PeekableAsyncIterator<Record, ResultSummary> {
+    const state: {
+      paused: boolean,
+      firstRun: boolean,
+      finished: boolean,
+      queuedObserver?: QueuedResultObserver,
+      streaming?: observer.ResultStreamObserver,
+      summary?: ResultSummary,
+    } = { paused: true, firstRun: true, finished: false }
 
-    const status = { paused: true, firstRun: true }
 
-    const streaming: observer.ResultStreamObserver | null =
-      // the error will be send to the onError callback
-      await this._subscribe(queuedObserver, true).catch(() => null) 
-
-    const controlFlow = () => {
-      if (queuedObserver.size >= this._watermarks.high && !status.paused) {
-        status.paused = true
-        streaming?.pause()
-      } else if (queuedObserver.size <= this._watermarks.low && status.paused || status.firstRun) {
-        status.firstRun = false
-        status.paused = false
-        streaming?.resume()
+    const controlFlow = async  () => {
+      if (state.queuedObserver === undefined) {
+        state.queuedObserver = this._createQueuedResultObserver()
+        state.streaming = await this._subscribe(state.queuedObserver, true).catch(() => undefined)
+      }
+      if (state.queuedObserver.size >= this._watermarks.high && !state.paused) {
+        state.paused = true
+        state.streaming?.pause()
+      } else if (state.queuedObserver.size <= this._watermarks.low && state.paused || state.firstRun) {
+        state.firstRun = false
+        state.paused = false
+        state.streaming?.resume()
       }
     }
 
-    while(true) {
-      controlFlow()
-      const next = await queuedObserver.dequeue()
-      if (next.done) {
-        return next.summary
+    const toIterableResult = (element: QueuedResultElement): IteratorResult<Record, ResultSummary> => {
+      if (element.done) {
+        return { done: true, value: element.summary }
       }
-      yield next.record
+      return { done: false, value: element.record }
+    }
+
+    return {
+      next: async () => {
+        if (state.finished) {
+          return { done: true, value: state.summary!! }
+        }
+        await controlFlow()
+        const next = await state.queuedObserver!!.dequeue()
+        if (next.done) {
+          state.finished = next.done
+          state.summary = next.summary
+        }
+        return toIterableResult(next)
+      },
+      return: async (value: ResultSummary) => {
+        state.finished = true
+        state.summary = value
+        state.streaming?.cancel()
+        return { done: true, value: value }
+      },
+      peek: async () => {
+        if (state.finished) {
+          return { done: true, value: state.summary!! }
+        }
+        await controlFlow()
+        const head = await state.queuedObserver!!.head()
+        return toIterableResult(head)
+      }
     }
   }
 
@@ -505,6 +539,24 @@ class Result implements Promise<QueryResult> {
         }
         promiseHolder.resolvable = createResolvablePromise()
         return await promiseHolder.resolvable.promise
+      },
+      head: async () => {
+        if (buffer.length > 0) {
+          const element = buffer[0]
+          if (isError(element)) {
+              throw element
+          }
+          return element
+        }
+        promiseHolder.resolvable = createResolvablePromise()
+        try {
+          const element =  await promiseHolder.resolvable.promise
+          buffer.unshift(element)
+          return element
+        } catch (error) {
+          buffer.unshift(error)
+          throw error
+        }
       },
       get size (): number {
         return buffer.length

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,3 +65,17 @@ export interface Config {
   resolver?: (address: string) => string[] | Promise<string[]>
   userAgent?: string
 }
+
+/**
+ * Extension interface for {@link AsyncIterator} with peek capabilities.
+ *
+ * @public
+ */
+export interface PeekableAsyncIterator<T, TReturn = any, TNext = undefined> extends AsyncIterator<T, TReturn, TNext> {
+  /**
+   * Returns the next element in the iteration without advancing the iterator.
+   *
+   * @return {IteratorResult<T, TReturn} The next element in the iteration.
+   */
+  peek(): Promise<IteratorResult<T, TReturn>>
+}

--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -810,7 +810,7 @@ describe('Result', () => {
 
           const it = result[Symbol.asyncIterator]()
           await it.next()
-          const { value, done } = await it.return!!(summary)
+          const { value, done } = await it.return!(summary)
 
           expect(value).toEqual(summary)
           expect(done).toEqual(true)
@@ -828,7 +828,7 @@ describe('Result', () => {
           const it = result[Symbol.asyncIterator]()
 
           await it.next()
-          await it.return!!(new ResultSummary('query', {}, {}))
+          await it.return!(new ResultSummary('query', {}, {}))
 
           const { value, done } = await it.next()
 
@@ -841,7 +841,7 @@ describe('Result', () => {
 
           const it = result[Symbol.asyncIterator]()
 
-          await it.return!!(new ResultSummary('query', {}, {}))
+          await it.return!(new ResultSummary('query', {}, {}))
 
           await it.next()
 
@@ -853,7 +853,7 @@ describe('Result', () => {
 
           const it = result[Symbol.asyncIterator]()
 
-          await it.return!!(new ResultSummary('query', {}, {}))
+          await it.return!(new ResultSummary('query', {}, {}))
 
           await it.next()
 
@@ -874,7 +874,7 @@ describe('Result', () => {
           const it = result[Symbol.asyncIterator]()
 
           await it.next()
-          await it.return!!(new ResultSummary('query', {}, {}))
+          await it.return!(new ResultSummary('query', {}, {}))
 
 
           expect(cancel).toBeCalled()
@@ -885,7 +885,7 @@ describe('Result', () => {
 
           const it = result[Symbol.asyncIterator]()
 
-          await it.return!!(new ResultSummary('query', {}, {}))
+          await it.return!(new ResultSummary('query', {}, {}))
           await it.next()
 
           expect(subscribe).not.toBeCalled()
@@ -896,7 +896,7 @@ describe('Result', () => {
 
           const it = result[Symbol.asyncIterator]()
 
-          await it.return!!(new ResultSummary('query', {}, {}))
+          await it.return!(new ResultSummary('query', {}, {}))
           await it.peek()
 
           expect(subscribe).not.toBeCalled()


### PR DESCRIPTION
This feature allows the user peek the element on the head of the cursor without moving the cursor forward.

The implementation of this feature has as side effect a new implementation `.return` method in the iterator.
This new version of the method does most the same thing as the previous one, but it also cancels the stream
since this method moves the cursor to the end.

The `next` method also got tweaked.