### PR TITLE
Prevent iterate over already consumed Result

### DIFF
--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -373,6 +373,10 @@ class Result implements Promise<QueryResult> {
       .catch(() => {})
   }
 
+  /**
+   * Check if this result is active, which means summary or error are not received by the result.
+   * @return {boolean} `true` when summary or error are not received by the result.
+   */
   isOpen (): boolean {
     return this._summary === null && this._error === null
   }

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -374,8 +374,8 @@ class Result implements Promise<QueryResult> {
   }
 
   /**
-   * Check if this result is active, which means summary or error are not received by the result.
-   * @return {boolean} `true` when summary or error are not received by the result.
+   * Check if this result is active, i.e., neither a summary nor an error has been received by the result.
+   * @return {boolean} `true` when neither a summary or nor an error has been received by the result.
    */
   isOpen (): boolean {
     return this._summary === null && this._error === null

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -209,9 +209,6 @@ class Result implements Promise<QueryResult> {
    * @return {Promise} new Promise.
    */
   private _getOrCreatePromise(): Promise<QueryResult> {
-    if (!this.isOpen()) {
-      return Promise.reject(newError('Result is already consumed'))
-    }
     if (!this._p) {
       this._p = new Promise((resolve, reject) => {
         const records: Record[] = []

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -600,7 +600,7 @@ function finishTransaction(
     .then(connection => {
       onConnection()
       pendingResults.forEach(r => r._cancel())
-      return Promise.all(pendingResults).then(results => {
+      return Promise.all(pendingResults.map(result => result.summary())).then(results => {
         if (connection) {
           if (commit) {
             return connection.protocol().commitTransaction({

--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -451,22 +451,6 @@ describe('Result', () => {
         result.catch(() => { }).finally(done)
       })
 
-      it.each([
-        ['success', async (stream: any) => stream.onCompleted({})],
-        ['error', async (stream: any) => stream.onError(new Error('error'))],
-      ])('should throw when iterating over consumed result [%s]', async(_, completeStream) => {
-        completeStream(streamObserverMock)
-
-        await result.summary().catch(() => {})
-
-        try {
-          await result
-          expect('not to finish iteration over consumed result').toBe(true)
-        } catch (e) {
-          expect(e).toEqual(newError('Result is already consumed'))
-        }
-      })
-
       describe.each([
         ['query', {}, { query: 'query', parameters: {} }],
         ['query', { a: 1 }, { query: 'query', parameters: { a: 1 } }],

--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -454,14 +454,14 @@ describe('Result', () => {
       it.each([
         ['success', async (stream: any) => stream.onCompleted({})],
         //['error', async (stream: any) => stream.onError(new Error('error'))],
-      ])('should thrown over an consumed result [%s]', async(_, completeStream) => {
+      ])('should throw when iterating over consumed result [%s]', async(_, completeStream) => {
         completeStream(streamObserverMock)
 
         await result.summary().catch(() => {})
 
         try {
           await result
-          expect('not finish iteration over consumed result').toBe(true)
+          expect('not to finish iteration over consumed result').toBe(true)
         } catch (e) {
           expect(e).toEqual(newError('Result is already consumed'))
         }
@@ -879,21 +879,21 @@ describe('Result', () => {
       it.each([
         ['success', async (stream: any) => stream.onCompleted({})],
         ['error', async (stream: any) => stream.onError(new Error('error'))],
-      ])('should thrown on iterate over an consumed result [%s]', async(_, completeStream) => {
+      ])('should thrown on iterating over an consumed result [%s]', async(_, completeStream) => {
         completeStream(streamObserverMock)
 
         await result.summary().catch(() => {})
 
         try {
           for await (const _ of result) {
-            expect('not iterate over consumed result').toBe(true)
+            expect('not to iterate over consumed result').toBe(true)
           }
-          expect('not finish iteration over consumed result').toBe(true)
+          expect('not to finish iteration over consumed result').toBe(true)
         } catch (e) {
           expect(e).toEqual(newError('Result is already consumed'))
         }
 
-        expect('not finish iteration over consumed result')
+        expect('not to finish iteration over consumed result')
       })
 
       describe('.return()', () => {
@@ -1257,7 +1257,7 @@ describe('Result', () => {
         expect(result.isOpen()).toBe(false)
       })
 
-      it('should return false when the stream is failed', async () => {
+      it('should return false when the stream failed', async () => {
         streamObserverMock.onError(new Error('test'))
 
         await result._subscribe({}).catch(() => {})
@@ -1385,7 +1385,7 @@ describe('Result', () => {
         expect(result.isOpen()).toBe(true)
       })
 
-      it('should be false after any interactio with the stream', async () => {
+      it('should be false after any interaction with the stream', async () => {
         const it = result[Symbol.asyncIterator]()
         await it.next()
 

--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -453,7 +453,7 @@ describe('Result', () => {
 
       it.each([
         ['success', async (stream: any) => stream.onCompleted({})],
-        //['error', async (stream: any) => stream.onError(new Error('error'))],
+        ['error', async (stream: any) => stream.onError(new Error('error'))],
       ])('should throw when iterating over consumed result [%s]', async(_, completeStream) => {
         completeStream(streamObserverMock)
 

--- a/packages/testkit-backend/src/controller/local.js
+++ b/packages/testkit-backend/src/controller/local.js
@@ -63,7 +63,7 @@ export default class LocalController extends Controller {
         const id = this._contexts.get(contextId).addError(e)
         this._writeResponse(contextId, newResponse('DriverError', {
           id,
-          msg: e.message + ' (' + e.code + ')',
+          msg: e.message,
           code: e.code
         }))
       }

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -138,10 +138,6 @@ const skippedTests = [
       'stub.iteration.test_result_list.TestResultList.test_session_run_result_list_pulls_all_records_at_once_next_before_list'
     )
   ),
-  // skip(
-  //   'Results are always valid but don\'t return records when out of scope',
-  //   ifStartsWith('stub.iteration.test_result_scope.TestResultScope.')
-  // ),
   skip(
     'Driver (still) allows explicit managing of managed transaction',
     ifEquals('stub.tx_lifetime.test_tx_lifetime.TestTxLifetime.test_managed_tx_raises_tx_managed_exec')

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -138,10 +138,10 @@ const skippedTests = [
       'stub.iteration.test_result_list.TestResultList.test_session_run_result_list_pulls_all_records_at_once_next_before_list'
     )
   ),
-  skip(
-    'Results are always valid but don\'t return records when out of scope',
-    ifStartsWith('stub.iteration.test_result_scope.TestResultScope.')
-  ),
+  // skip(
+  //   'Results are always valid but don\'t return records when out of scope',
+  //   ifStartsWith('stub.iteration.test_result_scope.TestResultScope.')
+  // ),
   skip(
     'Driver (still) allows explicit managing of managed transaction',
     ifEquals('stub.tx_lifetime.test_tx_lifetime.TestTxLifetime.test_managed_tx_raises_tx_managed_exec')


### PR DESCRIPTION
`for await (const r of result)` in already consumed results could block for ever since no new event will came from wire.

Blocking this kind of access improves not correct access to the Result object.

This change also includes the addition of `Result.isOpen()`