### PR TITLE
Add support for error cause in Neo4jError and Routing errors

### DIFF
--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -520,11 +520,11 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
 
       const protocolVersion = connection.protocol().version
       if (protocolVersion < 4.0) {
-        return new Session({
+        return [new Session({
           mode: WRITE,
           bookmarks: Bookmarks.empty(),
           connectionProvider
-        })
+        }), null]
       }
 
       return [new Session({

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -41,7 +41,15 @@ const { SERVICE_UNAVAILABLE, SESSION_EXPIRED } = error
 const READ = 'READ'
 const WRITE = 'WRITE'
 
-describe('#unit RoutingConnectionProvider', () => {
+describe.each([
+  3,
+  4.0,
+  4.1,
+  4.2,
+  4.3,
+  4.4,
+  5.0
+])('#unit RoutingConnectionProvider (PROTOCOL_VERSION=%d)', (PROTOCOL_VERSION) => {
   const server0 = ServerAddress.fromUrl('server0')
   const server1 = ServerAddress.fromUrl('server1')
   const server2 = ServerAddress.fromUrl('server2')
@@ -2922,71 +2930,88 @@ describe('#unit RoutingConnectionProvider', () => {
       })
     })
   })
-})
 
-function newRoutingConnectionProvider (
-  routingTables,
-  pool = null,
-  routerToRoutingTable = { null: {} }
-) {
-  const seedRouter = ServerAddress.fromUrl('server-non-existing-seed-router')
-  return newRoutingConnectionProviderWithSeedRouter(
+  function newPool ({ create, config } = {}) {
+    const _create = (address, release) => {
+      if (create) {
+        try {
+          return Promise.resolve(create(address, release))
+        } catch (e) {
+          return Promise.reject(e)
+        }
+      }
+      return Promise.resolve(new FakeConnection(address, release, 'version', PROTOCOL_VERSION))
+    }
+    return new Pool({
+      config,
+      create: (address, release) => _create(address, release)
+    })
+  }
+
+  function newRoutingConnectionProviderWithSeedRouter (
     seedRouter,
-    [seedRouter],
+    seedRouterResolved,
     routingTables,
-    routerToRoutingTable,
-    pool
-  )
-}
+    routerToRoutingTable = { null: {} },
+    connectionPool = null,
+    routingTablePurgeDelay = null,
+    fakeRediscovery = null
+  ) {
+    const pool = connectionPool || newPool()
+    const connectionProvider = new RoutingConnectionProvider({
+      id: 0,
+      address: seedRouter,
+      routingContext: {},
+      hostNameResolver: new SimpleHostNameResolver(),
+      config: {},
+      log: Logger.noOp(),
+      routingTablePurgeDelay: routingTablePurgeDelay
+    })
+    connectionProvider._connectionPool = pool
+    routingTables.forEach(r => {
+      connectionProvider._routingTableRegistry.register(r)
+    })
+    connectionProvider._rediscovery =
+      fakeRediscovery || new FakeRediscovery(routerToRoutingTable)
+    connectionProvider._hostNameResolver = new FakeDnsResolver(seedRouterResolved)
+    connectionProvider._useSeedRouter = routingTables.every(
+      r => r.expirationTime !== Integer.ZERO
+    )
+    return connectionProvider
+  }
 
-function newRoutingConnectionProviderWithFakeRediscovery (
-  fakeRediscovery,
-  pool = null,
-  routerToRoutingTable = { null: {} }
-) {
-  const seedRouter = ServerAddress.fromUrl('server-non-existing-seed-router')
-  return newRoutingConnectionProviderWithSeedRouter(
-    seedRouter,
-    [seedRouter],
-    [],
-    routerToRoutingTable,
-    pool,
-    null,
-    fakeRediscovery
-  )
-}
+  function newRoutingConnectionProvider (
+    routingTables,
+    pool = null,
+    routerToRoutingTable = { null: {} }
+  ) {
+    const seedRouter = ServerAddress.fromUrl('server-non-existing-seed-router')
+    return newRoutingConnectionProviderWithSeedRouter(
+      seedRouter,
+      [seedRouter],
+      routingTables,
+      routerToRoutingTable,
+      pool
+    )
+  }
 
-function newRoutingConnectionProviderWithSeedRouter (
-  seedRouter,
-  seedRouterResolved,
-  routingTables,
-  routerToRoutingTable = { null: {} },
-  connectionPool = null,
-  routingTablePurgeDelay = null,
-  fakeRediscovery = null
-) {
-  const pool = connectionPool || newPool()
-  const connectionProvider = new RoutingConnectionProvider({
-    id: 0,
-    address: seedRouter,
-    routingContext: {},
-    hostNameResolver: new SimpleHostNameResolver(),
-    config: {},
-    log: Logger.noOp(),
-    routingTablePurgeDelay: routingTablePurgeDelay
-  })
-  connectionProvider._connectionPool = pool
-  routingTables.forEach(r => {
-    connectionProvider._routingTableRegistry.register(r)
-  })
-  connectionProvider._rediscovery =
-    fakeRediscovery || new FakeRediscovery(routerToRoutingTable)
-  connectionProvider._hostNameResolver = new FakeDnsResolver(seedRouterResolved)
-  connectionProvider._useSeedRouter = routingTables.every(
-    r => r.expirationTime !== Integer.ZERO
-  )
-  return connectionProvider
-}
+  function newRoutingConnectionProviderWithFakeRediscovery (
+    fakeRediscovery,
+    pool = null,
+    routerToRoutingTable = { null: {} }
+  ) {
+    const seedRouter = ServerAddress.fromUrl('server-non-existing-seed-router')
+    return newRoutingConnectionProviderWithSeedRouter(
+      seedRouter,
+      [seedRouter],
+      [],
+      routerToRoutingTable,
+      pool,
+      null,
+      fakeRediscovery
+    )
+  }
+})
 
 function newRoutingTableWithUser ({
   database,
@@ -3032,23 +3057,6 @@ function setupRoutingConnectionProviderToRememberRouters (
     return originalFetch(routerAddresses, routingTable, bookmarks)
   }
   connectionProvider._fetchRoutingTable = rememberingFetch
-}
-
-function newPool ({ create, config } = {}) {
-  const _create = (address, release) => {
-    if (create) {
-      try {
-        return Promise.resolve(create(address, release))
-      } catch (e) {
-        return Promise.reject(e)
-      }
-    }
-    return Promise.resolve(new FakeConnection(address, release, 'version', 4.0))
-  }
-  return new Pool({
-    config,
-    create: (address, release) => _create(address, release)
-  })
 }
 
 function expectRoutingTable (

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -1701,6 +1701,8 @@ describe('#unit RoutingConnectionProvider', () => {
             'Server at server-non-existing-seed-router:7687 can\'t ' +
              'perform routing. Make sure you are connecting to a causal cluster'
           )
+          // Error should be the cause of the given capturedError
+          expect(capturedError).toEqual(newError(capturedError.message, capturedError.code, error))
         }
 
         expect(completed).toBe(false)
@@ -1728,6 +1730,9 @@ describe('#unit RoutingConnectionProvider', () => {
             'Could not perform discovery. ' +
             'No routing servers available. Known routing table: '
           ))
+
+          // Error should be the cause of the given capturedError
+          expect(capturedError).toEqual(newError(capturedError.message, capturedError.code, error))
         }
 
         expect(completed).toBe(false)

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -70,8 +70,9 @@ class Neo4jError extends Error {
    * @param {string} message - the error message
    * @param {string} code - Optional error code. Will be populated when error originates in the database.
    */
-  constructor (message: string, code: Neo4jErrorCode) {
-    super(message)
+  constructor (message: string, code: Neo4jErrorCode, cause?: Error) {
+    // @ts-expect-error
+    super(message, cause != null ? { cause } : undefined)
     this.constructor = Neo4jError
     // eslint-disable-next-line no-proto
     this.__proto__ = Neo4jError.prototype
@@ -105,8 +106,8 @@ class Neo4jError extends Error {
  * @return {Neo4jError} an {@link Neo4jError}
  * @private
  */
-function newError (message: string, code?: Neo4jErrorCode): Neo4jError {
-  return new Neo4jError(message, code ?? NOT_AVAILABLE)
+function newError (message: string, code?: Neo4jErrorCode, cause?: Error): Neo4jError {
+  return new Neo4jError(message, code ?? NOT_AVAILABLE, cause)
 }
 
 /**

--- a/packages/core/test/error.test.ts
+++ b/packages/core/test/error.test.ts
@@ -26,6 +26,14 @@ import {
 } from '../src/error'
 
 describe('newError', () => {
+  let supportsCause = false
+  beforeAll(() => {
+    // @ts-expect-error
+    const error = new Error('a', { cause: new Error('a') })
+    // @ts-expect-error
+    supportsCause = error.cause != null
+  })
+
   ;[PROTOCOL_ERROR, SERVICE_UNAVAILABLE, SESSION_EXPIRED].forEach(
     expectedCode => {
       test(`should create Neo4jError for code ${expectedCode}`, () => {
@@ -42,6 +50,31 @@ describe('newError', () => {
 
     expect(error.message).toEqual('some error')
     expect(error.code).toEqual('N/A')
+  })
+
+  test('should create Neo4jErro with cause', () => {
+    const cause = new Error('cause')
+    const error: Neo4jError = newError('some error', undefined, cause)
+
+    expect(error.message).toEqual('some error')
+    expect(error.code).toEqual('N/A')
+    if (supportsCause) {
+      // @ts-expect-error
+      expect(error.cause).toBe(cause)
+    } else {
+      // @ts-expect-error
+      expect(error.cause).toBeUndefined()
+    }
+  })
+
+  test.each([null, undefined])('should create Neo4jErro without cause (%s)', (cause) => {
+    // @ts-expect-error
+    const error: Neo4jError = newError('some error', undefined, cause)
+
+    expect(error.message).toEqual('some error')
+    expect(error.code).toEqual('N/A')
+    // @ts-expect-error
+    expect(error.cause).toBeUndefined()
   })
 })
 

--- a/packages/core/test/error.test.ts
+++ b/packages/core/test/error.test.ts
@@ -67,7 +67,7 @@ describe('newError', () => {
     }
   })
 
-  test.each([null, undefined])('should create Neo4jErro without cause (%s)', (cause) => {
+  test.each([null, undefined])('should create Neo4jError without cause (%s)', (cause) => {
     // @ts-expect-error
     const error: Neo4jError = newError('some error', undefined, cause)
 


### PR DESCRIPTION
Root causes of routing issue were suppressed by the routing error message.

This change enables the `Neo4jError` object use the `cause` property for giving more context about the error. This
also improves the routing error by making use of the error `cause`.

`Error.cause` is a new feature in JS, see which runtime already implemented it:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error