### PR TITLE
[4.4] Skip timeout: connection acquisition timeout includes router handshake

### DIFF
--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -132,6 +132,12 @@ const skippedTests = [
     ifEquals(
       'stub.iteration.test_result_list.TestResultList.test_session_run_result_list_pulls_all_records_at_once_next_before_list'
     )
+  ),
+  skip(
+    "TODO: ConnectionAcquisitionTimeout cancels handshake with the router",
+    ifEquals(
+      "stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_handshake"
+    )
   )
 ]
 


### PR DESCRIPTION
Required for https://github.com/neo4j-drivers/testkit/pull/477.

See [internal ADR](https://github.com/neo-technology/drivers-adr/pull/18) for details on the agreed upon approach.