### PR TITLE
Fix lack of ProtocolVersion in the `Result.summary()`

### DIFF
--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -436,7 +436,10 @@ class Result implements Promise<QueryResult> {
     const onKeysOriginal = observer.onKeys ?? DEFAULT_ON_KEYS
 
     const onCompletedWrapper = (metadata: any): void => {
-      this._createSummary(metadata).then(summary => {
+      this._releaseConnectionAndGetSummary(metadata).then(summary => {
+        if (this._summary !== null) {
+          return onCompletedOriginal.call(observer, this._summary)
+        }
         this._summary = summary
         return onCompletedOriginal.call(observer, summary)
       }).catch(onErrorOriginal)
@@ -484,7 +487,7 @@ class Result implements Promise<QueryResult> {
    * @param metadata
    * @returns
    */
-  private _createSummary (metadata: any): Promise<ResultSummary> {
+  private _releaseConnectionAndGetSummary (metadata: any): Promise<ResultSummary> {
     const {
       validatedQuery: query,
       params: parameters


### PR DESCRIPTION
When there are more than one observer subscribed to the ResultStreamObserver, the first notified observed got the summary with the protocol info because the connection holder stills holding the connection. The next observers notified won't have the protocol version since the connection holder will not have the connection in hands at the moment.

This situation is occurring during some tests where result iterator is not fully consumed and the summary is called in the meantime.

Checking for existance of the summary in the result and notifying the observer with the already created summary should solve issue since the first summary created will have the protocol version set.