### PR TITLE
Fix verifyConnectivity/getServerInfo procedures

### DIFF
--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2576,7 +2576,6 @@ describe('#unit RoutingConnectionProvider', () => {
             }
           })
         })
-
       })
 
       describe('when the reset and flush fails for all addresses', () => {

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2825,7 +2825,6 @@ describe('#unit RoutingConnectionProvider', () => {
           expect(error).toEqual(expectedError)
         }
       })
-
     })
   })
 })


### PR DESCRIPTION
The previous implementation was checking if all the servers are available instead of check if at least one server is available.

This should be done by iterate over the servers until it find one server available.