### PR TITLE
Fix exported Typescript types

### DIFF
--- a/packages/neo4j-driver/test/types/export.test.ts
+++ b/packages/neo4j-driver/test/types/export.test.ts
@@ -25,7 +25,8 @@ import driver, {
   RxResult,
   Session,
   ConnectionProvider,
-  Record
+  Record,
+  types
 } from '../../'
 
 const dateTime = DateTime.fromStandardDate(new Date())
@@ -70,3 +71,16 @@ const rxTransaction: RxTransaction = dummy
 const rxResult: RxResult = dummy
 
 const record: Record = new Record(['role'], [124])
+
+dummy instanceof types.Node
+dummy instanceof types.PathSegment
+dummy instanceof types.Path
+dummy instanceof types.Relationship
+dummy instanceof types.Point
+dummy instanceof types.Date
+dummy instanceof types.DateTime
+dummy instanceof types.Duration
+dummy instanceof types.LocalDateTime
+dummy instanceof types.LocalTime
+dummy instanceof types.Time
+dummy instanceof types.Integer

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -98,11 +98,11 @@ declare function driver(
 ): Driver
 
 declare const types: {
-  Node: Node
-  Relationship: Relationship
-  UnboundRelationship: UnboundRelationship
-  PathSegment: PathSegment
-  Path: Path
+  Node: typeof Node
+  Relationship: typeof Relationship
+  UnboundRelationship: typeof UnboundRelationship
+  PathSegment: typeof PathSegment
+  Path: typeof Path
   Result: Result
   ResultSummary: ResultSummary
   Record: Record


### PR DESCRIPTION
Use `typeof` to export the correct Typescript types for the graph types exported by the driver. 