### PR TITLE
Improve purge address of the Pool routine

### DIFF
--- a/packages/bolt-connection/src/pool/pool.js
+++ b/packages/bolt-connection/src/pool/pool.js
@@ -292,16 +292,18 @@ class Pool {
 
   async _purgeKey (key) {
     const pool = this._pools[key]
+    const destructionList = []
     if (pool) {
       while (pool.length) {
         const resource = pool.pop()
         if (this._removeIdleObserver) {
           this._removeIdleObserver(resource)
         }
-        await this._destroy(resource)
+        destructionList.push(this._destroy(resource))
       }
       pool.close()
       delete this._pools[key]
+      await Promise.all(destructionList)
     }
   }
 

--- a/packages/neo4j-driver/test/temporal-types.test.js
+++ b/packages/neo4j-driver/test/temporal-types.test.js
@@ -354,7 +354,7 @@ describe('#integration temporal-types', () => {
     await testSendAndReceiveRandomTemporalValues(() => randomLocalDateTime())
   }, 60000)
 
-  it('should send and receive random LocalDateTime', async () => {
+  it('should send and receive array of random LocalDateTime', async () => {
     if (neo4jDoesNotSupportTemporalTypes()) {
       return
     }


### PR DESCRIPTION
In Browser environments, the WebSocket release can take seconds to finish. This behaviour can make LDAP authentication expired take more time than usual.

Purging the connection in parallel speeds up this process.