### PR TITLE
Avoid sending resets when it is not needed

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -79,6 +79,7 @@ export default class BoltProtocol {
     this._log = log
     this._onProtocolError = onProtocolError
     this._fatalError = null
+    this._lastMessageSignature = null
   }
 
   /**
@@ -356,6 +357,8 @@ export default class BoltProtocol {
         this._log.debug(`C: ${message}`)
       }
 
+      this._lastMessageSignature = message.signature
+
       this.packer().packStruct(
         message.signature,
         message.fields.map(field => this.packer().packable(field))
@@ -367,6 +370,10 @@ export default class BoltProtocol {
         this._chunker.flush()
       }
     }
+  }
+
+  isLastMessageLogin () {
+    return this._lastMessageSignature === 0x01
   }
 
   /**

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -376,6 +376,10 @@ export default class BoltProtocol {
     return this._lastMessageSignature === 0x01
   }
 
+  isLastMessageReset () {
+    return this._lastMessageSignature === 0x0f
+  }
+
   /**
    * Notifies faltal erros to the observers and mark the protocol in the fatal error state.
    * @param {Error} error The error

--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -123,7 +123,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     const connection = await this._connectionPool.acquire(address)
     const serverInfo = new ServerInfo(connection.server, connection.protocol().version)
     try {
-      if (!connection._firstUsage) {
+      if (!connection._firstUsage && !connection.protocol().isLastMessageLogin()) {
         await connection.resetAndFlush()
       }
     } finally {

--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -71,9 +71,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
    */
   _createConnection (address, release) {
     return this._createChannelConnection(address).then(connection => {
-      connection._firstUsage = true
       connection._release = () => {
-        connection._firstUsage = false
         return release(address, connection)
       }
       this._openConnections[connection.id] = connection
@@ -123,7 +121,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     const connection = await this._connectionPool.acquire(address)
     const serverInfo = new ServerInfo(connection.server, connection.protocol().version)
     try {
-      if (!connection._firstUsage && !connection.protocol().isLastMessageLogin()) {
+      if (!connection.protocol().isLastMessageLogin()) {
         await connection.resetAndFlush()
       }
     } finally {

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -341,10 +341,22 @@ export default class ChannelConnection extends Connection {
   }
 
   _reset(observer) {
-    this._resetObservers.push(observer)
     if (this._reseting) {
+      if (!this._protocol.isLastMessageReset()) {
+        this._protocol.reset({
+          onError: error => {
+            observer.onError(error)
+          }, onComplete: () => {
+            observer.onComplete()
+          }
+        })
+      } else {
+        this._resetObservers.push(observer)
+      }
       return
     }
+
+    this._resetObservers.push(observer)
     this._reseting = true
 
     const notifyFinish = (notify) => {

--- a/packages/bolt-connection/src/connection/connection-delegate.js
+++ b/packages/bolt-connection/src/connection/connection-delegate.js
@@ -83,6 +83,10 @@ export default class DelegateConnection extends Connection {
     return this._delegate.resetAndFlush()
   }
 
+  hasOngoingObservableRequests () {
+    return this._delegate.hasOngoingObservableRequests()
+  }
+
   close () {
     return this._delegate.close()
   }

--- a/packages/bolt-connection/src/connection/connection.js
+++ b/packages/bolt-connection/src/connection/connection.js
@@ -103,6 +103,10 @@ export default class Connection {
     throw new Error('not implemented')
   }
 
+  hasOngoingObservableRequests () {
+    throw new Error('not implemented')
+  }
+
   /**
    * Call close on the channel.
    * @returns {Promise<void>} - A promise that will be resolved when the connection is closed.

--- a/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
@@ -251,7 +251,7 @@ describe('.verifyConnectivityAndGetServerInfo()', () => {
       const create = (address, release) => {
         const connection = new FakeConnection(address, release, server)
         connection.protocol = () => {
-          return { version: protocolVersion }
+          return { version: protocolVersion, isLastMessageLogin() { return false } }
         }
         connection.resetAndFlush = resetAndFlush
         if (releaseMock) {

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -3103,7 +3103,8 @@ class FakeConnection extends Connection {
 
   protocol () {
     return {
-      version: this._protocolVersion
+      version: this._protocolVersion,
+      isLastMessageLogin: () => this._firstUsage
     }
   }
 }

--- a/packages/bolt-connection/test/connection/connection-channel.test.js
+++ b/packages/bolt-connection/test/connection/connection-channel.test.js
@@ -19,7 +19,6 @@
 
 import ChannelConnection from '../../src/connection/connection-channel'
 import { int, internal, newError } from 'neo4j-driver-core'
-import { observer } from 'neo4j-driver-core/types/internal'
 
 const {
   serverAddress: { ServerAddress },

--- a/packages/bolt-connection/test/connection/connection-channel.test.js
+++ b/packages/bolt-connection/test/connection/connection-channel.test.js
@@ -269,7 +269,8 @@ describe('ChannelConnection', () => {
 
         const protocol = {
           reset: jest.fn(),
-          resetFailure: jest.fn()
+          resetFailure: jest.fn(),
+          isLastMessageReset: jest.fn(() => true)
         }
         const protocolSupplier = () => protocol
         const connection = spyOnConnectionChannel({ channel, protocolSupplier })
@@ -454,7 +455,8 @@ describe('ChannelConnection', () => {
         reset: jest.fn(observer => {
           setTimeout(() => observer.onComplete(), 100)
         }),
-        resetFailure: jest.fn()
+        resetFailure: jest.fn(),
+        isLastMessageReset: jest.fn(() => true)
       }
       const protocolSupplier = () => protocol
       const connection = spyOnConnectionChannel({ channel, protocolSupplier })

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -95,6 +95,14 @@ class Connection {
   }
 
   /**
+   * Checks if there is an ongoing request being handled
+   * @return {boolean} `true` if there is an ongoing request being handled
+   */
+  hasOngoingObservableRequests (): boolean {
+    throw Error('Not implemented')
+  }
+
+  /**
    * Call close on the channel.
    * @returns {Promise<void>} - A promise that will be resolved when the connection is closed.
    *

--- a/packages/core/src/internal/connection-holder.ts
+++ b/packages/core/src/internal/connection-holder.ts
@@ -178,11 +178,7 @@ class ConnectionHolder implements ConnectionHolderInterface {
     return this._connectionPromise
   }
 
-<<<<<<< HEAD
-  close (): Promise<null | Connection> {
-=======
-  close(hasTx?: boolean): Promise<void | Connection> {
->>>>>>> Sending reset if there is a tx going on
+  close (hasTx?: boolean): Promise<null | Connection> {
     if (this._referenceCount === 0) {
       return this._connectionPromise
     }
@@ -197,11 +193,11 @@ class ConnectionHolder implements ConnectionHolderInterface {
    * @return {Promise} - promise resolved then connection is returned to the pool.
    * @private
    */
-  private _releaseConnection (): Promise<Connection | null> {
+  private _releaseConnection (hasTx?: boolean): Promise<Connection | null> {
     this._connectionPromise = this._connectionPromise
       .then((connection?: Connection|null) => {
         if (connection != null) {
-          if (connection.isOpen() && (connection.hasOngoingObservableRequests() || hasTx)) {
+          if (connection.isOpen() && (connection.hasOngoingObservableRequests() || hasTx === true)) {
             return connection
               .resetAndFlush()
               .catch(ignoreError)

--- a/packages/core/src/internal/connection-holder.ts
+++ b/packages/core/src/internal/connection-holder.ts
@@ -178,12 +178,16 @@ class ConnectionHolder implements ConnectionHolderInterface {
     return this._connectionPromise
   }
 
+<<<<<<< HEAD
   close (): Promise<null | Connection> {
+=======
+  close(hasTx?: boolean): Promise<void | Connection> {
+>>>>>>> Sending reset if there is a tx going on
     if (this._referenceCount === 0) {
       return this._connectionPromise
     }
     this._referenceCount = 0
-    return this._releaseConnection()
+    return this._releaseConnection(hasTx)
   }
 
   /**
@@ -197,7 +201,7 @@ class ConnectionHolder implements ConnectionHolderInterface {
     this._connectionPromise = this._connectionPromise
       .then((connection?: Connection|null) => {
         if (connection != null) {
-          if (connection.isOpen() && connection.hasOngoingObservableRequests()) {
+          if (connection.isOpen() && (connection.hasOngoingObservableRequests() || hasTx)) {
             return connection
               .resetAndFlush()
               .catch(ignoreError)

--- a/packages/core/src/internal/connection-holder.ts
+++ b/packages/core/src/internal/connection-holder.ts
@@ -197,7 +197,7 @@ class ConnectionHolder implements ConnectionHolderInterface {
     this._connectionPromise = this._connectionPromise
       .then((connection?: Connection|null) => {
         if (connection != null) {
-          if (connection.isOpen()) {
+          if (connection.isOpen() && connection.hasOngoingObservableRequests()) {
             return connection
               .resetAndFlush()
               .catch(ignoreError)

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -494,8 +494,8 @@ class Session {
 
       this._transactionExecutor.close()
 
-      await this._readConnectionHolder.close()
-      await this._writeConnectionHolder.close()
+      await this._readConnectionHolder.close(this._hasTx)
+      await this._writeConnectionHolder.close(this._hasTx)
     }
   }
 

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -196,7 +196,18 @@ describe('session', () => {
     expect(resetAndFlushSpy).toHaveBeenCalledTimes(1)
   }, 70000)
 
-  it('close should not reset connection if there is not an ongoing request ', async () => {
+  it('close should not reset connection if there is not an ongoing request', async () => {
+    const connection = newFakeConnection()
+    connection.hasOngoingObservableRequests = () => false
+    const resetAndFlushSpy = jest.spyOn(connection, 'resetAndFlush')
+    const session = newSessionWithConnection(connection, false)
+
+    await session.close()
+
+    expect(resetAndFlushSpy).not.toHaveBeenCalled()
+  }, 70000)
+
+  it('close should reset connection if there is not an ongoing request but it has tx running', async () => {
     const connection = newFakeConnection()
     connection.hasOngoingObservableRequests = () => false
     const resetAndFlushSpy = jest.spyOn(connection, 'resetAndFlush')
@@ -204,7 +215,7 @@ describe('session', () => {
 
     await session.close()
 
-    expect(resetAndFlushSpy).not.toHaveBeenCalled()
+    expect(resetAndFlushSpy).toHaveBeenCalled()
   }, 70000)
 
   it('should close transaction executor', done => {

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -186,6 +186,27 @@ describe('session', () => {
     }).catch(done)
   }, 70000)
 
+  it('close should reset connection if there is an ongoing request ', async () => {
+    const connection = newFakeConnection()
+    const resetAndFlushSpy = jest.spyOn(connection, 'resetAndFlush')
+    const session = newSessionWithConnection(connection)
+
+    await session.close()
+
+    expect(resetAndFlushSpy).toHaveBeenCalledTimes(1)
+  }, 70000)
+
+  it('close should not reset connection if there is not an ongoing request ', async () => {
+    const connection = newFakeConnection()
+    connection.hasOngoingObservableRequests = () => false
+    const resetAndFlushSpy = jest.spyOn(connection, 'resetAndFlush')
+    const session = newSessionWithConnection(connection)
+
+    await session.close()
+
+    expect(resetAndFlushSpy).not.toHaveBeenCalled()
+  }, 70000)
+
   it('should close transaction executor', done => {
     const session = newSessionWithConnection(newFakeConnection())
 

--- a/packages/core/test/utils/connection.fake.ts
+++ b/packages/core/test/utils/connection.fake.ts
@@ -179,6 +179,10 @@ export default class FakeConnection extends Connection {
     this._open = false
     return this
   }
+
+  hasOngoingObservableRequests(): boolean {
+    return true
+  }
 }
 
 function mockResultStreamObserverWithError (query: string, parameters: any | undefined, error: Error): ResultStreamObserver {

--- a/packages/neo4j-driver/test/internal/connection-holder.test.js
+++ b/packages/neo4j-driver/test/internal/connection-holder.test.js
@@ -319,6 +319,33 @@ describe('#unit ConnectionHolder', () => {
         })
       })
 
+      describe('and has not ongoing requests', () => {
+        let connection
+
+        beforeEach(async () => {
+          connection = new FakeConnection().withHasOngoingObservableRequests(
+            false
+          )
+          const connectionProvider = newSingleConnectionProvider(connection)
+          const connectionHolder = new ConnectionHolder({
+            mode: READ,
+            connectionProvider
+          })
+
+          connectionHolder.initializeConnection()
+
+          await connectionHolder.releaseConnection()
+        })
+
+        it('should call connection.resetAndFlush', () => {
+          expect(connection.resetInvoked).toBe(0)
+        })
+
+        it('should call connection._release()', () => {
+          expect(connection.releaseInvoked).toBe(1)
+        })
+      })
+
       describe('and connection is not open', () => {
         let connection
 

--- a/packages/neo4j-driver/test/internal/fake-connection.js
+++ b/packages/neo4j-driver/test/internal/fake-connection.js
@@ -52,6 +52,7 @@ export default class FakeConnection extends Connection {
     this.protocolErrorsHandled = 0
     this.seenProtocolErrors = []
     this.seenRequestRoutingInformation = []
+    this._hasOnGoingObservableRequests = true
   }
 
   get id () {
@@ -159,6 +160,15 @@ export default class FakeConnection extends Connection {
   withRequestRoutingInformationMock (requestRoutingInformationMock) {
     this._requestRoutingInformationMock = requestRoutingInformationMock
     return this
+  }
+
+  withHasOngoingObservableRequests (value) {
+    this._hasOnGoingObservableRequests = value
+    return this
+  }
+
+  hasOngoingObservableRequests () {
+    return this._hasOnGoingObservableRequests
   }
 
   closed () {

--- a/packages/testkit-backend/src/feature/common.js
+++ b/packages/testkit-backend/src/feature/common.js
@@ -33,6 +33,7 @@ const features = [
   'Feature:API:Driver.VerifyConnectivity',
   'Feature:API:Result.Peek',
   'Optimization:ImplicitDefaultArguments',
+  'Optimization:MinimalResets',
   ...SUPPORTED_TLS
 ]
 

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -335,7 +335,7 @@ export function SessionWriteTransaction (context, data, wire) {
 }
 
 export function StartTest (context, { testName }, wire) {
-  if (testName.endsWith('.test_disconnect_session_on_tx_pull_after_record') || testName.endsWith('test_should_reject_server_using_verify_connectivity_bolt_4x4')) {
+  if (testName.endsWith('.test_disconnect_session_on_tx_pull_after_record') || testName.endsWith('test_no_reset_on_clean_connection')) {
     context.logLevel = 'debug'
   } else {
     context.logLevel = null

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -335,7 +335,7 @@ export function SessionWriteTransaction (context, data, wire) {
 }
 
 export function StartTest (context, { testName }, wire) {
-  if (testName.endsWith('.test_disconnect_session_on_tx_pull_after_record')) {
+  if (testName.endsWith('.test_disconnect_session_on_tx_pull_after_record') || testName.endsWith('test_should_reject_server_using_verify_connectivity_bolt_4x4')) {
     context.logLevel = 'debug'
   } else {
     context.logLevel = null

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -2,10 +2,6 @@ import skip, { ifEquals, ifEndsWith } from './skip'
 
 const skippedTests = [
   skip(
-    'Just for now',
-    ifEndsWith('test_no_reset_on_clean_connection')
-  ),
-  skip(
     'Skipped because server doesn\'t support protocol 5.0 yet',
     ifEndsWith('neo4j.test_summary.TestSummary.test_protocol_version_information')
   ),

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -2,6 +2,10 @@ import skip, { ifEquals, ifEndsWith } from './skip'
 
 const skippedTests = [
   skip(
+    'Just for now',
+    ifEndsWith('test_no_reset_on_clean_connection')
+  ),
+  skip(
     'Skipped because server doesn\'t support protocol 5.0 yet',
     ifEndsWith('neo4j.test_summary.TestSummary.test_protocol_version_information')
   ),


### PR DESCRIPTION
The `RESET` should be send when a failure occurs or whenever the connection is being sent back
to the pool with a pending request running, i.e. the bolt server is not in the `READY` state.

These changes also affect the `verifyConnectivity` and `getServerInfo` implementation.
The `RESET` message is not sent in these methods if it is a newly created connection.