### PR TITLE
Remove 4.0 Testkit feature flag

### DIFF
--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -360,7 +360,6 @@ export function GetFeatures (_context, _params, wire) {
       'ConfHint:connection.recv_timeout_seconds',
       'Feature:Impersonation',
       'Feature:Bolt:3.0',
-      'Feature:Bolt:4.0',
       'Feature:Bolt:4.1',
       'Feature:Bolt:4.2',
       'Feature:Bolt:4.3',


### PR DESCRIPTION
4.0 is not supported in the 5.0 handshake (full or minimal)