### PR TITLE
Fix integration tests related to index and constraint create/drop

### DIFF
--- a/packages/neo4j-driver/test/rx/summary.test.js
+++ b/packages/neo4j-driver/test/rx/summary.test.js
@@ -437,7 +437,7 @@ describe('#integration-rx summary', () => {
     }
 
     const query = isNewConstraintIndexSyntax(protocolVersion)
-      ? 'CREATE INDEX FOR :Label(prop)'
+      ? 'CREATE INDEX FOR (l:Label) ON (l.prop)'
       : 'CREATE INDEX ON :Label(prop)'
 
     await verifyUpdates(runnable, query, null, {
@@ -472,7 +472,7 @@ describe('#integration-rx summary', () => {
     const session = driver.session()
     try {
       const query = isNewConstraintIndexSyntax(protocolVersion)
-        ? 'CREATE INDEX FOR :Label(prop)'
+        ? 'CREATE INDEX l_prop FOR (l:Label) ON (l.prop)'
         : 'CREATE INDEX ON :Label(prop)'
       await session.run(query)
     } finally {
@@ -480,7 +480,7 @@ describe('#integration-rx summary', () => {
     }
 
     const query = isNewConstraintIndexSyntax(protocolVersion)
-      ? 'DROP INDEX FOR :Label(prop)'
+      ? 'DROP INDEX l_prop'
       : 'DROP INDEX ON :Label(prop)'
     await verifyUpdates(runnable, query, null, {
       nodesCreated: 0,
@@ -544,7 +544,7 @@ describe('#integration-rx summary', () => {
     const session = driver.session()
     try {
       const query = isNewConstraintIndexSyntax(protocolVersion)
-        ? 'CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
+        ? 'CREATE CONSTRAINT book_isbn FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
         : 'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
       await session.run(query)
     } finally {
@@ -552,7 +552,7 @@ describe('#integration-rx summary', () => {
     }
 
     const query = isNewConstraintIndexSyntax(protocolVersion)
-      ? 'DROP CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
+      ? 'DROP CONSTRAINT book_isbn'
       : 'DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
     await verifyUpdates(runnable, query, null, {
       nodesCreated: 0,

--- a/packages/neo4j-driver/test/rx/summary.test.js
+++ b/packages/neo4j-driver/test/rx/summary.test.js
@@ -436,10 +436,9 @@ describe('#integration-rx summary', () => {
       return
     }
 
-    const query =
-      protocolVersion > 4.2
-        ? 'CREATE INDEX FOR :Label(prop)'
-        : 'CREATE INDEX ON :Label(prop)'
+    const query = isNewConstraintIndexSyntax(protocolVersion)
+      ? 'CREATE INDEX FOR :Label(prop)'
+      : 'CREATE INDEX ON :Label(prop)'
 
     await verifyUpdates(runnable, query, null, {
       nodesCreated: 0,
@@ -472,19 +471,17 @@ describe('#integration-rx summary', () => {
     // first create the to-be-dropped index
     const session = driver.session()
     try {
-      const query =
-        protocolVersion > 4.2
-          ? 'CREATE INDEX FOR :Label(prop)'
-          : 'CREATE INDEX ON :Label(prop)'
+      const query = isNewConstraintIndexSyntax(protocolVersion)
+        ? 'CREATE INDEX FOR :Label(prop)'
+        : 'CREATE INDEX ON :Label(prop)'
       await session.run(query)
     } finally {
       await session.close()
     }
 
-    const query =
-      protocolVersion > 4.2
-        ? 'DROP INDEX FOR :Label(prop)'
-        : 'DROP INDEX ON :Label(prop)'
+    const query = isNewConstraintIndexSyntax(protocolVersion)
+      ? 'DROP INDEX FOR :Label(prop)'
+      : 'DROP INDEX ON :Label(prop)'
     await verifyUpdates(runnable, query, null, {
       nodesCreated: 0,
       nodesDeleted: 0,
@@ -512,10 +509,9 @@ describe('#integration-rx summary', () => {
       return
     }
 
-    const query =
-      protocolVersion > 4.2
-        ? 'CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
-        : 'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
+    const query = isNewConstraintIndexSyntax(protocolVersion)
+      ? 'CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
+      : 'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
     await verifyUpdates(runnable, query, null, {
       nodesCreated: 0,
       nodesDeleted: 0,
@@ -547,19 +543,17 @@ describe('#integration-rx summary', () => {
     // first create the to-be-dropped index
     const session = driver.session()
     try {
-      const query =
-        protocolVersion > 4.2
-          ? 'CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
-          : 'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
+      const query = isNewConstraintIndexSyntax(protocolVersion)
+        ? 'CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
+        : 'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
       await session.run(query)
     } finally {
       await session.close()
     }
 
-    const query =
-      protocolVersion > 4.2
-        ? 'DROP CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
-        : 'DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
+    const query = isNewConstraintIndexSyntax(protocolVersion)
+      ? 'DROP CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
+      : 'DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
     await verifyUpdates(runnable, query, null, {
       nodesCreated: 0,
       nodesDeleted: 0,
@@ -776,5 +770,9 @@ describe('#integration-rx summary', () => {
     } finally {
       await session.close()
     }
+  }
+
+  function isNewConstraintIndexSyntax (protocolVersion) {
+    return protocolVersion > 4.3
   }
 })

--- a/packages/neo4j-driver/test/rx/summary.test.js
+++ b/packages/neo4j-driver/test/rx/summary.test.js
@@ -436,7 +436,12 @@ describe('#integration-rx summary', () => {
       return
     }
 
-    await verifyUpdates(runnable, 'CREATE INDEX on :Label(prop)', null, {
+    const query =
+      protocolVersion > 4.2
+        ? 'CREATE INDEX FOR :Label(prop)'
+        : 'CREATE INDEX ON :Label(prop)'
+
+    await verifyUpdates(runnable, query, null, {
       nodesCreated: 0,
       nodesDeleted: 0,
       relationshipsCreated: 0,
@@ -467,12 +472,20 @@ describe('#integration-rx summary', () => {
     // first create the to-be-dropped index
     const session = driver.session()
     try {
-      await session.run('CREATE INDEX on :Label(prop)')
+      const query =
+        protocolVersion > 4.2
+          ? 'CREATE INDEX FOR :Label(prop)'
+          : 'CREATE INDEX ON :Label(prop)'
+      await session.run(query)
     } finally {
       await session.close()
     }
 
-    await verifyUpdates(runnable, 'DROP INDEX on :Label(prop)', null, {
+    const query =
+      protocolVersion > 4.2
+        ? 'DROP INDEX FOR :Label(prop)'
+        : 'DROP INDEX ON :Label(prop)'
+    await verifyUpdates(runnable, query, null, {
       nodesCreated: 0,
       nodesDeleted: 0,
       relationshipsCreated: 0,
@@ -499,24 +512,23 @@ describe('#integration-rx summary', () => {
       return
     }
 
-    await verifyUpdates(
-      runnable,
-      'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE',
-      null,
-      {
-        nodesCreated: 0,
-        nodesDeleted: 0,
-        relationshipsCreated: 0,
-        relationshipsDeleted: 0,
-        propertiesSet: 0,
-        labelsAdded: 0,
-        labelsRemoved: 0,
-        indexesAdded: 0,
-        indexesRemoved: 0,
-        constraintsAdded: 1,
-        constraintsRemoved: 0
-      }
-    )
+    const query =
+      protocolVersion > 4.2
+        ? 'CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
+        : 'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
+    await verifyUpdates(runnable, query, null, {
+      nodesCreated: 0,
+      nodesDeleted: 0,
+      relationshipsCreated: 0,
+      relationshipsDeleted: 0,
+      propertiesSet: 0,
+      labelsAdded: 0,
+      labelsRemoved: 0,
+      indexesAdded: 0,
+      indexesRemoved: 0,
+      constraintsAdded: 1,
+      constraintsRemoved: 0
+    })
   }
 
   /**
@@ -535,31 +547,32 @@ describe('#integration-rx summary', () => {
     // first create the to-be-dropped index
     const session = driver.session()
     try {
-      await session.run(
-        'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
-      )
+      const query =
+        protocolVersion > 4.2
+          ? 'CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
+          : 'CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
+      await session.run(query)
     } finally {
       await session.close()
     }
 
-    await verifyUpdates(
-      runnable,
-      'DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE',
-      null,
-      {
-        nodesCreated: 0,
-        nodesDeleted: 0,
-        relationshipsCreated: 0,
-        relationshipsDeleted: 0,
-        propertiesSet: 0,
-        labelsAdded: 0,
-        labelsRemoved: 0,
-        indexesAdded: 0,
-        indexesRemoved: 0,
-        constraintsAdded: 0,
-        constraintsRemoved: 1
-      }
-    )
+    const query =
+      protocolVersion > 4.2
+        ? 'DROP CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE'
+        : 'DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE'
+    await verifyUpdates(runnable, query, null, {
+      nodesCreated: 0,
+      nodesDeleted: 0,
+      relationshipsCreated: 0,
+      relationshipsDeleted: 0,
+      propertiesSet: 0,
+      labelsAdded: 0,
+      labelsRemoved: 0,
+      indexesAdded: 0,
+      indexesRemoved: 0,
+      constraintsAdded: 0,
+      constraintsRemoved: 1
+    })
   }
 
   /**


### PR DESCRIPTION
The syntax for creating and dropping constraint in Neo4j 5.0 changed. `ON` keyword was replaced by `FOR` and `ASSERT` replaced by `REQUIRED`.