### PR TITLE
Export types constructors in the neo4j-driver

### DIFF
--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -52,12 +52,18 @@ import {
   Record,
   ResultSummary,
   Result,
-  auth
+  auth,
+  Session,
+  Transaction,
 } from 'neo4j-driver-core'
 import {
   DirectConnectionProvider,
   RoutingConnectionProvider
 } from 'neo4j-driver-bolt-connection'
+
+import RxSession from './session-rx'
+import RxTransaction from './transaction-rx'
+import RxResult from './result-rx'
 
 const {
   util: { ENCRYPTION_ON, assertString, isEmptyObjectOrNull },
@@ -390,7 +396,14 @@ const forExport = {
   session,
   error,
   spatial,
-  temporal
+  temporal,
+  Driver,
+  Session,
+  Transaction,
+  Result,
+  RxSession,
+  RxTransaction,
+  RxResult
 }
 
 export {
@@ -413,6 +426,13 @@ export {
   session,
   error,
   spatial,
-  temporal
+  temporal,
+  Driver,
+  Session,
+  Transaction,
+  Result,
+  RxSession,
+  RxTransaction,
+  RxResult
 }
 export default forExport

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -424,7 +424,9 @@ const forExport = {
   Relationship,
   UnboundRelationship,
   Path,
-  PathSegment
+  PathSegment,
+  Point,
+  Integer
 }
 
 export {
@@ -468,6 +470,8 @@ export {
   Relationship,
   UnboundRelationship,
   Path,
-  PathSegment
+  PathSegment,
+  Point,
+  Integer
 }
 export default forExport

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -419,7 +419,12 @@ const forExport = {
   QueryStatistics,
   Notification,
   ServerInfo,
-  Record
+  Record,
+  Node,
+  Relationship,
+  UnboundRelationship,
+  Path,
+  PathSegment
 }
 
 export {
@@ -458,6 +463,11 @@ export {
   QueryStatistics,
   Notification,
   ServerInfo,
-  Record
+  Record,
+  Node,
+  Relationship,
+  UnboundRelationship,
+  Path,
+  PathSegment
 }
 export default forExport

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -426,7 +426,13 @@ const forExport = {
   Path,
   PathSegment,
   Point,
-  Integer
+  Integer,
+  Duration,
+  LocalTime,
+  Time,
+  Date,
+  LocalDateTime,
+  DateTime
 }
 
 export {
@@ -472,6 +478,12 @@ export {
   Path,
   PathSegment,
   Point,
-  Integer
+  Integer,
+  Duration,
+  LocalTime,
+  Time,
+  Date,
+  LocalDateTime,
+  DateTime
 }
 export default forExport

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -51,10 +51,16 @@ import {
   UnboundRelationship,
   Record,
   ResultSummary,
+  Plan,
+  ProfiledPlan,
+  QueryStatistics,
+  Notification,
+  ServerInfo,
   Result,
   auth,
   Session,
   Transaction,
+  ManagedTransaction
 } from 'neo4j-driver-core'
 import {
   DirectConnectionProvider,
@@ -63,6 +69,7 @@ import {
 
 import RxSession from './session-rx'
 import RxTransaction from './transaction-rx'
+import RxManagedTransaction from './transaction-managed-rx'
 import RxResult from './result-rx'
 
 const {
@@ -400,10 +407,19 @@ const forExport = {
   Driver,
   Session,
   Transaction,
+  ManagedTransaction,
   Result,
   RxSession,
   RxTransaction,
-  RxResult
+  RxManagedTransaction,
+  RxResult,
+  ResultSummary,
+  Plan,
+  ProfiledPlan,
+  QueryStatistics,
+  Notification,
+  ServerInfo,
+  Record
 }
 
 export {
@@ -430,9 +446,18 @@ export {
   Driver,
   Session,
   Transaction,
+  ManagedTransaction,
   Result,
   RxSession,
   RxTransaction,
-  RxResult
+  RxManagedTransaction,
+  RxResult,
+  ResultSummary,
+  Plan,
+  ProfiledPlan,
+  QueryStatistics,
+  Notification,
+  ServerInfo,
+  Record
 }
 export default forExport

--- a/packages/neo4j-driver/test/index.test.js
+++ b/packages/neo4j-driver/test/index.test.js
@@ -1,10 +1,10 @@
-import neo4j, { 
-  Driver, 
-  Session, 
+import neo4j, {
+  Driver,
+  Session,
   Transaction,
-  ManagedTransaction, 
-  Result, 
-  RxSession, 
+  ManagedTransaction,
+  Result,
+  RxSession,
   RxTransaction,
   RxManagedTransaction,
   RxResult,
@@ -19,11 +19,14 @@ import neo4j, {
   Relationship,
   UnboundRelationship,
   Path,
-  PathSegment
+  PathSegment,
+  Point,
+  Integer,
+  Neo4jError
 } from '../src'
 
-import { 
-  ManagedTransaction as InternalManagedTransaction, 
+import {
+  ManagedTransaction as InternalManagedTransaction,
   ResultSummary as InternalResultSummary,
   Plan as InternalPlan,
   ProfiledPlan as InternalProfiledPlan,
@@ -35,7 +38,10 @@ import {
   Relationship as InternalRelationship,
   UnboundRelationship as InternalUnboundRelationship,
   Path as InternalPath,
-  PathSegment as InternalPathSegment
+  PathSegment as InternalPathSegment,
+  Point as InternalPoint,
+  Integer as InternalInteger,
+  Neo4jError as InternalNeo4jError
 } from 'neo4j-driver-core'
 import InternalRxManagedTransaction from '../src/transaction-managed-rx'
 
@@ -64,7 +70,7 @@ describe('#unit index', () => {
         expect(session).toBeInstanceOf(Session)
       })
 
-      function subject() {
+      function subject () {
         const driver = neo4j.driver('bolt://localhost')
         return driver.session()
       }
@@ -81,7 +87,7 @@ describe('#unit index', () => {
         expect(transaction).toBeInstanceOf(Transaction)
       })
 
-      function subject() {
+      function subject () {
         const driver = neo4j.driver('bolt://localhost')
         return driver.session().beginTransaction()
       }
@@ -98,7 +104,7 @@ describe('#unit index', () => {
         expect(result).toBeInstanceOf(Result)
       })
 
-      function subject() {
+      function subject () {
         const driver = neo4j.driver('bolt://localhost')
         return driver.session().run('RETURN 1')
       }
@@ -115,7 +121,7 @@ describe('#unit index', () => {
         expect(session).toBeInstanceOf(RxSession)
       })
 
-      function subject() {
+      function subject () {
         const driver = neo4j.driver('bolt://localhost')
         return driver.rxSession()
       }
@@ -132,7 +138,7 @@ describe('#unit index', () => {
         expect(transaction).toBeInstanceOf(RxTransaction)
       })
 
-      function subject() {
+      function subject () {
         const driver = neo4j.driver('bolt://localhost')
         return driver.rxSession().beginTransaction().toPromise()
       }
@@ -149,7 +155,7 @@ describe('#unit index', () => {
         expect(result).toBeInstanceOf(RxResult)
       })
 
-      function subject() {
+      function subject () {
         const driver = neo4j.driver('bolt://localhost')
         return driver.rxSession().run()
       }
@@ -164,9 +170,9 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(ManagedTransaction)
       })
 
-      function subject() {
+      function subject () {
         const driver = neo4j.driver('bolt://localhost')
-        const tx =  driver.session().beginTransaction()
+        const tx = driver.session().beginTransaction()
         return InternalManagedTransaction.fromTransaction(tx)
       }
     })
@@ -182,9 +188,9 @@ describe('#unit index', () => {
         expect(rxManagedTransaction).toBeInstanceOf(RxManagedTransaction)
       })
 
-      async function subject() {
+      async function subject () {
         const driver = neo4j.driver('bolt://localhost')
-        const tx =  await driver.rxSession().beginTransaction().toPromise()
+        const tx = await driver.rxSession().beginTransaction().toPromise()
         return InternalRxManagedTransaction.fromTransaction(tx)
       }
     })
@@ -198,7 +204,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(ResultSummary)
       })
 
-      function subject() {
+      function subject () {
         return new InternalResultSummary('query', {}, {}, 5.0)
       }
     })
@@ -212,7 +218,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(Plan)
       })
 
-      function subject() {
+      function subject () {
         return new InternalPlan({})
       }
     })
@@ -226,7 +232,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(ProfiledPlan)
       })
 
-      function subject() {
+      function subject () {
         return new InternalProfiledPlan({})
       }
     })
@@ -240,7 +246,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(QueryStatistics)
       })
 
-      function subject() {
+      function subject () {
         return new InternalQueryStatistics({})
       }
     })
@@ -254,7 +260,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(Notification)
       })
 
-      function subject() {
+      function subject () {
         return new InternalNotification({})
       }
     })
@@ -268,7 +274,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(ServerInfo)
       })
 
-      function subject() {
+      function subject () {
         return new InternalServerInfo({}, 5.0)
       }
     })
@@ -282,7 +288,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(Record)
       })
 
-      function subject() {
+      function subject () {
         return new InternalRecord([], [])
       }
     })
@@ -296,7 +302,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(Node)
       })
 
-      function subject() {
+      function subject () {
         return new InternalNode(1, [], [])
       }
     })
@@ -310,8 +316,8 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(Relationship)
       })
 
-      function subject() {
-        return new InternalRelationship(1, 1, 1, "Type", [], [])
+      function subject () {
+        return new InternalRelationship(1, 1, 1, 'Type', [], [])
       }
     })
 
@@ -324,8 +330,8 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(UnboundRelationship)
       })
 
-      function subject() {
-        return new InternalUnboundRelationship(1, "Type", [])
+      function subject () {
+        return new InternalUnboundRelationship(1, 'Type', [])
       }
     })
 
@@ -338,7 +344,7 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(Path)
       })
 
-      function subject() {
+      function subject () {
         return new InternalPath(new InternalNode(1, [], []), new InternalNode(1, [], []), [])
       }
     })
@@ -352,8 +358,50 @@ describe('#unit index', () => {
         expect(subject()).toBeInstanceOf(PathSegment)
       })
 
-      function subject() {
+      function subject () {
         return new InternalPathSegment(new InternalNode(1, [], []), new InternalNode(1, [], []), [])
+      }
+    })
+
+    describe('Point', () => {
+      it('should be instanceof neo4j.Point', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Point)
+      })
+
+      it('should be instanceof Point', () => {
+        expect(subject()).toBeInstanceOf(Point)
+      })
+
+      function subject () {
+        return new InternalPoint(1, 1, 1)
+      }
+    })
+
+    describe('Integer', () => {
+      it('should be instanceof neo4j.Integer', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Integer)
+      })
+
+      it('should be instanceof Integer', () => {
+        expect(subject()).toBeInstanceOf(Integer)
+      })
+
+      function subject () {
+        return new InternalInteger(1, 1)
+      }
+    })
+
+    describe('Neo4jError', () => {
+      it('should be instanceof neo4j.Neo4jError', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Neo4jError)
+      })
+
+      it('should be instanceof Neo4jError', () => {
+        expect(subject()).toBeInstanceOf(Neo4jError)
+      })
+
+      function subject () {
+        return new InternalNeo4jError('Message', 'N/A')
       }
     })
   })

--- a/packages/neo4j-driver/test/index.test.js
+++ b/packages/neo4j-driver/test/index.test.js
@@ -22,7 +22,13 @@ import neo4j, {
   PathSegment,
   Point,
   Integer,
-  Neo4jError
+  Neo4jError,
+  Duration,
+  LocalTime,
+  Time,
+  Date,
+  LocalDateTime,
+  DateTime
 } from '../src'
 
 import {
@@ -41,7 +47,13 @@ import {
   PathSegment as InternalPathSegment,
   Point as InternalPoint,
   Integer as InternalInteger,
-  Neo4jError as InternalNeo4jError
+  Neo4jError as InternalNeo4jError,
+  Duration as InternalDuration,
+  LocalTime as InternalLocalTime,
+  Time as InternalTime,
+  Date as InternalDate,
+  LocalDateTime as InternalLocalDateTime,
+  DateTime as InternalDateTime
 } from 'neo4j-driver-core'
 import InternalRxManagedTransaction from '../src/transaction-managed-rx'
 
@@ -402,6 +414,90 @@ describe('#unit index', () => {
 
       function subject () {
         return new InternalNeo4jError('Message', 'N/A')
+      }
+    })
+
+    describe('Duration', () => {
+      it('should be instanceof neo4j.Duration', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Duration)
+      })
+
+      it('should be instanceof Duration', () => {
+        expect(subject()).toBeInstanceOf(Duration)
+      })
+
+      function subject () {
+        return new InternalDuration(1, 1, 1, 1)
+      }
+    })
+
+    describe('LocalTime', () => {
+      it('should be instanceof neo4j.LocalTime', () => {
+        expect(subject()).toBeInstanceOf(neo4j.LocalTime)
+      })
+
+      it('should be instanceof LocalTime', () => {
+        expect(subject()).toBeInstanceOf(LocalTime)
+      })
+
+      function subject () {
+        return new InternalLocalTime(1, 1, 1, 1)
+      }
+    })
+
+    describe('Time', () => {
+      it('should be instanceof neo4j.Time', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Time)
+      })
+
+      it('should be instanceof Time', () => {
+        expect(subject()).toBeInstanceOf(Time)
+      })
+
+      function subject () {
+        return new InternalTime(1, 1, 1, 1, 1)
+      }
+    })
+
+    describe('Date', () => {
+      it('should be instanceof neo4j.Date', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Date)
+      })
+
+      it('should be instanceof Date', () => {
+        expect(subject()).toBeInstanceOf(Date)
+      })
+
+      function subject () {
+        return new InternalDate(1, 1, 1)
+      }
+    })
+
+    describe('LocalDateTime', () => {
+      it('should be instanceof neo4j.LocalDateTime', () => {
+        expect(subject()).toBeInstanceOf(neo4j.LocalDateTime)
+      })
+
+      it('should be instanceof LocalDateTime', () => {
+        expect(subject()).toBeInstanceOf(LocalDateTime)
+      })
+
+      function subject () {
+        return new InternalLocalDateTime(1, 1, 1, 1, 1, 1, 1)
+      }
+    })
+
+    describe('DateTime', () => {
+      it('should be instanceof neo4j.DateTime', () => {
+        expect(subject()).toBeInstanceOf(neo4j.DateTime)
+      })
+
+      it('should be instanceof DateTime', () => {
+        expect(subject()).toBeInstanceOf(DateTime)
+      })
+
+      function subject () {
+        return new InternalDateTime(1, 1, 1, 1, 1, 1, 1, 1)
       }
     })
   })

--- a/packages/neo4j-driver/test/index.test.js
+++ b/packages/neo4j-driver/test/index.test.js
@@ -1,13 +1,42 @@
-import neo4j, { Driver, Session, Transaction, Result, RxSession, RxTransaction, RxResult } from '../src'
+import neo4j, { 
+  Driver, 
+  Session, 
+  Transaction,
+  ManagedTransaction, 
+  Result, 
+  RxSession, 
+  RxTransaction,
+  RxManagedTransaction,
+  RxResult,
+  ResultSummary,
+  Plan,
+  ProfiledPlan,
+  QueryStatistics,
+  Notification,
+  ServerInfo,
+  Record
+} from '../src'
 
-describe('#unit index', () =>  {
+import { 
+  ManagedTransaction as InternalManagedTransaction, 
+  ResultSummary as InternalResultSummary,
+  Plan as InternalPlan,
+  ProfiledPlan as InternalProfiledPlan,
+  QueryStatistics as InternalQueryStatistics,
+  Notification as InternalNotification,
+  ServerInfo as InternalServerInfo,
+  Record as InternalRecord
+} from 'neo4j-driver-core'
+import InternalRxManagedTransaction from '../src/transaction-managed-rx'
+
+describe('#unit index', () => {
   describe('instanceof', () => {
     describe('neo4j.driver() return', () => {
       it('should be an instanceof neo4j.Driver', () => {
         const driver = neo4j.driver('bolt://localhost')
         expect(driver).toBeInstanceOf(neo4j.Driver)
       })
-  
+
       it('should be an instanceof Driver', () => {
         const driver = neo4j.driver('bolt://localhost')
         expect(driver).toBeInstanceOf(Driver)
@@ -25,7 +54,7 @@ describe('#unit index', () =>  {
         expect(session).toBeInstanceOf(Session)
       })
 
-      function subject () {
+      function subject() {
         const driver = neo4j.driver('bolt://localhost')
         return driver.session()
       }
@@ -42,7 +71,7 @@ describe('#unit index', () =>  {
         expect(transaction).toBeInstanceOf(Transaction)
       })
 
-      function subject () {
+      function subject() {
         const driver = neo4j.driver('bolt://localhost')
         return driver.session().beginTransaction()
       }
@@ -59,7 +88,7 @@ describe('#unit index', () =>  {
         expect(result).toBeInstanceOf(Result)
       })
 
-      function subject () {
+      function subject() {
         const driver = neo4j.driver('bolt://localhost')
         return driver.session().run('RETURN 1')
       }
@@ -76,7 +105,7 @@ describe('#unit index', () =>  {
         expect(session).toBeInstanceOf(RxSession)
       })
 
-      function subject () {
+      function subject() {
         const driver = neo4j.driver('bolt://localhost')
         return driver.rxSession()
       }
@@ -93,7 +122,7 @@ describe('#unit index', () =>  {
         expect(transaction).toBeInstanceOf(RxTransaction)
       })
 
-      function subject () {
+      function subject() {
         const driver = neo4j.driver('bolt://localhost')
         return driver.rxSession().beginTransaction().toPromise()
       }
@@ -110,9 +139,141 @@ describe('#unit index', () =>  {
         expect(result).toBeInstanceOf(RxResult)
       })
 
-      function subject () {
+      function subject() {
         const driver = neo4j.driver('bolt://localhost')
         return driver.rxSession().run()
+      }
+    })
+
+    describe('ManagedTransaction', () => {
+      it('should be instanceof neo4j.ManagedTransaction', () => {
+        expect(subject()).toBeInstanceOf(neo4j.ManagedTransaction)
+      })
+
+      it('should be instanceof ManagedTransaction', () => {
+        expect(subject()).toBeInstanceOf(ManagedTransaction)
+      })
+
+      function subject() {
+        const driver = neo4j.driver('bolt://localhost')
+        const tx =  driver.session().beginTransaction()
+        return InternalManagedTransaction.fromTransaction(tx)
+      }
+    })
+
+    describe('RxManagedTransaction', () => {
+      it('should be instanceof neo4j.RxManagedTransaction', async () => {
+        const rxManagedTransaction = await subject()
+        expect(rxManagedTransaction).toBeInstanceOf(neo4j.RxManagedTransaction)
+      })
+
+      it('should be instanceof RxManagedTransaction', async () => {
+        const rxManagedTransaction = await subject()
+        expect(rxManagedTransaction).toBeInstanceOf(RxManagedTransaction)
+      })
+
+      async function subject() {
+        const driver = neo4j.driver('bolt://localhost')
+        const tx =  await driver.rxSession().beginTransaction().toPromise()
+        return InternalRxManagedTransaction.fromTransaction(tx)
+      }
+    })
+
+    describe('ResultSummary', () => {
+      it('should be instanceof neo4j.ResultSummary', () => {
+        expect(subject()).toBeInstanceOf(neo4j.ResultSummary)
+      })
+
+      it('should be instanceof ResultSummary', () => {
+        expect(subject()).toBeInstanceOf(ResultSummary)
+      })
+
+      function subject() {
+        return new InternalResultSummary('query', {}, {}, 5.0)
+      }
+    })
+
+    describe('Plan', () => {
+      it('should be instanceof neo4j.Plan', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Plan)
+      })
+
+      it('should be instanceof Plan', () => {
+        expect(subject()).toBeInstanceOf(Plan)
+      })
+
+      function subject() {
+        return new InternalPlan({})
+      }
+    })
+
+    describe('ProfiledPlan', () => {
+      it('should be instanceof neo4j.ProfiledPlan', () => {
+        expect(subject()).toBeInstanceOf(neo4j.ProfiledPlan)
+      })
+
+      it('should be instanceof ProfiledPlan', () => {
+        expect(subject()).toBeInstanceOf(ProfiledPlan)
+      })
+
+      function subject() {
+        return new InternalProfiledPlan({})
+      }
+    })
+
+    describe('QueryStatistics', () => {
+      it('should be instanceof neo4j.QueryStatistics', () => {
+        expect(subject()).toBeInstanceOf(neo4j.QueryStatistics)
+      })
+
+      it('should be instanceof QueryStatistics', () => {
+        expect(subject()).toBeInstanceOf(QueryStatistics)
+      })
+
+      function subject() {
+        return new InternalQueryStatistics({})
+      }
+    })
+
+    describe('Notification', () => {
+      it('should be instanceof neo4j.Notification', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Notification)
+      })
+
+      it('should be instanceof Notification', () => {
+        expect(subject()).toBeInstanceOf(Notification)
+      })
+
+      function subject() {
+        return new InternalNotification({})
+      }
+    })
+
+    describe('ServerInfo', () => {
+      it('should be instanceof neo4j.ServerInfo', () => {
+        expect(subject()).toBeInstanceOf(neo4j.ServerInfo)
+      })
+
+      it('should be instanceof ServerInfo', () => {
+        expect(subject()).toBeInstanceOf(ServerInfo)
+      })
+
+      function subject() {
+        return new InternalServerInfo({}, 5.0)
+      }
+    })
+
+    describe('Record', () => {
+      it('should be instanceof neo4j.Record', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Record)
+      })
+
+      it('should be instanceof Record', () => {
+        expect(subject()).toBeInstanceOf(Record)
+      })
+
+      function subject() {
+        return new InternalRecord([], [])
       }
     })
   })

--- a/packages/neo4j-driver/test/index.test.js
+++ b/packages/neo4j-driver/test/index.test.js
@@ -14,7 +14,12 @@ import neo4j, {
   QueryStatistics,
   Notification,
   ServerInfo,
-  Record
+  Record,
+  Node,
+  Relationship,
+  UnboundRelationship,
+  Path,
+  PathSegment
 } from '../src'
 
 import { 
@@ -25,7 +30,12 @@ import {
   QueryStatistics as InternalQueryStatistics,
   Notification as InternalNotification,
   ServerInfo as InternalServerInfo,
-  Record as InternalRecord
+  Record as InternalRecord,
+  Node as InternalNode,
+  Relationship as InternalRelationship,
+  UnboundRelationship as InternalUnboundRelationship,
+  Path as InternalPath,
+  PathSegment as InternalPathSegment
 } from 'neo4j-driver-core'
 import InternalRxManagedTransaction from '../src/transaction-managed-rx'
 
@@ -274,6 +284,76 @@ describe('#unit index', () => {
 
       function subject() {
         return new InternalRecord([], [])
+      }
+    })
+
+    describe('Node', () => {
+      it('should be instanceof neo4j.Node', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Node)
+      })
+
+      it('should be instanceof Node', () => {
+        expect(subject()).toBeInstanceOf(Node)
+      })
+
+      function subject() {
+        return new InternalNode(1, [], [])
+      }
+    })
+
+    describe('Relationship', () => {
+      it('should be instanceof neo4j.Relationship', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Relationship)
+      })
+
+      it('should be instanceof Relationship', () => {
+        expect(subject()).toBeInstanceOf(Relationship)
+      })
+
+      function subject() {
+        return new InternalRelationship(1, 1, 1, "Type", [], [])
+      }
+    })
+
+    describe('UnboundRelationship', () => {
+      it('should be instanceof neo4j.UnboundRelationship', () => {
+        expect(subject()).toBeInstanceOf(neo4j.UnboundRelationship)
+      })
+
+      it('should be instanceof UnboundRelationship', () => {
+        expect(subject()).toBeInstanceOf(UnboundRelationship)
+      })
+
+      function subject() {
+        return new InternalUnboundRelationship(1, "Type", [])
+      }
+    })
+
+    describe('Path', () => {
+      it('should be instanceof neo4j.Path', () => {
+        expect(subject()).toBeInstanceOf(neo4j.Path)
+      })
+
+      it('should be instanceof Path', () => {
+        expect(subject()).toBeInstanceOf(Path)
+      })
+
+      function subject() {
+        return new InternalPath(new InternalNode(1, [], []), new InternalNode(1, [], []), [])
+      }
+    })
+
+    describe('PathSegment', () => {
+      it('should be instanceof neo4j.PathSegment', () => {
+        expect(subject()).toBeInstanceOf(neo4j.PathSegment)
+      })
+
+      it('should be instanceof PathSegment', () => {
+        expect(subject()).toBeInstanceOf(PathSegment)
+      })
+
+      function subject() {
+        return new InternalPathSegment(new InternalNode(1, [], []), new InternalNode(1, [], []), [])
       }
     })
   })

--- a/packages/neo4j-driver/test/index.test.js
+++ b/packages/neo4j-driver/test/index.test.js
@@ -1,0 +1,119 @@
+import neo4j, { Driver, Session, Transaction, Result, RxSession, RxTransaction, RxResult } from '../src'
+
+describe('#unit index', () =>  {
+  describe('instanceof', () => {
+    describe('neo4j.driver() return', () => {
+      it('should be an instanceof neo4j.Driver', () => {
+        const driver = neo4j.driver('bolt://localhost')
+        expect(driver).toBeInstanceOf(neo4j.Driver)
+      })
+  
+      it('should be an instanceof Driver', () => {
+        const driver = neo4j.driver('bolt://localhost')
+        expect(driver).toBeInstanceOf(Driver)
+      })
+    })
+
+    describe('driver.session() return', () => {
+      it('should be instanceof neo4j.Session', () => {
+        const session = subject()
+        expect(session).toBeInstanceOf(neo4j.Session)
+      })
+
+      it('should be instanceof Session', () => {
+        const session = subject()
+        expect(session).toBeInstanceOf(Session)
+      })
+
+      function subject () {
+        const driver = neo4j.driver('bolt://localhost')
+        return driver.session()
+      }
+    })
+
+    describe('session.beginTransaction() return', () => {
+      it('should be instanceof neo4j.Transaction', () => {
+        const transaction = subject()
+        expect(transaction).toBeInstanceOf(neo4j.Transaction)
+      })
+
+      it('should be instanceof Transaction', () => {
+        const transaction = subject()
+        expect(transaction).toBeInstanceOf(Transaction)
+      })
+
+      function subject () {
+        const driver = neo4j.driver('bolt://localhost')
+        return driver.session().beginTransaction()
+      }
+    })
+
+    describe('session.run() return', () => {
+      it('should be instanceof neo4j.Result', () => {
+        const result = subject()
+        expect(result).toBeInstanceOf(neo4j.Result)
+      })
+
+      it('should be instanceof Result', () => {
+        const result = subject()
+        expect(result).toBeInstanceOf(Result)
+      })
+
+      function subject () {
+        const driver = neo4j.driver('bolt://localhost')
+        return driver.session().run('RETURN 1')
+      }
+    })
+
+    describe('driver.rxSession() return', () => {
+      it('should be instanceof neo4j.RxSession', () => {
+        const session = subject()
+        expect(session).toBeInstanceOf(neo4j.RxSession)
+      })
+
+      it('should be instanceof RxSession', () => {
+        const session = subject()
+        expect(session).toBeInstanceOf(RxSession)
+      })
+
+      function subject () {
+        const driver = neo4j.driver('bolt://localhost')
+        return driver.rxSession()
+      }
+    })
+
+    describe('await rxRession.beginTransaction().toPromise() return', () => {
+      it('should be instanceof neo4j.RxTransaction', async () => {
+        const transaction = await subject()
+        expect(transaction).toBeInstanceOf(neo4j.RxTransaction)
+      })
+
+      it('should be instanceof RxTransaction', async () => {
+        const transaction = await subject()
+        expect(transaction).toBeInstanceOf(RxTransaction)
+      })
+
+      function subject () {
+        const driver = neo4j.driver('bolt://localhost')
+        return driver.rxSession().beginTransaction().toPromise()
+      }
+    })
+
+    describe('rxSession.run() return', () => {
+      it('should be instanceof neo4j.RxResult', async () => {
+        const result = subject()
+        expect(result).toBeInstanceOf(neo4j.RxResult)
+      })
+
+      it('should be instanceof RxResult', async () => {
+        const result = subject()
+        expect(result).toBeInstanceOf(RxResult)
+      })
+
+      function subject () {
+        const driver = neo4j.driver('bolt://localhost')
+        return driver.rxSession().run()
+      }
+    })
+  })
+})


### PR DESCRIPTION
The lack of constructor export was avoiding type checkins using `instanceof`.

The exported constructors are already present in `index.d.ts`