### PR TITLE
Skip flaky test: test_should_write_successfully_on_leader_switch_using_tx_function

### DIFF
--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -2,6 +2,10 @@ import skip, { ifEquals, ifEndsWith } from './skip'
 
 const skippedTests = [
   skip(
+    'Fails when because tx function could start with not broken transations',
+    ifEndsWith('test_should_write_successfully_on_leader_switch_using_tx_function'),
+  ),
+  skip(
     'Fail while enable Temporary::ResultKeys',
     ifEquals('neo4j.test_bookmarks.TestBookmarks.test_can_pass_bookmark_into_next_session'),
     ifEquals('neo4j.test_tx_run.TestTxRun.test_consume_after_commit'),


### PR DESCRIPTION
This test fails because of Javascript driver doesn't validate the tx before send it to the tx function.

In this case, the transaction could be in a failed state when `tx.run` get called and it produces the
`DriverError :  : Cannot run query in this transaction, because it has been rolled back either because of an error or explicit termination. (N/A)`.

This errant behaviour of the driver was fixed in the 5.0 with the TransactionPromise.