### PR TITLE
Add temporary feature flags which doesn't need change driver or testkit code (#856)

### DIFF
--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -81,6 +81,9 @@ export function NewDriver (context, data, wire) {
   if ('connectionAcquisitionTimeoutMs' in data) {
     config.connectionAcquisitionTimeout = data.connectionAcquisitionTimeoutMs
   }
+  if ('fetchSize' in data) {
+    config.fetchSize = data.fetchSize
+  }
   let driver
   try {
     driver = neo4j.driver(uri, parsedAuthToken, config)
@@ -339,9 +342,13 @@ export function GetFeatures (_context, _params, wire) {
       'Feature:Bolt:4.4',
       'Feature:API:Result.List',
       'Temporary:ConnectionAcquisitionTimeout',
+      'Temporary:CypherPathAndRelationship',
+      'Temporary:DriverFetchSize',
       'Temporary:DriverMaxConnectionPoolSize',
+      'Temporary:DriverMaxTxRetryTime',
       'Temporary:FastFailingDiscovery',
       'Temporary:FullSummary',
+      'Temporary:GetConnectionPoolMetrics',
       'Temporary:ResultKeys',
       'Temporary:TransactionClose',
       ...SUPPORTED_TLS

--- a/packages/testkit-backend/src/skipped-tests/browser.js
+++ b/packages/testkit-backend/src/skipped-tests/browser.js
@@ -10,7 +10,6 @@ const skippedTests = [
     ifEquals('stub.disconnects.test_disconnects.TestDisconnects.test_fail_on_reset'),
     ifEquals('stub.tx_begin_parameters.test_tx_begin_parameters.TestTxBeginParameters.test_impersonation_fails_on_v4x3'),
     ifEquals('stub.session_run_parameters.test_session_run_parameters.TestSessionRunParameters.test_impersonation_fails_on_v4x3'),
-    
   ),
   skip(
     'TLS Tests not implemented for browwer',

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -24,6 +24,10 @@ const skippedTests = [
     ifEndsWith('test_should_enforce_pool_size_per_cluster_member')
   ),
   skip(
+    'Flaky in TeamCity',
+    ifEndsWith('test_should_fail_when_writing_to_unexpectedly_interrupting_writers_on_run_using_tx_function'),
+  ),
+  skip(
     'Not support by the JS driver',
     ifEquals('neo4j.sessionrun.TestSessionRun.test_partial_iteration')
   ),


### PR DESCRIPTION
The feature flags are:

* 'Temporary:CypherPathAndRelationship'
* 'Temporary:DriverFetchSize'
* 'Temporary:DriverMaxTxRetryTime'
* 'Temporary:GetConnectionPoolMetrics'