### PR TITLE
Keep seed router address in the pool after routing table

### DIFF
--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -535,7 +535,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
 
   async _updateRoutingTable (newRoutingTable, onDatabaseNameResolved) {
     // close old connections to servers not present in the new routing table
-    await this._connectionPool.keepAll(newRoutingTable.allServers())
+    await this._connectionPool.keepAll([...newRoutingTable.allServers(),  this._seedRouter])
     this._routingTableRegistry.removeExpired()
     this._routingTableRegistry.register(
       newRoutingTable


### PR DESCRIPTION
Forgetting the seed router was causing the connection to the seed router being recreated whenever the routing table is fetched and the seed router is not part of the cluster formation. For cases where the database name is set in the session, the driver will have to fetch the routing table for the default/home database for discovering the database name and make it consitent during the session lifetime. In this scenario, the seed router will be always used during the discovery. So, a new connection to the seed router will be created for each session.

The solution for this issue is to keep the seed router in the pool during the update routing table process. This way, the same connections for the seed router can be re-used.