### PR TITLE
Add support for `connection.recv_timeout_seconds` in the Browser Channel

### DIFF
--- a/packages/bolt-connection/test/timers-util.js
+++ b/packages/bolt-connection/test/timers-util.js
@@ -28,6 +28,7 @@ class SetTimeoutMock {
         code()
         this.invocationDelays.push(delay)
       }
+      this.calls.push([...arguments])
       return this._timeoutIdCounter++
     }
 
@@ -59,6 +60,7 @@ class SetTimeoutMock {
     this._paused = false
     this._timeoutIdCounter = 0
 
+    this.calls = []
     this.invocationDelays = []
     this.clearedTimeouts = []
   }


### PR DESCRIPTION
The implementation of the timeout connection hint has changed. The control of when start and stop the timeout has moved to the `channel-channel` instead of relying on the socket timeout configuration.

This change enables the `browser-channel` to implement the `receive timeout` which was not possible before since the `WebSocket` doesn't have a timeout configuration.