### PR TITLE
Fix exported types for result, resultsummary, and record

### DIFF
--- a/packages/neo4j-driver/test/types/export.test.ts
+++ b/packages/neo4j-driver/test/types/export.test.ts
@@ -75,6 +75,9 @@ const record: Record = new Record(['role'], [124])
 dummy instanceof types.Node
 dummy instanceof types.PathSegment
 dummy instanceof types.Path
+dummy instanceof types.Result
+dummy instanceof types.ResultSummary
+dummy instanceof types.Record
 dummy instanceof types.Relationship
 dummy instanceof types.Point
 dummy instanceof types.Date

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -103,9 +103,9 @@ declare const types: {
   UnboundRelationship: typeof UnboundRelationship
   PathSegment: typeof PathSegment
   Path: typeof Path
-  Result: Result
-  ResultSummary: ResultSummary
-  Record: Record
+  Result: typeof Result
+  ResultSummary: typeof ResultSummary
+  Record: typeof Record
   Point: typeof Point
   Duration: typeof Duration
   LocalTime: typeof LocalTime


### PR DESCRIPTION
Follow up from https://github.com/neo4j/neo4j-javascript-driver/pull/941, I just realized Result, ResultSummary, and Record are also classes and need to use the `typeof` operator to export the correct type.