### PR TITLE
Improve back-pressure control in `Result[Symbol.asyncIterator]`

### DIFF
--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -252,11 +252,9 @@ class Result implements Promise<QueryResult> {
         state.paused = true
         state.streaming.pause()
       } else if (queueSizeIsBellowOrEqualLowWatermark && state.paused || state.firstRun && !queueSizeIsOverHighOrEqualWatermark ) {
-        if (state.streaming) {
-          state.firstRun = false
-          state.paused = false
-          state.streaming.resume()
-        }
+        state.firstRun = false
+        state.paused = false
+        state.streaming.resume()
       }
     }
 


### PR DESCRIPTION
The previous implemenation only controls the flow while is iterating over the records, but if the interation
is done in a really low pace, the control flow method won't be called in time for pausing the flow.

Changing the flow control for observing the queue size instead of check on each time it iterates solve this issue.