### PR TITLE
Implemented typesafe parameters

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -27,7 +27,7 @@ import { TransactionExecutor } from './internal/transaction-executor'
 import { Bookmark } from './internal/bookmark'
 import { TxConfig } from './internal/tx-config'
 import ConnectionProvider from './connection-provider'
-import { Query, SessionMode } from './types'
+import { Parameters, Query, SessionMode } from './types'
 import Connection from './connection'
 import { NumberOrInteger } from './graph-types'
 
@@ -136,7 +136,7 @@ class Session {
    */
   run(
     query: Query,
-    parameters?: any,
+    parameters?: Parameters,
     transactionConfig?: TransactionConfig
   ): Result {
     const { validatedQuery, params } = validateQueryAndParameters(

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -34,7 +34,7 @@ import {
 
 import { newError } from './error'
 import Result from './result'
-import { Query } from './types'
+import { Parameters, Query } from './types'
 
 /**
  * Represents a transaction in the Neo4j database.
@@ -131,7 +131,7 @@ class Transaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run(query: Query, parameters?: any): Result {
+  run(query: Query, parameters?: Parameters): Result {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,12 +40,20 @@ export type TrustStrategy =
   | 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES'
   | 'TRUST_SYSTEM_CA_SIGNED_CERTIFICATES'
 
-export type Primitives = string | number | boolean
+  export type Primitives =
+  | string
+  | number
+  | boolean
+  | Array<Primitives>
 
-export type Parameters = Record<
+export type PrimitiveInner = Record<
   string,
-  Primitives | Record<string, Primitives>
+  | Primitives
+  | Array<PrimitiveInner>
+  | Record<string, Primitives | Array<PrimitiveInner>>
 >
+
+export type Parameters = PrimitiveInner
   
 export interface AuthToken {
   scheme: string

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,7 +40,13 @@ export type TrustStrategy =
   | 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES'
   | 'TRUST_SYSTEM_CA_SIGNED_CERTIFICATES'
 
-export type Parameters = { [key: string]: any }
+export type Primitives = string | number | boolean
+
+export type Parameters = Record<
+  string,
+  Primitives | Record<string, Primitives>
+>
+  
 export interface AuthToken {
   scheme: string
   principal: string


### PR DESCRIPTION
Query Parameters will be type safe with two layers of nesting.

```ts
let parameters = {
  a: 5, // will work
  b: {
   c: 5, // will work
   d: {} // won't work
  }
}
```

Not entirely sure if this covers all the use cases, for now the primitive types that are allowed are `string` | `number` | `boolean` and `Array<string | number | boolean>` however I'd be glad to make this fully work.
