### PR TITLE
Fix `TypeError: Cannot read properties of undefined (reading 'isActive')`

### DIFF
--- a/packages/bolt-connection/src/pool/pool.js
+++ b/packages/bolt-connection/src/pool/pool.js
@@ -251,7 +251,7 @@ class Pool {
     const key = address.asKey()
     const pool = this._pools[key]
 
-    if (pool && poolState.isActive()) {
+    if (pool && poolState && poolState.isActive()) {
       // there exist idle connections for the given key
       if (!this._validate(resource)) {
         if (this._log.isDebugEnabled()) {


### PR DESCRIPTION
This error occurs in situations where the pool was already close, the acquire resource was already completed and a pool was recreated in the meantime. In this situation,
the _release method is called again but with an empty pool state causing the error.

For solving this issue, we should check if the state is defined before check the `isActive`. Undefined poolState should be considered closed in this case and the connection
should be destroyed.