### PR TITLE
Verify transaction begin before hand-over it to the tx function work

### DIFF
--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -101,7 +101,7 @@ describe('session', () => {
   })
 
   it('run should send watermarks to Transaction when fetchsize if defined (writeTransaction)', async () => {
-    const connection = newFakeConnection()
+    const connection = mockBeginWithSuccess(newFakeConnection())
     const session = newSessionWithConnection(connection, false, 1000)
     const status = { functionCalled: false }
 
@@ -118,7 +118,7 @@ describe('session', () => {
   })
 
   it('run should send watermarks to Transaction when fetchsize is fetch all (writeTransaction)', async () => {
-    const connection = newFakeConnection()
+    const connection = mockBeginWithSuccess(newFakeConnection())
     const session = newSessionWithConnection(connection, false, FETCH_ALL)
     const status = { functionCalled: false }
 
@@ -135,7 +135,7 @@ describe('session', () => {
   })
 
   it('run should send watermarks to Transaction when fetchsize if defined (readTransaction)', async () => {
-    const connection = newFakeConnection()
+    const connection = mockBeginWithSuccess(newFakeConnection())
     const session = newSessionWithConnection(connection, false, 1000)
     const status = { functionCalled: false }
 
@@ -152,7 +152,7 @@ describe('session', () => {
   })
 
   it('run should send watermarks to Transaction when fetchsize is fetch all (readTransaction)', async () => {
-    const connection = newFakeConnection()
+    const connection = mockBeginWithSuccess(newFakeConnection())
     const session = newSessionWithConnection(connection, false, FETCH_ALL)
     const status = { functionCalled: false }
 
@@ -238,17 +238,8 @@ describe('session', () => {
     })
 
     it('should resolves a Transaction', async () => {
-      const connection = newFakeConnection()
-      const protocol = connection.protocol()
-      // @ts-ignore
-      connection.protocol = () => {
-        return {
-          ...protocol,
-          beginTransaction: (params: { afterComplete: () => {} }) => {
-            params.afterComplete()
-          }
-        }
-      }
+      const connection = mockBeginWithSuccess(newFakeConnection())
+
       const session = newSessionWithConnection(connection, false, 1000)
 
       const tx: Transaction = await session.beginTransaction()
@@ -257,6 +248,20 @@ describe('session', () => {
     })
   })
 })
+
+function mockBeginWithSuccess(connection: FakeConnection) {
+  const protocol = connection.protocol()
+  // @ts-ignore
+  connection.protocol = () => {
+    return {
+      ...protocol,
+      beginTransaction: (params: { afterComplete: () => {}} ) => {
+        params.afterComplete()
+      }
+    }
+  }
+  return connection
+}
 
 function newSessionWithConnection(
   connection: Connection,

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -8,11 +8,6 @@ const skippedTests = [
     ifEquals('stub.optimizations.test_optimizations.TestOptimizations.test_uses_implicit_default_arguments_multi_query_nested')
   ),
   skip(
-    'Eager verification not implemented for tx functions',
-    ifEquals('stub.tx_run.test_tx_run.TestTxRun.test_eager_begin_on_tx_func_run_with_error_on_begin'),
-    ifEquals('stub.tx_run.test_tx_run.TestTxRun.test_eager_begin_on_tx_func_run_with_disconnect_on_begin')
-  ),
-  skip(
     'Fail while enable Temporary::ResultKeys',
     ifEquals('neo4j.test_bookmarks.TestBookmarks.test_can_pass_bookmark_into_next_session'),
     ifEquals('neo4j.test_tx_run.TestTxRun.test_consume_after_commit'),


### PR DESCRIPTION
Calling the transaction work with a broken transaction can waste machine resources with transactions which will fail.