### PR TITLE
Deprecate `Session.(read|write)Transaction` in favor of `execute(Read|Write)` methods

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,7 @@ import Result, { QueryResult, ResultObserver } from './result'
 import ConnectionProvider from './connection-provider'
 import Connection from './connection'
 import Transaction from './transaction'
+import ManagedTransaction from './transaction-managed'
 import TransactionPromise from './transaction-promise'
 import Session, { TransactionConfig } from './session'
 import Driver, * as driver from './driver'
@@ -137,6 +138,7 @@ const forExport = {
   Stats,
   Result,
   Transaction,
+  ManagedTransaction,
   TransactionPromise,
   Session,
   Driver,
@@ -196,6 +198,7 @@ export {
   ConnectionProvider,
   Connection,
   Transaction,
+  ManagedTransaction,
   TransactionPromise,
   Session,
   Driver,

--- a/packages/core/src/internal/transaction-executor.ts
+++ b/packages/core/src/internal/transaction-executor.ts
@@ -161,7 +161,10 @@ export class TransactionExecutor {
       return
     }
 
-    const wrap = transactionWrapper || ((tx: Transaction) => tx)
+    // The conversion from `tx` as `unknown` then to `Tx` is necessary
+    // because it is not possible to be sure that `Tx` is a subtype of `Transaction`
+    // in using static type checking.
+    const wrap = transactionWrapper || ((tx: Transaction) => tx as unknown as Tx)
     const wrappedTx = wrap(tx)
     const resultPromise = this._safeExecuteTransactionWork(wrappedTx, transactionWork)
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -449,7 +449,6 @@ class Session {
       () => this._beginTransaction(accessMode, transactionConfig),
       transactionWork,
       tx => new ManagedTransaction({
-        isOpen: tx.isOpen.bind(tx),
         run: tx.run.bind(tx),
       })
     )

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -448,9 +448,7 @@ class Session {
     return this._transactionExecutor.execute(
       () => this._beginTransaction(accessMode, transactionConfig),
       transactionWork,
-      tx => new ManagedTransaction({
-        run: tx.run.bind(tx),
-      })
+      ManagedTransaction.fromTransaction
     )
   }
 

--- a/packages/core/src/transaction-managed.ts
+++ b/packages/core/src/transaction-managed.ts
@@ -24,10 +24,6 @@ interface Run {
   (query: Query, parameters?: any): Result
 }
 
-interface IsOpen {
-  (): boolean
-}
-
 /**
  * Represents a transaction that is managed by the transaction executor.
  * 
@@ -35,17 +31,12 @@ interface IsOpen {
  */
 class ManagedTransaction {
   private _run: Run
-  private _isOpen: IsOpen
 
-  constructor({ run, isOpen }: { run: Run, isOpen: IsOpen }) {
+  constructor({ run }: { run: Run }) {
     /**
      * @private
      */
     this._run = run
-    /**
-     * @private
-     */
-    this._isOpen = isOpen
   }
 
   /**
@@ -58,14 +49,6 @@ class ManagedTransaction {
    */
   run(query: Query, parameters?: any): Result {
     return this._run(query, parameters)
-  }
-
-  /**
-  * Check if this transaction is active, which means commit and rollback did not happen.
-  * @return {boolean} `true` when not committed and not rolled back, `false` otherwise.
-  */
-  isOpen(): boolean {
-    return this._isOpen()
   }
 }
 

--- a/packages/core/src/transaction-managed.ts
+++ b/packages/core/src/transaction-managed.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Result from './result'
+import { Query } from './types'
+
+interface Run {
+  (query: Query, parameters?: any): Result
+}
+
+interface IsOpen {
+  (): boolean
+}
+
+/**
+ * Represents a transaction that is managed by the transaction executor.
+ * 
+ * @public
+ */
+class ManagedTransaction {
+  private _run: Run
+  private _isOpen: IsOpen
+
+  constructor({ run, isOpen }: { run: Run, isOpen: IsOpen }) {
+    /**
+     * @private
+     */
+    this._run = run
+    /**
+     * @private
+     */
+    this._isOpen = isOpen
+  }
+
+  /**
+   * Run Cypher query
+   * Could be called with a query object i.e.: `{text: "MATCH ...", parameters: {param: 1}}`
+   * or with the query and parameters as separate arguments.
+   * @param {mixed} query - Cypher query to execute
+   * @param {Object} parameters - Map with parameters to use in query
+   * @return {Result} New Result
+   */
+  run(query: Query, parameters?: any): Result {
+    return this._run(query, parameters)
+  }
+
+  /**
+  * Check if this transaction is active, which means commit and rollback did not happen.
+  * @return {boolean} `true` when not committed and not rolled back, `false` otherwise.
+  */
+  isOpen(): boolean {
+    return this._isOpen()
+  }
+}
+
+export default ManagedTransaction

--- a/packages/core/src/transaction-managed.ts
+++ b/packages/core/src/transaction-managed.ts
@@ -18,6 +18,7 @@
  */
 
 import Result from './result'
+import Transaction from './transaction'
 import { Query } from './types'
 
 interface Run {
@@ -32,11 +33,25 @@ interface Run {
 class ManagedTransaction {
   private _run: Run
 
-  constructor({ run }: { run: Run }) {
+  /**
+   * @private
+   */
+  private constructor({ run }: { run: Run }) {
     /**
      * @private
      */
     this._run = run
+  }
+
+  /**
+   * @private
+   * @param {Transaction} tx - Transaction to wrap
+   * @returns {ManagedTransaction} the ManagedTransaction
+   */
+  static fromTransaction(tx: Transaction): ManagedTransaction {
+    return new ManagedTransaction({
+      run: tx.run.bind(tx)
+    })
   }
 
   /**

--- a/packages/core/src/transaction-promise.ts
+++ b/packages/core/src/transaction-promise.ts
@@ -170,6 +170,7 @@ class TransactionPromise extends Transaction implements Promise<Transaction>{
 
   /**
    * @access private
+   * @returns {void}
    */
   private _onBeginError(error: Error): void {
     this._beginError = error;
@@ -180,6 +181,7 @@ class TransactionPromise extends Transaction implements Promise<Transaction>{
 
   /**
    * @access private
+   * @returns {void}
    */
   private _onBeginMetadata(metadata: any): void {
     this._beginMetadata = metadata || {};

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -300,7 +300,7 @@ describe('session', () => {
       expect(status.functionCalled).toEqual(true)
     })
 
-    it('should proxy run to the begined transaction', async () => {
+    it('should proxy run to the begun transaction', async () => {
       const connection = mockBeginWithSuccess(newFakeConnection())
       const session = newSessionWithConnection(connection, false, FETCH_ALL)
       // @ts-ignore
@@ -318,7 +318,7 @@ describe('session', () => {
       expect(run).toHaveBeenCalledWith(query, params)
     })
 
-    it('should proxy isOpen to the begined transaction', async () => {
+    it('should proxy isOpen to the begun transaction', async () => {
       const connection = mockBeginWithSuccess(newFakeConnection())
       const session = newSessionWithConnection(connection, false, FETCH_ALL)
       const isOpen = jest.spyOn(Transaction.prototype, 'isOpen').mockImplementationOnce(() => true)

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -317,6 +317,7 @@ describe('session', () => {
       expect(status.functionCalled).toEqual(true)
       expect(run).toHaveBeenCalledWith(query, params)
     })
+  })
 })
 
 function mockBeginWithSuccess(connection: FakeConnection) {

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -317,22 +317,6 @@ describe('session', () => {
       expect(status.functionCalled).toEqual(true)
       expect(run).toHaveBeenCalledWith(query, params)
     })
-
-    it('should proxy isOpen to the begun transaction', async () => {
-      const connection = mockBeginWithSuccess(newFakeConnection())
-      const session = newSessionWithConnection(connection, false, FETCH_ALL)
-      const isOpen = jest.spyOn(Transaction.prototype, 'isOpen').mockImplementationOnce(() => true)
-      const status = { functionCalled: false }
-
-      await execute(session)(async (tx: ManagedTransaction) => {
-        status.functionCalled = true
-        expect(tx.isOpen()).toBe(true)
-      })
-
-      expect(status.functionCalled).toEqual(true)
-      expect(isOpen).toHaveBeenCalled()
-    })
-  })
 })
 
 function mockBeginWithSuccess(connection: FakeConnection) {

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -63,6 +63,7 @@ import {
   NotificationPosition,
   Session,
   Transaction,
+  ManagedTransaction,
   TransactionPromise,
   ServerInfo,
   Connection,
@@ -151,7 +152,7 @@ const {
  *       connectionAcquisitionTimeout: 60000, // 1 minute
  *
  *       // Specify the maximum time in milliseconds transactions are allowed to retry via
- *       // `Session#readTransaction()` and `Session#writeTransaction()` functions.
+ *       // `Session#executeRead()` and `Session#executeWrite()` functions.
  *       // These functions will retry the given unit of work on `ServiceUnavailable`, `SessionExpired` and transient
  *       // errors with exponential backoff using initial delay of 1 second.
  *       // Default value is 30000 which is 30 seconds.
@@ -428,6 +429,7 @@ const forExport = {
   ServerInfo,
   Session,
   Transaction,
+  ManagedTransaction,
   TransactionPromise,
   Point,
   Duration,
@@ -478,6 +480,7 @@ export {
   ServerInfo,
   Session,
   Transaction,
+  ManagedTransaction,
   TransactionPromise,
   Point,
   Duration,

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -126,7 +126,7 @@ const {
  *       connectionAcquisitionTimeout: 60000, // 1 minute
  *
  *       // Specify the maximum time in milliseconds transactions are allowed to retry via
- *       // `Session#readTransaction()` and `Session#writeTransaction()` functions.
+ *       // `Session#executeRead()` and `Session#executeWrite()` functions.
  *       // These functions will retry the given unit of work on `ServiceUnavailable`, `SessionExpired` and transient
  *       // errors with exponential backoff using initial delay of 1 second.
  *       // Default value is 30000 which is 30 seconds.

--- a/packages/neo4j-driver/src/session-rx.js
+++ b/packages/neo4j-driver/src/session-rx.js
@@ -140,8 +140,7 @@ export default class RxSession {
    */
   _executeInTransaction (accessMode, work, transactionConfig) {
     const wrapper = txc => new RxManagedTransaction({
-      run: txc.run.bind(txc),
-      isOpen: txc.isOpen.bind(txc)
+      run: txc.run.bind(txc)
     })
     return this._runTransaction(accessMode, work, transactionConfig, wrapper)
   }

--- a/packages/neo4j-driver/src/session-rx.js
+++ b/packages/neo4j-driver/src/session-rx.js
@@ -21,6 +21,7 @@ import { flatMap, catchError, concat } from 'rxjs/operators'
 import RxResult from './result-rx'
 import { Session, internal } from 'neo4j-driver-core'
 import RxTransaction from './transaction-rx'
+import RxManagedTransaction from './transaction-managed-rx'
 import RxRetryLogic from './internal/retry-logic-rx'
 
 const {

--- a/packages/neo4j-driver/src/transaction-managed-rx.js
+++ b/packages/neo4j-driver/src/transaction-managed-rx.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Represents a rx transaction that is managed by the transaction executor.
+ * 
+ * @public
+ */
+class RxManagedTransaction {
+  constructor({ run, isOpen }) {
+    this._run = run
+    this._isOpen = isOpen
+  }
+
+  /**
+   * Creates a reactive result that will execute the query in this transaction, with the provided parameters.
+   *
+   * @public
+   * @param {string} query - Query to be executed.
+   * @param {Object} parameters - Parameter values to use in query execution.
+   * @returns {RxResult} - A reactive result
+   */
+   run (query, parameters) {
+     return this._run(query, parameters)
+   }
+
+   /**
+   * Check if this transaction is active, which means commit and rollback did not happen.
+   * @return {boolean} `true` when not committed and not rolled back, `false` otherwise.
+   */
+    isOpen() {
+      return this._isOpen()
+    }
+}

--- a/packages/neo4j-driver/src/transaction-managed-rx.js
+++ b/packages/neo4j-driver/src/transaction-managed-rx.js
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import RxResult from './result-rx'
+import RxTransaction from './transaction-rx'
 
 /**
  * Represents a rx transaction that is managed by the transaction executor.
@@ -23,8 +25,22 @@
  * @public
  */
 class RxManagedTransaction {
+  /**
+   * @private
+   */
   constructor({ run }) {
     this._run = run
+  }
+
+  /**
+   * @private
+   * @param {RxTransaction} txc - The transaction to be wrapped
+   * @returns {RxManagedTransaction} The managed transaction
+   */
+  static fromTransaction (txc) {
+    return new RxManagedTransaction({
+      run: txc.run.bind(txc)
+    })
   }
 
   /**

--- a/packages/neo4j-driver/src/transaction-managed-rx.js
+++ b/packages/neo4j-driver/src/transaction-managed-rx.js
@@ -48,3 +48,5 @@ class RxManagedTransaction {
       return this._isOpen()
     }
 }
+
+export default RxManagedTransaction

--- a/packages/neo4j-driver/src/transaction-managed-rx.js
+++ b/packages/neo4j-driver/src/transaction-managed-rx.js
@@ -23,9 +23,8 @@
  * @public
  */
 class RxManagedTransaction {
-  constructor({ run, isOpen }) {
+  constructor({ run }) {
     this._run = run
-    this._isOpen = isOpen
   }
 
   /**
@@ -39,14 +38,6 @@ class RxManagedTransaction {
    run (query, parameters) {
      return this._run(query, parameters)
    }
-
-   /**
-   * Check if this transaction is active, which means commit and rollback did not happen.
-   * @return {boolean} `true` when not committed and not rolled back, `false` otherwise.
-   */
-    isOpen() {
-      return this._isOpen()
-    }
 }
 
 export default RxManagedTransaction

--- a/packages/neo4j-driver/src/transaction-rx.js
+++ b/packages/neo4j-driver/src/transaction-rx.js
@@ -41,7 +41,6 @@ export default class RxTransaction {
    * @param {Object} parameters - Parameter values to use in query execution.
    * @returns {RxResult} - A reactive result
    */
-
   run (query, parameters) {
     return new RxResult(
       new Observable(observer => {
@@ -89,6 +88,14 @@ export default class RxTransaction {
         })
         .catch(err => observer.error(err))
     })
+  }
+
+  /**
+   * Check if this transaction is active, which means commit and rollback did not happen.
+   * @return {boolean} `true` when not committed and not rolled back, `false` otherwise.
+   */
+   isOpen() {
+    return this._txc.isOpen()
   }
 
   /**

--- a/packages/neo4j-driver/test/internal/shared-neo4j.js
+++ b/packages/neo4j-driver/test/internal/shared-neo4j.js
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import neo4j from '../../src'
 import { json } from 'neo4j-driver-core'
 

--- a/packages/neo4j-driver/test/internal/transaction-executor.test.js
+++ b/packages/neo4j-driver/test/internal/transaction-executor.test.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { newError, error as err, internal, int } from 'neo4j-driver-core'
+import { newError, error as err, internal } from 'neo4j-driver-core'
 import { setTimeoutMock } from './timers-util'
 import lolex from 'lolex'
 

--- a/packages/neo4j-driver/test/types/session-rx.test.ts
+++ b/packages/neo4j-driver/test/types/session-rx.test.ts
@@ -19,6 +19,7 @@
 
 import RxSession from '../../types/session-rx'
 import RxTransaction from '../../types/transaction-rx'
+import { RxManagedTransaction } from '../../types'
 import RxResult from '../../types/result-rx'
 import {
   Integer,
@@ -151,4 +152,28 @@ const observable5: Observable<string> = rxSession.readTransaction(
 const observable6: Observable<number> = rxSession.writeTransaction(
   (tx: RxTransaction) => of(42),
   txConfig4
+)
+
+const observable7: Observable<number> = rxSession.executeRead(
+  (tx: RxManagedTransaction) => {
+    return of(10)
+  }
+)
+
+const observable8: Observable<string> = rxSession.executeRead(
+  (tx: RxManagedTransaction) => {
+    return of('42')
+  }
+)
+
+const observable9: Observable<number> = rxSession.executeWrite(
+  (tx: RxManagedTransaction) => {
+    return of(10)
+  }
+)
+
+const observable10: Observable<string> = rxSession.executeWrite(
+  (tx: RxManagedTransaction) => {
+    return of('42')
+  }
 )

--- a/packages/neo4j-driver/test/types/transaction-managed-rx.test.ts
+++ b/packages/neo4j-driver/test/types/transaction-managed-rx.test.ts
@@ -20,8 +20,7 @@
 import RxManagedTransaction from '../../types/transaction-managed-rx'
 import { Record, ResultSummary } from 'neo4j-driver-core'
 import RxResult from '../../types/result-rx'
-import { Observable, of, Observer, throwError } from 'rxjs'
-import { concat, finalize, catchError } from 'rxjs/operators'
+import { Observer } from 'rxjs'
 
 const dummy: any = null
 
@@ -60,5 +59,3 @@ const result2: RxResult = tx.run('RETURN $value', { value: '42' })
 result2.keys().subscribe(keysObserver)
 result2.records().subscribe(recordsObserver)
 result2.consume().subscribe(summaryObserver)
-
-const isOpen: boolean = tx.isOpen()

--- a/packages/neo4j-driver/test/types/transaction-managed-rx.test.ts
+++ b/packages/neo4j-driver/test/types/transaction-managed-rx.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import RxTransaction from '../../types/transaction-rx'
+import RxManagedTransaction from '../../types/transaction-managed-rx'
 import { Record, ResultSummary } from 'neo4j-driver-core'
 import RxResult from '../../types/result-rx'
 import { Observable, of, Observer, throwError } from 'rxjs'
@@ -49,7 +49,7 @@ const summaryObserver: Observer<ResultSummary> = {
   error: error => console.log(`summary error: ${error}`)
 }
 
-const tx: RxTransaction = dummy
+const tx: RxManagedTransaction = dummy
 
 const result1: RxResult = tx.run('RETURN 1')
 result1.keys().subscribe(keysObserver)
@@ -62,15 +62,3 @@ result2.records().subscribe(recordsObserver)
 result2.consume().subscribe(summaryObserver)
 
 const isOpen: boolean = tx.isOpen()
-
-tx.commit()
-  .pipe(concat(of('committed')))
-  .subscribe(stringObserver)
-
-tx.rollback()
-  .pipe(concat(of('rolled back')))
-  .subscribe(stringObserver)
-
-tx.close()
-  .pipe(concat(of('closed')))
-  .subscribe(stringObserver)

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -74,6 +74,7 @@ import {
 } from './driver'
 import RxSession from './session-rx'
 import RxTransaction from './transaction-rx'
+import RxManagedTransaction from './transaction-managed-rx'
 import RxResult from './result-rx'
 import { Parameters } from './query-runner'
 
@@ -118,6 +119,7 @@ declare const types: {
   Integer: typeof Integer
   RxSession: RxSession
   RxTransaction: RxTransaction
+  RxManagedTransaction: RxManagedTransaction,
   RxResult: RxResult
 }
 
@@ -203,6 +205,7 @@ declare const forExport: {
   DateTime: DateTime
   RxSession: RxSession
   RxTransaction: RxTransaction
+  RxManagedTransaction: RxManagedTransaction,
   RxResult: RxResult
   ConnectionProvider: ConnectionProvider
   isDuration: typeof isDuration
@@ -262,6 +265,7 @@ export {
   DateTime,
   RxSession,
   RxTransaction,
+  RxManagedTransaction,
   RxResult,
   ConnectionProvider,
   isDuration,

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -58,6 +58,7 @@ import {
   ResultObserver,
   QueryResult,
   Transaction,
+  ManagedTransaction,
   Session,
   ConnectionProvider
 } from 'neo4j-driver-core'
@@ -190,7 +191,8 @@ declare const forExport: {
   ServerInfo: ServerInfo
   NotificationPosition: NotificationPosition
   Session: Session
-  Transaction: Transaction
+  Transaction: Transaction,
+  ManagedTransaction: ManagedTransaction,
   Point: Point
   isPoint: typeof isPoint
   Duration: Duration
@@ -249,6 +251,7 @@ export {
   NotificationPosition,
   Session,
   Transaction,
+  ManagedTransaction,
   Point,
   isPoint,
   Duration,

--- a/packages/neo4j-driver/types/session-rx.d.ts
+++ b/packages/neo4j-driver/types/session-rx.d.ts
@@ -35,13 +35,28 @@ declare interface RxSession {
 
   lastBookmarks(): string[]
   lastBookmark(): string[]
-
+  /**
+   * @deprecated This method will be removed in version 6.0. Please, use {@link RxSession#executeRead} instead. 
+   */
   readTransaction<T>(
     work: RxTransactionWork<T>,
     config?: TransactionConfig
   ): Observable<T>
 
+  /**
+   * @deprecated This method will be removed in version 6.0. Please, use {@link RxSession#executeWrite} instead. 
+   */
   writeTransaction<T>(
+    work: RxTransactionWork<T>,
+    config?: TransactionConfig
+  ): Observable<T>
+
+  executeRead<T>(
+    work: RxTransactionWork<T>,
+    config?: TransactionConfig
+  ): Observable<T>
+
+  executeWrite<T>(
     work: RxTransactionWork<T>,
     config?: TransactionConfig
   ): Observable<T>

--- a/packages/neo4j-driver/types/transaction-managed-rx.d.ts
+++ b/packages/neo4j-driver/types/transaction-managed-rx.d.ts
@@ -21,7 +21,6 @@
  
  declare interface RxManagedTransaction {
    run(query: string, parameters?: Parameters): RxResult
-   isOpen(): boolean
  }
  
  export default RxManagedTransaction

--- a/packages/neo4j-driver/types/transaction-managed-rx.d.ts
+++ b/packages/neo4j-driver/types/transaction-managed-rx.d.ts
@@ -16,20 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Observable } from 'rxjs'
-import { Parameters } from './query-runner'
-import RxResult from './result-rx'
-
-declare interface RxTransaction {
-  run(query: string, parameters?: Parameters): RxResult
-  
-  isOpen(): boolean
-
-  commit(): Observable<any>
-
-  rollback(): Observable<any>
-
-  close(): Observable<any>
-}
-
-export default RxTransaction
+ import { Parameters } from './query-runner'
+ import RxResult from './result-rx'
+ 
+ declare interface RxManagedTransaction {
+   run(query: string, parameters?: Parameters): RxResult
+   isOpen(): boolean
+ }
+ 
+ export default RxManagedTransaction
+ 

--- a/packages/testkit-backend/src/request-handlers-rx.js
+++ b/packages/testkit-backend/src/request-handlers-rx.js
@@ -173,7 +173,7 @@ export function SessionReadTransaction(context, data, wire) {
   const session = context.getSession(sessionId)
 
   try {
-    return session.readTransaction(tx => {
+    return session.executeRead(tx => {
       return from(new Promise((resolve, reject) => {
         const id = context.addTx(tx, sessionId, resolve, reject)
         wire.writeResponse(responses.RetryableTry({ id }))
@@ -193,7 +193,7 @@ export function SessionWriteTransaction(context, data, wire) {
   const session = context.getSession(sessionId)
 
   try {
-    return session.writeTransaction(tx => {
+    return session.executeWrite(tx => {
       return from(new Promise((resolve, reject) => {
         const id = context.addTx(tx, sessionId, resolve, reject)
         wire.writeResponse(responses.RetryableTry({ id }))

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -225,7 +225,7 @@ export function SessionReadTransaction (context, data, wire) {
   const { sessionId, txMeta: metadata } = data
   const session = context.getSession(sessionId)
   return session
-    .readTransaction(
+    .executeRead(
       tx =>
         new Promise((resolve, reject) => {
           const id = context.addTx(tx, sessionId, resolve, reject)
@@ -323,7 +323,7 @@ export function SessionWriteTransaction (context, data, wire) {
   const { sessionId, txMeta: metadata } = data
   const session = context.getSession(sessionId)
   return session
-    .writeTransaction(
+    .executeWrite(
       tx =>
         new Promise((resolve, reject) => {
           const id = context.addTx(tx, sessionId, resolve, reject)


### PR DESCRIPTION

The new methods provides a `ManagedTransaction` objects to the transaction functions. These
transaction objects don't have `commit`, `rollback` and `close` capabilities exposed in the API.