### PR TITLE
Bump RxJS to 7.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ rxSession
   .records()
   .pipe(
     map(record => record.get('name')),
-    concat(rxSession.close())
+    concatWith(rxSession.close())
   )
   .subscribe({
     next: data => console.log(data),
@@ -373,8 +373,8 @@ try {
 rxSession
   .beginTransaction()
   .pipe(
-    flatMap(txc =>
-      concat(
+    mergeMap(txc =>
+      concatWith(
         txc
           .run(
             'MERGE (bob:Person {name: $nameParam}) RETURN bob.name AS name',
@@ -397,7 +397,7 @@ rxSession
         of('Second query completed'),
         txc.commit(),
         of('committed')
-      ).pipe(catchError(err => txc.rollback().pipe(throwError(err))))
+      ).pipe(catchError(err => txc.rollback().pipe(throwError(() => err))))
     )
   )
   .subscribe({

--- a/packages/neo4j-driver/README.md
+++ b/packages/neo4j-driver/README.md
@@ -222,7 +222,7 @@ rxSession
   .records()
   .pipe(
     map(record => record.get('name')),
-    concat(rxSession.close())
+    concatWith(rxSession.close())
   )
   .subscribe({
     next: data => console.log(data),
@@ -373,8 +373,8 @@ try {
 rxSession
   .beginTransaction()
   .pipe(
-    flatMap(txc =>
-      concat(
+    mergeMap(txc =>
+      concatWith(
         txc
           .run(
             'MERGE (bob:Person {name: $nameParam}) RETURN bob.name AS name',
@@ -397,7 +397,7 @@ rxSession
         of('Second query completed'),
         txc.commit(),
         of('committed')
-      ).pipe(catchError(err => txc.rollback().pipe(throwError(err))))
+      ).pipe(catchError(err => txc.rollback().pipe(throwError(() => err))))
     )
   )
   .subscribe({

--- a/packages/neo4j-driver/package-lock.json
+++ b/packages/neo4j-driver/package-lock.json
@@ -5,11 +5,12 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "neo4j-driver",
 			"version": "5.0.0-dev",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/runtime": "^7.17.8",
-				"rxjs": "^6.6.7"
+				"rxjs": "^7.5.5"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.17.8",
@@ -13013,14 +13014,11 @@
 			}
 		},
 		"node_modules/rxjs": {
-			"version": "6.6.7",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+			"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
 			"dependencies": {
-				"tslib": "^1.9.0"
-			},
-			"engines": {
-				"npm": ">=2.0.0"
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -14476,9 +14474,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/tty-browserify": {
 			"version": "0.0.1",
@@ -26148,11 +26146,11 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.6.7",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+			"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
 			"requires": {
-				"tslib": "^1.9.0"
+				"tslib": "^2.1.0"
 			}
 		},
 		"safe-buffer": {
@@ -27327,9 +27325,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"tty-browserify": {
 			"version": "0.0.1",

--- a/packages/neo4j-driver/package.json
+++ b/packages/neo4j-driver/package.json
@@ -90,6 +90,6 @@
     "@babel/runtime": "^7.17.8",
     "neo4j-driver-bolt-connection": "5.0.0-dev",
     "neo4j-driver-core": "5.0.0-dev",
-    "rxjs": "^6.6.7"
+    "rxjs": "^7.5.5"
   }
 }

--- a/packages/neo4j-driver/src/internal/retry-logic-rx.js
+++ b/packages/neo4j-driver/src/internal/retry-logic-rx.js
@@ -20,7 +20,7 @@
 import { newError, error, internal, isRetriableError } from 'neo4j-driver-core'
 // eslint-disable-next-line no-unused-vars
 import { Observable, throwError, of } from 'rxjs'
-import { retryWhen, flatMap, delay } from 'rxjs/operators'
+import { retryWhen, mergeMap, delay } from 'rxjs/operators'
 
 const {
   logger: {
@@ -80,9 +80,9 @@ export default class RxRetryLogic {
         let delayDuration = this._initialDelay
 
         return failedWork.pipe(
-          flatMap(err => {
+          mergeMap(err => {
             if (!isRetriableError(err)) {
-              return throwError(err)
+              return throwError(() => err)
             }
 
             handledExceptions.push(err)
@@ -98,7 +98,7 @@ export default class RxRetryLogic {
 
               error.seenErrors = handledExceptions
 
-              return throwError(error)
+              return throwError(() => error)
             }
 
             const nextDelayDuration = this._computeNextDelay(delayDuration)

--- a/packages/neo4j-driver/src/result-rx.js
+++ b/packages/neo4j-driver/src/result-rx.js
@@ -19,7 +19,7 @@
 /* eslint-disable-next-line no-unused-vars */
 import { newError, Record, ResultSummary } from 'neo4j-driver-core'
 import { Observable, Subject, ReplaySubject, from } from 'rxjs'
-import { flatMap, publishReplay, refCount } from 'rxjs/operators'
+import { mergeMap, publishReplay, refCount } from 'rxjs/operators'
 
 const States = {
   READY: 0,
@@ -41,7 +41,7 @@ export default class RxResult {
 
     this._result = replayedResult
     this._keys = replayedResult.pipe(
-      flatMap(r => from(r.keys())),
+      mergeMap(r => from(r.keys())),
       publishReplay(1),
       refCount()
     )
@@ -75,7 +75,7 @@ export default class RxResult {
    */
   records () {
     const result = this._result.pipe(
-      flatMap(
+      mergeMap(
         result =>
           new Observable(recordsObserver =>
             this._startStreaming({ result, recordsObserver })
@@ -97,7 +97,7 @@ export default class RxResult {
    */
   consume () {
     return this._result.pipe(
-      flatMap(
+      mergeMap(
         result =>
           new Observable(summaryObserver =>
             this._startStreaming({ result, summaryObserver })

--- a/packages/neo4j-driver/test/internal/retry-logic-rx.test.js
+++ b/packages/neo4j-driver/test/internal/retry-logic-rx.test.js
@@ -245,7 +245,8 @@ describe('#unit-rx retrylogic', () => {
         clock.tick(delayBy)
       }
       if (index < errors.length) {
-        return throwError(errors[index++])
+        const i = index++
+        return throwError(() => errors[i])
       } else {
         return of(value)
       }

--- a/packages/neo4j-driver/test/rx/session.test.js
+++ b/packages/neo4j-driver/test/rx/session.test.js
@@ -18,7 +18,7 @@
  */
 
 import { Notification, throwError } from 'rxjs'
-import { map, materialize, toArray, concat } from 'rxjs/operators'
+import { map, materialize, toArray, concatWith } from 'rxjs/operators'
 import neo4j from '../../src'
 import RxSession from '../../src/session-rx'
 import sharedNeo4j from '../internal/shared-neo4j'
@@ -377,7 +377,7 @@ describe('#integration rx-session', () => {
       .records()
       .pipe(
         map(r => r.get(0).toInt()),
-        concat(session.close())
+        concatWith(session.close())
       )
       .toPromise()
   }
@@ -403,7 +403,8 @@ describe('#integration rx-session', () => {
       }
 
       if (this._reactiveFailuresIndex < this._reactiveFailures.length) {
-        return throwError(this._reactiveFailures[this._reactiveFailuresIndex++])
+        const i = this._reactiveFailuresIndex++
+        return throwError(() => this._reactiveFailures[i])
       }
 
       return txc

--- a/packages/neo4j-driver/test/rx/transaction.test.js
+++ b/packages/neo4j-driver/test/rx/transaction.test.js
@@ -19,11 +19,11 @@
 
 import { Notification } from 'rxjs'
 import {
-  flatMap,
+  mergeMap,
   materialize,
   toArray,
-  concat,
-  map
+  map,
+  concatWith
 } from 'rxjs/operators'
 import neo4j from '../../src'
 // eslint-disable-next-line no-unused-vars
@@ -64,7 +64,7 @@ describe('#integration-rx transaction', () => {
     const result = await session
       .beginTransaction()
       .pipe(
-        flatMap(txc => txc.commit()),
+        mergeMap(txc => txc.commit()),
         materialize(),
         toArray()
       )
@@ -81,7 +81,7 @@ describe('#integration-rx transaction', () => {
     const result = await session
       .beginTransaction()
       .pipe(
-        flatMap(txc => txc.rollback()),
+        mergeMap(txc => txc.rollback()),
         materialize(),
         toArray()
       )
@@ -98,13 +98,13 @@ describe('#integration-rx transaction', () => {
     const result = await session
       .beginTransaction()
       .pipe(
-        flatMap(txc =>
+        mergeMap(txc =>
           txc
             .run('CREATE (n:Node {id: 42}) RETURN n')
             .records()
             .pipe(
               map(r => r.get('n').properties.id),
-              concat(txc.commit())
+              concatWith(txc.commit())
             )
         ),
         materialize(),
@@ -127,13 +127,13 @@ describe('#integration-rx transaction', () => {
     const result = await session
       .beginTransaction()
       .pipe(
-        flatMap(txc =>
+        mergeMap(txc =>
           txc
             .run('CREATE (n:Node {id: 42}) RETURN n')
             .records()
             .pipe(
               map(r => r.get('n').properties.id),
-              concat(txc.rollback())
+              concatWith(txc.rollback())
             )
         ),
         materialize(),
@@ -156,13 +156,13 @@ describe('#integration-rx transaction', () => {
     const result = await session
       .beginTransaction()
       .pipe(
-        flatMap(txc =>
+        mergeMap(txc =>
           txc
             .run('CREATE (n:Node {id: 42}) RETURN n')
             .records()
             .pipe(
               map(r => r.get('n').properties.id),
-              concat(txc.close())
+              concatWith(txc.close())
             )
         ),
         materialize(),
@@ -457,9 +457,9 @@ describe('#integration-rx transaction', () => {
     const result = await result1
       .records()
       .pipe(
-        concat(result2.records()),
-        concat(result3.records()),
-        concat(result4.records()),
+        concatWith(result2.records()),
+        concatWith(result3.records()),
+        concatWith(result4.records()),
         map(r => r.get(0).toInt()),
         materialize(),
         toArray()
@@ -489,9 +489,9 @@ describe('#integration-rx transaction', () => {
     const result = await result4
       .records()
       .pipe(
-        concat(result3.records()),
-        concat(result2.records()),
-        concat(result1.records()),
+        concatWith(result3.records()),
+        concatWith(result2.records()),
+        concatWith(result1.records()),
         map(r => r.get(0).toInt()),
         materialize(),
         toArray()
@@ -615,8 +615,8 @@ describe('#integration-rx transaction', () => {
     const results = await result1
       .records()
       .pipe(
-        concat(result2.records()),
-        concat(result3.records()),
+        concatWith(result2.records()),
+        concatWith(result3.records()),
         materialize(),
         toArray()
       )
@@ -641,8 +641,8 @@ describe('#integration-rx transaction', () => {
     const results = await result1
       .keys()
       .pipe(
-        concat(result2.keys()),
-        concat(result3.keys()),
+        concatWith(result2.keys()),
+        concatWith(result3.keys()),
         materialize(),
         toArray()
       )
@@ -744,7 +744,7 @@ describe('#integration-rx transaction', () => {
       .records()
       .pipe(
         map(r => r.get(0).toInt()),
-        concat(session.close())
+        concatWith(session.close())
       )
       .toPromise()
   }

--- a/packages/neo4j-driver/test/types/driver.test.ts
+++ b/packages/neo4j-driver/test/types/driver.test.ts
@@ -31,7 +31,7 @@ import Driver, {
 import { Parameters } from '../../types/query-runner'
 import { ServerInfo, Session } from 'neo4j-driver-core'
 import RxSession from '../../types/session-rx'
-import { concat, map, catchError } from 'rxjs/operators'
+import { map, catchError, concatWith } from 'rxjs/operators'
 import { throwError } from 'rxjs'
 
 const dummy: any = null
@@ -140,8 +140,8 @@ rxSession1
   .records()
   .pipe(
     map(r => r.get(0)),
-    concat(rxSession1.close()),
-    catchError(err => rxSession1.close().pipe(concat(throwError(err))))
+    concatWith(rxSession1.close()),
+    catchError(err => rxSession1.close().pipe(concatWith(throwError(() => err))))
   )
   .subscribe({
     next: data => console.log(data),

--- a/packages/neo4j-driver/test/types/session-rx.test.ts
+++ b/packages/neo4j-driver/test/types/session-rx.test.ts
@@ -30,7 +30,7 @@ import {
   TransactionConfig
 } from 'neo4j-driver-core'
 import { Observable, of, Observer, throwError } from 'rxjs'
-import { concat, finalize, catchError } from 'rxjs/operators'
+import { finalize, catchError, concatWith } from 'rxjs/operators'
 
 const dummy: any = null
 const intValue: Integer = Integer.fromInt(42)
@@ -120,8 +120,8 @@ result1.records().subscribe(recordsObserver)
 result1
   .consume()
   .pipe(
-    concat(close1),
-    catchError(err => close1.pipe(concat(throwError(err))))
+    concatWith(close1),
+    catchError(err => close1.pipe(concatWith(throwError(() => err))))
   )
   .subscribe(summaryObserver)
 
@@ -131,8 +131,8 @@ result2.records().subscribe(recordsObserver)
 result2
   .consume()
   .pipe(
-    concat(close1),
-    catchError(err => close1.pipe(concat(throwError(err))))
+    concatWith(close1),
+    catchError(err => close1.pipe(concatWith(throwError(() => err))))
   )
   .subscribe(summaryObserver)
 
@@ -146,8 +146,8 @@ result3.records().subscribe(recordsObserver)
 result3
   .consume()
   .pipe(
-    concat(close1),
-    catchError(err => close1.pipe(concat(throwError(err))))
+    concatWith(close1),
+    catchError(err => close1.pipe(concatWith(throwError(() => err))))
   )
   .subscribe(summaryObserver)
 

--- a/packages/neo4j-driver/test/types/transaction-rx.test.ts
+++ b/packages/neo4j-driver/test/types/transaction-rx.test.ts
@@ -22,8 +22,8 @@
 import RxTransaction from '../../types/transaction-rx'
 import { Record, ResultSummary } from 'neo4j-driver-core'
 import RxResult from '../../types/result-rx'
-import { Observable, of, Observer, throwError } from 'rxjs'
-import { concat, finalize, catchError } from 'rxjs/operators'
+import { of, Observer } from 'rxjs'
+import { concatWith } from 'rxjs/operators'
 
 const dummy: any = null
 
@@ -72,13 +72,13 @@ result2.consume().subscribe(summaryObserver)
 const isOpen: boolean = tx.isOpen()
 
 tx.commit()
-  .pipe(concat(of('committed')))
+  .pipe(concatWith(of('committed')))
   .subscribe(stringObserver)
 
 tx.rollback()
-  .pipe(concat(of('rolled back')))
+  .pipe(concatWith(of('rolled back')))
   .subscribe(stringObserver)
 
 tx.close()
-  .pipe(concat(of('closed')))
+  .pipe(concatWith(of('closed')))
   .subscribe(stringObserver)


### PR DESCRIPTION
The breaking changes present on this update was already gone through deprecation in the last releases.

Some adjustments in the driver code was needed.

* `concat` was replaced by `concatWith`
* `flatMap` was replaced by `mergeMap`
* `throwError` was change for receiving an error supplier instead of an error