### PR TITLE
Add `Temporary:FastFailingDiscovery` and `Temporary:ResultKeys` feature flags (#858)

### DIFF
--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -334,6 +334,8 @@ export function GetFeatures (_context, _params, wire) {
       'Feature:Bolt:4.4',
       'Feature:API:Result.List',
       'Temporary:ConnectionAcquisitionTimeout',
+      'Temporary:FastFailingDiscovery',
+      'Temporary:ResultKeys',
       ...SUPPORTED_TLS
     ]
   })

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -2,6 +2,25 @@ import skip, { ifEquals, ifEndsWith } from './skip'
 
 const skippedTests = [
   skip(
+    'Fail while enable Temporary::ResultKeys',
+    ifEquals('neo4j.test_bookmarks.TestBookmarks.test_can_pass_bookmark_into_next_session'),
+    ifEquals('neo4j.test_tx_run.TestTxRun.test_consume_after_commit'),
+    ifEquals('neo4j.test_tx_run.TestTxRun.test_tx_configuration'),
+    ifEquals('neo4j.test_tx_run.TestTxRun.test_interwoven_queries'),
+    ifEquals('neo4j.test_tx_run.TestTxRun.test_parallel_queries'),
+    ifEquals('neo4j.test_session_run.TestSessionRun.test_iteration_smaller_than_fetch_size'),
+    ifEquals('neo4j.test_tx_func_run.TestTxFuncRun.test_tx_func_configuration')
+  ),
+  skip(
+    'Fail while enable Temporary:FastFailingDiscovery',
+    ifEndsWith('test_should_request_rt_from_all_initial_routers_until_successful_on_authorization_expired'),
+    ifEndsWith('test_should_request_rt_from_all_initial_routers_until_successful_on_unknown_failure'),
+    ifEndsWith('test_should_fail_with_routing_failure_on_any_security_discovery_failure'),
+    ifEndsWith('test_should_fail_with_routing_failure_on_invalid_bookmark_mixture_discovery_failure'),
+    ifEndsWith('test_should_fail_with_routing_failure_on_invalid_bookmark_discovery_failure'),
+    ifEndsWith('test_should_fail_with_routing_failure_on_forbidden_discovery_failure')
+  ),
+  skip(
     'Not support by the JS driver',
     ifEquals('neo4j.sessionrun.TestSessionRun.test_partial_iteration')
   ),


### PR DESCRIPTION
Most of the tests in `Temporary:FastFailingDiscovery` are skipped and they will be evaluated afterwards. Skip tests related to  `Temporary:ResultKeys`