### PR TITLE
Discard active auto-commit results on Session.close()

### DIFF
--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -59,6 +59,26 @@ describe('Result', () => {
         expect(keys).toBe(expectedKeys)
       })
 
+      it('should reject pre-existing errors', () => {
+        const expectedError = newError('some error')
+        streamObserverMock.onError(expectedError)
+
+        expect(result.keys()).rejects.toBe(expectedError)
+      })
+
+      it('should reject already consumed pre-existing error', async () => {
+        const expectedError = newError('some error')
+        streamObserverMock.onError(expectedError)
+
+        try {
+          await result
+        } catch (e) {
+          // ignore
+        }
+
+        expect(result.keys()).rejects.toBe(expectedError)
+      })
+
       it('should resolve key pushed afterwards', done => {
         const expectedKeys = ['a', 'c']
 
@@ -152,6 +172,26 @@ describe('Result', () => {
           const summary = await result.summary()
 
           expect(summary).toEqual(expectedSummary)
+        })
+
+        it('should reject a pre-existing error', () => {
+          const expectedError = newError('the expected error')
+          streamObserverMock.onError(expectedError)
+
+          expect(result.summary()).rejects.toThrow(expectedError)
+        })
+
+        it('should reject already consumed pre-existing error', async () => {
+          const expectedError = newError('the expected error')
+          streamObserverMock.onError(expectedError)
+
+          try {
+            await result
+          } catch (_) {
+            // ignore
+          }
+
+          expect(result.summary()).rejects.toThrow(expectedError)
         })
 
         it('should resolve summary pushe afterwards', done => {

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -204,6 +204,38 @@ describe('session', () => {
     })
   }, 70000)
 
+  it('should call cancel current result', done => {
+    const session = newSessionWithConnection(newFakeConnection())
+
+    const result = session.run('RETURN 1')
+    const spiedCancel =  jest.spyOn(result, '_cancel')
+
+    session.close()
+      .finally(() => {
+        expect(spiedCancel).toHaveBeenCalled()
+        done()
+      })
+  })
+
+  it('should call cancel current results', done => {
+    const session = newSessionWithConnection(newFakeConnection())
+
+    const spiedCancels: any[] = []
+
+    for (let i = 0; i < 10; i++) {
+      const result = session.run('RETURN 1')
+      spiedCancels.push(jest.spyOn(result, '_cancel'))
+    }
+
+    session.close()
+      .finally(() => {
+        spiedCancels.forEach(spy => {
+          expect(spy).toHaveBeenCalled()
+        })
+        done()
+      })
+  })
+
   describe('.lastBookmark()', () => {
     it.each([
       [bookmarks.Bookmarks.empty()],

--- a/packages/neo4j-driver/test/session.test.js
+++ b/packages/neo4j-driver/test/session.test.js
@@ -341,7 +341,7 @@ describe('#integration session', () => {
               'Query failed after a long running query was terminated',
               error
             )
-            done.fail.bind(done)
+            done.fail(error)
           })
       })
 


### PR DESCRIPTION
Discarding the elements before reseting the Session allows non-consumed results to be committed before reset the result.

This PR also improves the `keys()` and `summary()` methods by allowing get errors cached in the result.