### PR TITLE
Introduce `sessionConnectionTimeout` and `updateRoutingTableTimeout` (#966)

### DIFF
--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -19,7 +19,7 @@
 
 import { createChannelConnection, ConnectionErrorHandler } from '../connection'
 import Pool, { PoolConfig } from '../pool'
-import { error, ConnectionProvider } from 'neo4j-driver-core'
+import { error, newError, ConnectionProvider } from 'neo4j-driver-core'
 
 const { SERVICE_UNAVAILABLE } = error
 export default class PooledConnectionProvider extends ConnectionProvider {
@@ -58,6 +58,12 @@ export default class PooledConnectionProvider extends ConnectionProvider {
       log: this._log
     })
     this._openConnections = {}
+    this._sessionConnectionTimeoutConfig = {
+      timeout: this._config.sessionConnectionTimeout,
+      reason: () => newError(
+        `Session acquisition timed out in ${this._config.sessionConnectionTimeout} ms.`
+      )
+    }
   }
 
   _createConnectionErrorHandler () {

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -23,6 +23,7 @@ import { HostNameResolver } from '../channel'
 import SingleConnectionProvider from './connection-provider-single'
 import PooledConnectionProvider from './connection-provider-pooled'
 import { LeastConnectedLoadBalancingStrategy } from '../load-balancing'
+import { controller } from '../lang'
 import {
   createChannelConnection,
   ConnectionErrorHandler,
@@ -69,6 +70,13 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         this._routingContext
       )
     })
+
+    this._updateRoutingTableTimeoutConfig = {
+      timeout: this._config.updateRoutingTableTimeout,
+      reason: () => newError(
+        `Routing table update timed out in ${this._config.updateRoutingTableTimeout} ms.`
+      )
+    }
 
     this._routingContext = { ...routingContext, address: address.toString() }
     this._seedRouter = address
@@ -137,53 +145,66 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         this._handleAuthorizationExpired(error, address, context.database)
     )
 
-    const routingTable = await this._freshRoutingTable({
-      accessMode,
-      database: context.database,
-      bookmark: bookmarks,
-      impersonatedUser,
-      onDatabaseNameResolved: (databaseName) => {
-        context.database = context.database || databaseName
-        if (onDatabaseNameResolved) {
-          onDatabaseNameResolved(databaseName)
+    const refreshRoutingTableJob = {
+      run: async (_, cancelationToken) => {
+        const routingTable = await this._freshRoutingTable({
+          accessMode,
+          database: context.database,
+          bookmarks: bookmarks,
+          impersonatedUser,
+          onDatabaseNameResolved: (databaseName) => {
+            context.database = context.database || databaseName
+            if (onDatabaseNameResolved) {
+              onDatabaseNameResolved(databaseName)
+            }
+          },
+          cancelationToken
+        })
+
+        // select a target server based on specified access mode
+        if (accessMode === READ) {
+          address = this._loadBalancingStrategy.selectReader(routingTable.readers)
+          name = 'read'
+        } else if (accessMode === WRITE) {
+          address = this._loadBalancingStrategy.selectWriter(routingTable.writers)
+          name = 'write'
+        } else {
+          throw newError('Illegal mode ' + accessMode)
         }
+
+        // we couldn't select a target server
+        if (!address) {
+          throw newError(
+            `Failed to obtain connection towards ${name} server. Known routing table is: ${routingTable}`,
+            SESSION_EXPIRED
+          )
+        }
+        return { routingTable, address }
       }
-    })
-
-    // select a target server based on specified access mode
-    if (accessMode === READ) {
-      address = this._loadBalancingStrategy.selectReader(routingTable.readers)
-      name = 'read'
-    } else if (accessMode === WRITE) {
-      address = this._loadBalancingStrategy.selectWriter(routingTable.writers)
-      name = 'write'
-    } else {
-      throw newError('Illegal mode ' + accessMode)
     }
 
-    // we couldn't select a target server
-    if (!address) {
-      throw newError(
-        `Failed to obtain connection towards ${name} server. Known routing table is: ${routingTable}`,
-        SESSION_EXPIRED
-      )
+    const acquireConnectionJob = {
+      run: async ({ routingTable, address }) => {
+        try {
+          const connection = await this._acquireConnectionToServer(
+            address,
+            name,
+            routingTable
+          )
+
+          return new DelegateConnection(connection, databaseSpecificErrorHandler)
+        } catch (error) {
+          const transformed = databaseSpecificErrorHandler.handleAndTransformError(
+            error,
+            address
+          )
+          throw transformed
+        }
+      },
+      onTimeout: connection => connection._release()
     }
 
-    try {
-      const connection = await this._acquireConnectionToServer(
-        address,
-        name,
-        routingTable
-      )
-
-      return new DelegateConnection(connection, databaseSpecificErrorHandler)
-    } catch (error) {
-      const transformed = databaseSpecificErrorHandler.handleAndTransformError(
-        error,
-        address
-      )
-      throw transformed
-    }
+    return controller.runWithTimeout(this._sessionConnectionTimeoutConfig, refreshRoutingTableJob, acquireConnectionJob)
   }
 
   async _hasProtocolVersion (versionPredicate) {
@@ -259,48 +280,57 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     return this._connectionPool.acquire(address)
   }
 
-  _freshRoutingTable ({ accessMode, database, bookmark, impersonatedUser, onDatabaseNameResolved } = {}) {
-    const currentRoutingTable = this._routingTableRegistry.get(
-      database,
-      () => new RoutingTable({ database })
-    )
+  _freshRoutingTable ({ accessMode, database, bookmarks, impersonatedUser, onDatabaseNameResolved, cancelationToken = new controller.CancelationToken(() => false) } = {}) {
+    const refreshRoutingTableJob = {
+      run: (_, refreshCancelationToken) => {
+        const combinedCancelationToken = refreshCancelationToken.combine(cancelationToken)
+        const currentRoutingTable = this._routingTableRegistry.get(
+          database,
+          () => new RoutingTable({ database })
+        )
 
-    if (!currentRoutingTable.isStaleFor(accessMode)) {
-      return currentRoutingTable
+        if (!currentRoutingTable.isStaleFor(accessMode)) {
+          return currentRoutingTable
+        }
+        this._log.info(
+          `Routing table is stale for database: "${database}" and access mode: "${accessMode}": ${currentRoutingTable}`
+        )
+        return this._refreshRoutingTable(currentRoutingTable, bookmarks, impersonatedUser, onDatabaseNameResolved, combinedCancelationToken)
+      }
     }
-    this._log.info(
-      `Routing table is stale for database: "${database}" and access mode: "${accessMode}": ${currentRoutingTable}`
-    )
-    return this._refreshRoutingTable(currentRoutingTable, bookmark, impersonatedUser, onDatabaseNameResolved)
+    return controller.runWithTimeout(this._updateRoutingTableTimeoutConfig, refreshRoutingTableJob)
   }
 
-  _refreshRoutingTable (currentRoutingTable, bookmark, impersonatedUser, onDatabaseNameResolved) {
+  _refreshRoutingTable (currentRoutingTable, bookmarks, impersonatedUser, onDatabaseNameResolved, cancelationToken) {
     const knownRouters = currentRoutingTable.routers
 
     if (this._useSeedRouter) {
       return this._fetchRoutingTableFromSeedRouterFallbackToKnownRouters(
         knownRouters,
         currentRoutingTable,
-        bookmark,
+        bookmarks,
         impersonatedUser,
-        onDatabaseNameResolved
+        onDatabaseNameResolved,
+        cancelationToken
       )
     }
     return this._fetchRoutingTableFromKnownRoutersFallbackToSeedRouter(
       knownRouters,
       currentRoutingTable,
-      bookmark,
+      bookmarks,
       impersonatedUser,
-      onDatabaseNameResolved
+      onDatabaseNameResolved,
+      cancelationToken
     )
   }
 
   async _fetchRoutingTableFromSeedRouterFallbackToKnownRouters (
     knownRouters,
     currentRoutingTable,
-    bookmark,
+    bookmarks,
     impersonatedUser,
-    onDatabaseNameResolved
+    onDatabaseNameResolved,
+    cancelationToken
   ) {
     // we start with seed router, no routers were probed before
     const seenRouters = []
@@ -308,8 +338,9 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
       seenRouters,
       this._seedRouter,
       currentRoutingTable,
-      bookmark,
-      impersonatedUser
+      bookmarks,
+      impersonatedUser,
+      cancelationToken
     )
 
     if (newRoutingTable) {
@@ -319,8 +350,9 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
       newRoutingTable = await this._fetchRoutingTableUsingKnownRouters(
         knownRouters,
         currentRoutingTable,
-        bookmark,
-        impersonatedUser
+        bookmarks,
+        impersonatedUser,
+        cancelationToken
       )
     }
 
@@ -334,15 +366,17 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
   async _fetchRoutingTableFromKnownRoutersFallbackToSeedRouter (
     knownRouters,
     currentRoutingTable,
-    bookmark,
+    bookmarks,
     impersonatedUser,
-    onDatabaseNameResolved
+    onDatabaseNameResolved,
+    cancelationToken
   ) {
     let newRoutingTable = await this._fetchRoutingTableUsingKnownRouters(
       knownRouters,
       currentRoutingTable,
-      bookmark,
-      impersonatedUser
+      bookmarks,
+      impersonatedUser,
+      cancelationToken
     )
 
     if (!newRoutingTable) {
@@ -351,8 +385,9 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         knownRouters,
         this._seedRouter,
         currentRoutingTable,
-        bookmark,
-        impersonatedUser
+        bookmarks,
+        impersonatedUser,
+        cancelationToken
       )
     }
 
@@ -366,14 +401,16 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
   async _fetchRoutingTableUsingKnownRouters (
     knownRouters,
     currentRoutingTable,
-    bookmark,
-    impersonatedUser
+    bookmarks,
+    impersonatedUser,
+    cancelationToken
   ) {
     const newRoutingTable = await this._fetchRoutingTable(
       knownRouters,
       currentRoutingTable,
-      bookmark,
-      impersonatedUser
+      bookmarks,
+      impersonatedUser,
+      cancelationToken
     )
 
     if (newRoutingTable) {
@@ -397,17 +434,20 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     seenRouters,
     seedRouter,
     routingTable,
-    bookmark,
-    impersonatedUser
+    bookmarks,
+    impersonatedUser,
+    cancelationToken
   ) {
     const resolvedAddresses = await this._resolveSeedRouter(seedRouter)
+
+    cancelationToken.throwIfCancellationRequested()
 
     // filter out all addresses that we've already tried
     const newAddresses = resolvedAddresses.filter(
       address => seenRouters.indexOf(address) < 0
     )
 
-    return await this._fetchRoutingTable(newAddresses, routingTable, bookmark, impersonatedUser)
+    return await this._fetchRoutingTable(newAddresses, routingTable, bookmarks, impersonatedUser, cancelationToken)
   }
 
   async _resolveSeedRouter (seedRouter) {
@@ -419,7 +459,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     return [].concat.apply([], dnsResolvedAddresses)
   }
 
-  _fetchRoutingTable (routerAddresses, routingTable, bookmark, impersonatedUser) {
+  async _fetchRoutingTable (routerAddresses, routingTable, bookmarks, impersonatedUser, cancelationToken) {
     return routerAddresses.reduce(
       async (refreshedTablePromise, currentRouter, currentIndex) => {
         const newRoutingTable = await refreshedTablePromise
@@ -441,7 +481,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         // try next router
         const session = await this._createSessionForRediscovery(
           currentRouter,
-          bookmark,
+          bookmarks,
           impersonatedUser
         )
         if (session) {
@@ -453,6 +493,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
               impersonatedUser
             )
           } catch (error) {
+            cancelationToken.throwIfCancellationRequested()
             if (error && error.code === DATABASE_NOT_FOUND_ERROR_CODE) {
               // not finding the target database is a sign of a configuration issue
               throw error
@@ -462,9 +503,10 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
             )
             return null
           } finally {
-            session.close()
+            await session.close()
           }
         } else {
+          cancelationToken.throwIfCancellationRequested()
           // unable to acquire connection and create session towards the current router
           // return null to signal that the next router should be tried
           return null

--- a/packages/bolt-connection/src/lang/controller.js
+++ b/packages/bolt-connection/src/lang/controller.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The cancel operation error
+ */
+export class OperationCanceledError extends Error {
+  constructor () {
+    super()
+    this.name = OperationCanceledError.name
+  }
+}
+
+/**
+ * The CancelationToken used by `runWithTimeout` for cancel an working job.
+ */
+export class CancelationToken {
+  constructor (getCancelationRequested) {
+    this._getCancelationRequested = getCancelationRequested
+    Object.freeze(this)
+  }
+
+  /**
+   * If it receive a cancelation request
+   */
+  get isCancelationRequested () {
+    return this._getCancelationRequested()
+  }
+
+  /**
+   * Combine two cancelations token in one.
+   *
+   * The new cancelation token will be canceled if one of the
+   * token get canceled.
+   *
+   * @param {CancelationToken} cancelationToken The other cancelation token
+   * @returns {CancelationToken} Combined cancelation toke
+   */
+  combine (cancelationToken) {
+    return new CancelationToken(() =>
+      this.isCancelationRequested === true || cancelationToken.isCancelationRequested === true)
+  }
+
+  /**
+   *
+   * @param {Error} [error] the error to be thrown. Be default: OperationCanceledError will be thrown
+   * @throws {OperationCanceledError|Error} if a cancelation request was done
+   * @returns {void}
+   */
+  throwIfCancellationRequested (error) {
+    if (this.isCancelationRequested) {
+      if (error != null) {
+        throw error
+      }
+      throw new OperationCanceledError()
+    }
+  }
+}
+
+/**
+ * @typedef {Object} Job
+ * @property {function(any, CancelationToken)} run method called for run the job
+ * @property {function(any)} [onTimeout] method called after job finished and the controller has timeout.
+ *                Useful for cleanups.
+ */
+/**
+ * @param {any} param0
+ * @param {number} param0.timeout The timeout time
+ * @param {Error} param0.reason The reason for the timeout
+ * @param  {...Job} jobs The jobs to be run in sequence
+ * @returns {Promise} The result of all the jobs or a timeout failure
+ */
+export function runWithTimeout ({ timeout, reason }, ...jobs) {
+  const status = { timedout: false }
+  const cancelationToken = new CancelationToken(() => status.timedout)
+  async function _run (currentValue, { resolve, reject }, myJobs) {
+    const [{ run, onTimeout = () => Promise.resolve() }, ...otherJobs] = myJobs
+    try {
+      const value = await run(currentValue, cancelationToken)
+      if (status.timedout) {
+        await onTimeout(value).catch(() => {})
+      } else if (otherJobs.length === 0) {
+        resolve(value)
+      } else {
+        await _run(value, { resolve, reject }, otherJobs)
+      }
+    } catch (e) {
+      if (!status.timedout) {
+        reject(e)
+      }
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    if (timeout != null) {
+      status.timeoutHandle = setTimeout(() => {
+        status.timedout = true
+        reject(reason())
+      }, timeout)
+    }
+
+    _run(undefined, { resolve, reject }, jobs)
+      .finally(() => {
+        if (status.timeoutHandle != null) {
+          clearTimeout(status.timeoutHandle)
+        }
+      })
+  })
+}

--- a/packages/bolt-connection/src/lang/index.js
+++ b/packages/bolt-connection/src/lang/index.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * as controller from './controller'

--- a/packages/bolt-connection/test/test-utils.js
+++ b/packages/bolt-connection/test/test-utils.js
@@ -134,11 +134,16 @@ function spyProtocolWrite (protocol, callRealMethod = false) {
   return protocol
 }
 
+function wait (time) {
+  return new Promise((resolve) => setTimeout(resolve, time))
+}
+
 export default {
   isClient,
   isServer,
   fakeStandardDateWithOffset,
   matchers,
   MessageRecordingConnection,
-  spyProtocolWrite
+  spyProtocolWrite,
+  wait
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,6 +58,8 @@ export interface Config {
   maxTransactionRetryTime?: number
   maxConnectionLifetime?: number
   connectionAcquisitionTimeout?: number
+  sessionConnectionTimeout?: number
+  updateRoutingTableTimeout?: number
   connectionTimeout?: number
   disableLosslessIntegers?: boolean
   useBigInt?: boolean

--- a/packages/core/test/driver.test.ts
+++ b/packages/core/test/driver.test.ts
@@ -143,7 +143,7 @@ describe('Driver', () => {
         connectionAcquisitionTimeout: 60000,
         fetchSize: 1000,
         maxConnectionLifetime: 3600000,
-        maxConnectionPoolSize: 100,
+        maxConnectionPoolSize: 100
       },
       connectionProvider,
       database: '',

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -148,6 +148,19 @@ const {
  *       // connection or borrow an existing one.
  *       connectionAcquisitionTimeout: 60000, // 1 minute
  *
+ *       // The maximum amout of time for a session to wait to acquire an usable connection. This encompasses *everything*
+ *       // that needs to happen for this, including, if necessary, updating the routing table<, acquiring a connection
+ *       // from the pool, and, if necessary performing a BOLT and Authentication handshake with the reader/writer.
+ *       // Since this can include updating the routing table, it is recommended to keep this bigger than `updateRoutingTableTimeout`.
+ *       sessionConnectionTimeout: null, // Disabled for not breaking compatibility. Recommended: 120000 ms
+ *
+ *       // the maximum amount of time the driver will attempt to fetch a new routing table. This encompasses *everything*
+ *       // that needs to happen for this, including fetching connections from the pool, performing handshakes,
+ *       // and requesting and receiving a fresh routing table.
+ *       // Since this includes acquiring a connection from the pool plus an extra round-trip for fetching the routing table,
+ *       // it is recommended to keep this bigger than `connectionAcquisitionTimeout`.
+ *       updateRoutingTableTimeout: null, // Disabled for not breaking compatibility. Recommended: 90000 ms
+ *
  *       // Specify the maximum time in milliseconds transactions are allowed to retry via
  *       // `Session#readTransaction()` and `Session#writeTransaction()` functions.
  *       // These functions will retry the given unit of work on `ServiceUnavailable`, `SessionExpired` and transient

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -134,6 +134,19 @@ const {
  *       // connection or borrow an existing one.
  *       connectionAcquisitionTimeout: 60000, // 1 minute
  *
+ *       // The maximum amout of time for a session to wait to acquire an usable connection. This encompasses *everything*
+ *       // that needs to happen for this, including, if necessary, updating the routing table<, acquiring a connection
+ *       // from the pool, and, if necessary performing a BOLT and Authentication handshake with the reader/writer.
+ *       // Since this can include updating the routing table, it is recommended to keep this bigger than `updateRoutingTableTimeout`.
+ *       sessionConnectionTimeout: null, // Disabled for not breaking compatibility. Recommended: 120000 ms
+ *
+ *       // the maximum amount of time the driver will attempt to fetch a new routing table. This encompasses *everything*
+ *       // that needs to happen for this, including fetching connections from the pool, performing handshakes,
+ *       // and requesting and receiving a fresh routing table.
+ *       // Since this includes acquiring a connection from the pool plus an extra round-trip for fetching the routing table,
+ *       // it is recommended to keep this bigger than `connectionAcquisitionTimeout`.
+ *       updateRoutingTableTimeout: null, // Disabled for not breaking compatibility. Recommended: 90000 ms
+ *
  *       // Specify the maximum time in milliseconds transactions are allowed to retry via
  *       // `Session#readTransaction()` and `Session#writeTransaction()` functions.
  *       // These functions will retry the given unit of work on `ServiceUnavailable`, `SessionExpired` and transient

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -81,6 +81,12 @@ export function NewDriver (context, data, wire) {
   if ('connectionAcquisitionTimeoutMs' in data) {
     config.connectionAcquisitionTimeout = data.connectionAcquisitionTimeoutMs
   }
+  if ('sessionConnectionTimeoutMs' in data) {
+    config.sessionConnectionTimeout = data.sessionConnectionTimeoutMs
+  }
+  if ('updateRoutingTableTimeoutMs' in data) {
+    config.updateRoutingTableTimeout = data.updateRoutingTableTimeoutMs
+  }
   if ('fetchSize' in data) {
     config.fetchSize = data.fetchSize
   }
@@ -344,6 +350,8 @@ export function GetFeatures (_context, _params, wire) {
       'Feature:Bolt:4.4',
       'Feature:API:Result.List',
       'Detail:ResultStreamWorksAfterBrokenRecord',
+      'Feature:API:SessionConnectionTimeout',
+      'Feature:API:UpdateRoutingTableTimeout',
       ...SUPPORTED_TLS
     ]
   })

--- a/packages/testkit-backend/src/skipped-tests/browser.js
+++ b/packages/testkit-backend/src/skipped-tests/browser.js
@@ -1,6 +1,12 @@
 import skip, { ifEndsWith, ifEquals, ifStartsWith } from './skip'
 const skippedTests = [
   skip(
+    'Flacky in testkit',
+    ifStartsWith('stub.driver_parameters.test_update_routing_table_timeout_ms'),
+    ifStartsWith('stub.driver_parameters.test_session_connection_timeout'),
+    ifStartsWith('stub.driver_parameters.test_max_connection_pool_size.TestMaxConnectionPoolSize.test_connection_pool_maxes_out_at_100_by_default')
+  ),
+  skip(
     "Browser doesn't support socket timeouts",
     ifStartsWith('stub.configuration_hints.test_connection_recv_timeout_seconds')
   ),


### PR DESCRIPTION
`sessionConnnectionTimeout` is the maximum amount of time the session will wait when trying to establish a usable read/write connection to the remote host. This encompasses *everything* that needs to happen for this, including, if necessary, updating the routing table<sup>1</sup>, fetching a connection from the pool, and, if necessary performing a BOLT and Authentication handshake with the reader/writer.

`updateRoutingTableTimeout` is the maximum amount of time the driver will attempt to fetch a new routing table. This encompasses *everything* that needs to happen for this, including fetching connections from the pool, performing handshakes, and requesting and receiving a fresh routing table.

<sup>1</sup>Updating the routing table in turn might also require fetching a connection for the pool and performing the handshakes, plus potentially trying other routers.