### PR TITLE
Treat errors on handling income bolt messages

### DIFF
--- a/packages/bolt-connection/src/bolt/create.js
+++ b/packages/bolt-connection/src/bolt/create.js
@@ -70,7 +70,11 @@ export default function create ({
 
     // setup dechunker to dechunk messages and forward them to the message handler
     dechunker.onmessage = buf => {
-      responseHandler.handleResponse(protocol.unpacker().unpack(buf))
+      try {
+        responseHandler.handleResponse(protocol.unpacker().unpack(buf))
+      } catch (e) {
+        return observer.onError(e)
+      }
     }
 
     return responseHandler


### PR DESCRIPTION
Invalid income messages which could not be parsed or handled correctly where throwing exceptions in non-safe context. This leads the driver to crash hard since the error is bubble up to the socket thread.