### PR TITLE
Fix `driver.rxSession` initial bookmarks configuration and `RxSession.lastBookmark` return mapping

### DIFF
--- a/packages/neo4j-driver/src/driver.js
+++ b/packages/neo4j-driver/src/driver.js
@@ -67,7 +67,7 @@ class Driver extends CoreDriver {
     return new RxSession({
       session: this._newSession({
         defaultAccessMode,
-        bookmarks,
+        bookmarkOrBookmarks: bookmarks,
         database,
         impersonatedUser,
         reactive: true,

--- a/packages/neo4j-driver/test/types/driver.test.ts
+++ b/packages/neo4j-driver/test/types/driver.test.ts
@@ -135,6 +135,15 @@ const rxSession9: RxSession = driver.rxSession({
   bookmarks: ['bookmark1', 'bookmark2']
 })
 
+const rxSession10: RxSession = driver.rxSession({
+  defaultAccessMode: WRITE,
+  bookmarks: 'bookmark1'
+})
+const rxSession11: RxSession = driver.rxSession({
+  defaultAccessMode: WRITE,
+  bookmarks: ['bookmark1', 'bookmark2']
+})
+
 rxSession1
   .run('RETURN 1')
   .records()

--- a/packages/neo4j-driver/test/types/session-rx.test.ts
+++ b/packages/neo4j-driver/test/types/session-rx.test.ts
@@ -74,7 +74,7 @@ const txConfig7: TransactionConfig = {
 }
 
 const tx1: Observable<RxTransaction> = rxSession.beginTransaction()
-const bookmark: null | string = <null>rxSession.lastBookmark()
+const bookmark: string[] = rxSession.lastBookmark()
 
 const observable1: Observable<number> = rxSession.readTransaction(
   (tx: RxTransaction) => {

--- a/packages/neo4j-driver/types/session-rx.d.ts
+++ b/packages/neo4j-driver/types/session-rx.d.ts
@@ -33,7 +33,7 @@ declare interface RxSession {
 
   beginTransaction(config?: TransactionConfig): Observable<RxTransaction>
 
-  lastBookmark(): string | null
+  lastBookmark(): string[]
 
   readTransaction<T>(
     work: RxTransactionWork<T>,


### PR DESCRIPTION
The initial bookmark configuration for the RxSession were not working since the wrong parameter were
being passed to the Session. The typescript mapping for `RxSession.lastBookmark` was also wrong, `lastBookmark`
always returns an string array.