### PR TITLE
Add generics and type mapping to Result, Session.run and Transaction.run

### DIFF
--- a/packages/core/src/record.ts
+++ b/packages/core/src/record.ts
@@ -243,3 +243,4 @@ class Record<
 }
 
 export default Record
+export type { Dict }

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -65,7 +65,7 @@ interface QueryResult<Entries extends Dict = Dict> {
  * Interface to observe updates on the Result which is being produced.
  *
  */
-interface ResultObserver {
+interface ResultObserver<Entries=Dict> {
   /**
    * Receive the keys present on the record whenever this information is available
    *
@@ -77,7 +77,7 @@ interface ResultObserver {
    * Receive the each record present on the {@link @Result}
    * @param {Record} record The {@link Record} produced
    */
-  onNext?: (record: Record) => void
+  onNext?: (record: Record<Entries>) => void
 
   /**
    * Called when the result is fully received
@@ -391,7 +391,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @param {function(error: {message:string, code:string})} observer.onError - handle errors.
    * @return {void}
    */
-  subscribe (observer: ResultObserver): void {
+  subscribe (observer: ResultObserver<Entries>): void {
     this._subscribe(observer)
       .catch(() => {})
   }

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -56,8 +56,8 @@ const DEFAULT_ON_KEYS = (keys: string[]): void => {}
  * The query result is the combination of the {@link ResultSummary} and
  * the array {@link Record[]} produced by the query
  */
-interface QueryResult<Entries extends Dict = Dict> {
-  records: Array<Record<Entries>>
+interface QueryResult<RecordShape extends Dict = Dict> {
+  records: Array<Record<RecordShape>>
   summary: ResultSummary
 }
 
@@ -65,7 +65,7 @@ interface QueryResult<Entries extends Dict = Dict> {
  * Interface to observe updates on the Result which is being produced.
  *
  */
-interface ResultObserver<Entries=Dict> {
+interface ResultObserver<RecordShape extends Dict =Dict> {
   /**
    * Receive the keys present on the record whenever this information is available
    *
@@ -77,7 +77,7 @@ interface ResultObserver<Entries=Dict> {
    * Receive the each record present on the {@link @Result}
    * @param {Record} record The {@link Record} produced
    */
-  onNext?: (record: Record<Entries>) => void
+  onNext?: (record: Record<RecordShape>) => void
 
   /**
    * Called when the result is fully received
@@ -111,7 +111,7 @@ interface QueuedResultObserver extends ResultObserver {
  * Alternatively can be consumed lazily using {@link Result#subscribe} function.
  * @access public
  */
-class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries>> {
+class Result<RecordShape extends Dict = Dict> implements Promise<QueryResult<RecordShape>> {
   private readonly _stack: string | null
   private readonly _streamObserverPromise: Promise<observer.ResultStreamObserver>
   private _p: Promise<QueryResult> | null
@@ -212,7 +212,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @private
    * @return {Promise} new Promise.
    */
-  private _getOrCreatePromise (): Promise<QueryResult<Entries>> {
+  private _getOrCreatePromise (): Promise<QueryResult<RecordShape>> {
     if (this._p == null) {
       this._p = new Promise((resolve, reject) => {
         const records: Record[] = []
@@ -240,9 +240,9 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * *Should not be combined with {@link Result#subscribe} or ${@link Result#then} functions.*
    *
    * @public
-   * @returns {PeekableAsyncIterator<Record<Entries>, ResultSummary>} The async iterator for the Results
+   * @returns {PeekableAsyncIterator<Record<RecordShape>, ResultSummary>} The async iterator for the Results
    */
-  [Symbol.asyncIterator] (): PeekableAsyncIterator<Record<Entries>, ResultSummary> {
+  [Symbol.asyncIterator] (): PeekableAsyncIterator<Record<RecordShape>, ResultSummary> {
     if (!this.isOpen()) {
       const error = newError('Result is already consumed')
       return {
@@ -345,9 +345,9 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @param {function(error: {message:string, code:string})} onRejected - function to be called upon errors.
    * @return {Promise} promise.
    */
-  then<TResult1 = QueryResult<Entries>, TResult2 = never>(
+  then<TResult1 = QueryResult<RecordShape>, TResult2 = never>(
     onFulfilled?:
-    | ((value: QueryResult<Entries>) => TResult1 | PromiseLike<TResult1>)
+    | ((value: QueryResult<RecordShape>) => TResult1 | PromiseLike<TResult1>)
     | null,
     onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
   ): Promise<TResult1 | TResult2> {
@@ -364,7 +364,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    */
   catch <TResult = never>(
     onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
-  ): Promise<QueryResult<Entries> | TResult> {
+  ): Promise<QueryResult<RecordShape> | TResult> {
     return this._getOrCreatePromise().catch(onRejected)
   }
 
@@ -376,7 +376,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @return {Promise} promise.
    */
   [Symbol.toStringTag]: string
-  finally (onfinally?: (() => void) | null): Promise<QueryResult<Entries>> {
+  finally (onfinally?: (() => void) | null): Promise<QueryResult<RecordShape>> {
     return this._getOrCreatePromise().finally(onfinally)
   }
 
@@ -391,7 +391,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @param {function(error: {message:string, code:string})} observer.onError - handle errors.
    * @return {void}
    */
-  subscribe (observer: ResultObserver<Entries>): void {
+  subscribe (observer: ResultObserver<RecordShape>): void {
     this._subscribe(observer)
       .catch(() => {})
   }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -36,6 +36,7 @@ import { NumberOrInteger } from './graph-types'
 import TransactionPromise from './transaction-promise'
 import ManagedTransaction from './transaction-managed'
 import BookmarkManager from './bookmark-manager'
+import { Dict } from './record'
 
 type ConnectionConsumer = (connection: Connection | null) => any | undefined | Promise<any> | Promise<undefined>
 type TransactionWork<T> = (tx: Transaction) => Promise<T> | T
@@ -154,11 +155,11 @@ class Session {
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
    * @return {Result} New Result.
    */
-  run (
+  run<Entries = Dict> (
     query: Query,
     parameters?: any,
     transactionConfig?: TransactionConfig
-  ): Result {
+  ): Result<Entries> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -155,11 +155,11 @@ class Session {
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
    * @return {Result} New Result.
    */
-  run<Entries = Dict> (
+  run<RecordShape extends Dict = Dict> (
     query: Query,
     parameters?: any,
     transactionConfig?: TransactionConfig
-  ): Result<Entries> {
+  ): Result<RecordShape> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/core/src/transaction-managed.ts
+++ b/packages/core/src/transaction-managed.ts
@@ -61,7 +61,7 @@ class ManagedTransaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run<Entries=Dict> (query: Query, parameters?: any): Result<Entries> {
+  run<RecordShape extends Dict =Dict> (query: Query, parameters?: any): Result<RecordShape> {
     return this._run(query, parameters)
   }
 }

--- a/packages/core/src/transaction-managed.ts
+++ b/packages/core/src/transaction-managed.ts
@@ -20,6 +20,7 @@
 import Result from './result'
 import Transaction from './transaction'
 import { Query } from './types'
+import { Dict } from './record'
 
 type Run = (query: Query, parameters?: any) => Result
 
@@ -60,7 +61,7 @@ class ManagedTransaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run (query: Query, parameters?: any): Result {
+  run<Entries=Dict> (query: Query, parameters?: any): Result<Entries> {
     return this._run(query, parameters)
   }
 }

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -175,7 +175,7 @@ class Transaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run<Entries = Dict> (query: Query, parameters?: any): Result<Entries> {
+  run<RecordShape extends Dict = Dict> (query: Query, parameters?: any): Result<RecordShape> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -37,6 +37,7 @@ import {
 import { newError } from './error'
 import Result from './result'
 import { Query } from './types'
+import { Dict } from './record'
 
 /**
  * Represents a transaction in the Neo4j database.
@@ -109,7 +110,7 @@ class Transaction {
     this._lowRecordWatermak = lowRecordWatermark
     this._highRecordWatermark = highRecordWatermark
     this._bookmarks = Bookmarks.empty()
-    this._acceptActive = () => { } // satisfy DenoJS 
+    this._acceptActive = () => { } // satisfy DenoJS
     this._activePromise = new Promise((resolve, reject) => {
       this._acceptActive = resolve
     })
@@ -174,7 +175,7 @@ class Transaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run (query: Query, parameters?: any): Result {
+  run<Entries = Dict> (query: Query, parameters?: any): Result<Entries> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/neo4j-driver-deno/lib/core/record.ts
+++ b/packages/neo4j-driver-deno/lib/core/record.ts
@@ -243,3 +243,4 @@ class Record<
 }
 
 export default Record
+export type { Dict }

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -65,7 +65,7 @@ interface QueryResult<Entries extends Dict = Dict> {
  * Interface to observe updates on the Result which is being produced.
  *
  */
-interface ResultObserver {
+interface ResultObserver<Entries=Dict> {
   /**
    * Receive the keys present on the record whenever this information is available
    *
@@ -77,7 +77,7 @@ interface ResultObserver {
    * Receive the each record present on the {@link @Result}
    * @param {Record} record The {@link Record} produced
    */
-  onNext?: (record: Record) => void
+  onNext?: (record: Record<Entries>) => void
 
   /**
    * Called when the result is fully received
@@ -391,7 +391,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @param {function(error: {message:string, code:string})} observer.onError - handle errors.
    * @return {void}
    */
-  subscribe (observer: ResultObserver): void {
+  subscribe (observer: ResultObserver<Entries>): void {
     this._subscribe(observer)
       .catch(() => {})
   }

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -20,7 +20,7 @@
 /* eslint-disable @typescript-eslint/promise-function-async */
 
 import ResultSummary from './result-summary.ts'
-import Record from './record.ts'
+import Record, { Dict } from './record.ts'
 import { Query, PeekableAsyncIterator } from './types.ts'
 import { observer, util, connectionHolder } from './internal/index.ts'
 import { newError, PROTOCOL_ERROR } from './error.ts'
@@ -56,8 +56,8 @@ const DEFAULT_ON_KEYS = (keys: string[]): void => {}
  * The query result is the combination of the {@link ResultSummary} and
  * the array {@link Record[]} produced by the query
  */
-interface QueryResult {
-  records: Record[]
+interface QueryResult<Entries extends Dict = Dict> {
+  records: Array<Record<Entries>>
   summary: ResultSummary
 }
 
@@ -111,7 +111,7 @@ interface QueuedResultObserver extends ResultObserver {
  * Alternatively can be consumed lazily using {@link Result#subscribe} function.
  * @access public
  */
-class Result implements Promise<QueryResult> {
+class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries>> {
   private readonly _stack: string | null
   private readonly _streamObserverPromise: Promise<observer.ResultStreamObserver>
   private _p: Promise<QueryResult> | null
@@ -212,7 +212,7 @@ class Result implements Promise<QueryResult> {
    * @private
    * @return {Promise} new Promise.
    */
-  private _getOrCreatePromise (): Promise<QueryResult> {
+  private _getOrCreatePromise (): Promise<QueryResult<Entries>> {
     if (this._p == null) {
       this._p = new Promise((resolve, reject) => {
         const records: Record[] = []
@@ -240,9 +240,9 @@ class Result implements Promise<QueryResult> {
    * *Should not be combined with {@link Result#subscribe} or ${@link Result#then} functions.*
    *
    * @public
-   * @returns {PeekableAsyncIterator<Record, ResultSummary>} The async iterator for the Results
+   * @returns {PeekableAsyncIterator<Record<Entries>, ResultSummary>} The async iterator for the Results
    */
-  [Symbol.asyncIterator] (): PeekableAsyncIterator<Record, ResultSummary> {
+  [Symbol.asyncIterator] (): PeekableAsyncIterator<Record<Entries>, ResultSummary> {
     if (!this.isOpen()) {
       const error = newError('Result is already consumed')
       return {
@@ -345,9 +345,9 @@ class Result implements Promise<QueryResult> {
    * @param {function(error: {message:string, code:string})} onRejected - function to be called upon errors.
    * @return {Promise} promise.
    */
-  then<TResult1 = QueryResult, TResult2 = never>(
+  then<TResult1 = QueryResult<Entries>, TResult2 = never>(
     onFulfilled?:
-    | ((value: QueryResult) => TResult1 | PromiseLike<TResult1>)
+    | ((value: QueryResult<Entries>) => TResult1 | PromiseLike<TResult1>)
     | null,
     onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
   ): Promise<TResult1 | TResult2> {
@@ -364,7 +364,7 @@ class Result implements Promise<QueryResult> {
    */
   catch <TResult = never>(
     onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
-  ): Promise<QueryResult | TResult> {
+  ): Promise<QueryResult<Entries> | TResult> {
     return this._getOrCreatePromise().catch(onRejected)
   }
 
@@ -376,7 +376,7 @@ class Result implements Promise<QueryResult> {
    * @return {Promise} promise.
    */
   [Symbol.toStringTag]: string
-  finally (onfinally?: (() => void) | null): Promise<QueryResult> {
+  finally (onfinally?: (() => void) | null): Promise<QueryResult<Entries>> {
     return this._getOrCreatePromise().finally(onfinally)
   }
 

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -56,8 +56,8 @@ const DEFAULT_ON_KEYS = (keys: string[]): void => {}
  * The query result is the combination of the {@link ResultSummary} and
  * the array {@link Record[]} produced by the query
  */
-interface QueryResult<Entries extends Dict = Dict> {
-  records: Array<Record<Entries>>
+interface QueryResult<RecordShape extends Dict = Dict> {
+  records: Array<Record<RecordShape>>
   summary: ResultSummary
 }
 
@@ -65,7 +65,7 @@ interface QueryResult<Entries extends Dict = Dict> {
  * Interface to observe updates on the Result which is being produced.
  *
  */
-interface ResultObserver<Entries=Dict> {
+interface ResultObserver<RecordShape extends Dict =Dict> {
   /**
    * Receive the keys present on the record whenever this information is available
    *
@@ -77,7 +77,7 @@ interface ResultObserver<Entries=Dict> {
    * Receive the each record present on the {@link @Result}
    * @param {Record} record The {@link Record} produced
    */
-  onNext?: (record: Record<Entries>) => void
+  onNext?: (record: Record<RecordShape>) => void
 
   /**
    * Called when the result is fully received
@@ -111,7 +111,7 @@ interface QueuedResultObserver extends ResultObserver {
  * Alternatively can be consumed lazily using {@link Result#subscribe} function.
  * @access public
  */
-class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries>> {
+class Result<RecordShape extends Dict = Dict> implements Promise<QueryResult<RecordShape>> {
   private readonly _stack: string | null
   private readonly _streamObserverPromise: Promise<observer.ResultStreamObserver>
   private _p: Promise<QueryResult> | null
@@ -212,7 +212,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @private
    * @return {Promise} new Promise.
    */
-  private _getOrCreatePromise (): Promise<QueryResult<Entries>> {
+  private _getOrCreatePromise (): Promise<QueryResult<RecordShape>> {
     if (this._p == null) {
       this._p = new Promise((resolve, reject) => {
         const records: Record[] = []
@@ -240,9 +240,9 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * *Should not be combined with {@link Result#subscribe} or ${@link Result#then} functions.*
    *
    * @public
-   * @returns {PeekableAsyncIterator<Record<Entries>, ResultSummary>} The async iterator for the Results
+   * @returns {PeekableAsyncIterator<Record<RecordShape>, ResultSummary>} The async iterator for the Results
    */
-  [Symbol.asyncIterator] (): PeekableAsyncIterator<Record<Entries>, ResultSummary> {
+  [Symbol.asyncIterator] (): PeekableAsyncIterator<Record<RecordShape>, ResultSummary> {
     if (!this.isOpen()) {
       const error = newError('Result is already consumed')
       return {
@@ -345,9 +345,9 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @param {function(error: {message:string, code:string})} onRejected - function to be called upon errors.
    * @return {Promise} promise.
    */
-  then<TResult1 = QueryResult<Entries>, TResult2 = never>(
+  then<TResult1 = QueryResult<RecordShape>, TResult2 = never>(
     onFulfilled?:
-    | ((value: QueryResult<Entries>) => TResult1 | PromiseLike<TResult1>)
+    | ((value: QueryResult<RecordShape>) => TResult1 | PromiseLike<TResult1>)
     | null,
     onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
   ): Promise<TResult1 | TResult2> {
@@ -364,7 +364,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    */
   catch <TResult = never>(
     onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
-  ): Promise<QueryResult<Entries> | TResult> {
+  ): Promise<QueryResult<RecordShape> | TResult> {
     return this._getOrCreatePromise().catch(onRejected)
   }
 
@@ -376,7 +376,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @return {Promise} promise.
    */
   [Symbol.toStringTag]: string
-  finally (onfinally?: (() => void) | null): Promise<QueryResult<Entries>> {
+  finally (onfinally?: (() => void) | null): Promise<QueryResult<RecordShape>> {
     return this._getOrCreatePromise().finally(onfinally)
   }
 
@@ -391,7 +391,7 @@ class Result<Entries extends Dict = Dict> implements Promise<QueryResult<Entries
    * @param {function(error: {message:string, code:string})} observer.onError - handle errors.
    * @return {void}
    */
-  subscribe (observer: ResultObserver<Entries>): void {
+  subscribe (observer: ResultObserver<RecordShape>): void {
     this._subscribe(observer)
       .catch(() => {})
   }

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -36,6 +36,7 @@ import { NumberOrInteger } from './graph-types.ts'
 import TransactionPromise from './transaction-promise.ts'
 import ManagedTransaction from './transaction-managed.ts'
 import BookmarkManager from './bookmark-manager.ts'
+import { Dict } from './record.ts'
 
 type ConnectionConsumer = (connection: Connection | null) => any | undefined | Promise<any> | Promise<undefined>
 type TransactionWork<T> = (tx: Transaction) => Promise<T> | T
@@ -154,11 +155,11 @@ class Session {
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
    * @return {Result} New Result.
    */
-  run (
+  run<Entries = Dict> (
     query: Query,
     parameters?: any,
     transactionConfig?: TransactionConfig
-  ): Result {
+  ): Result<Entries> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -155,11 +155,11 @@ class Session {
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
    * @return {Result} New Result.
    */
-  run<Entries = Dict> (
+  run<RecordShape extends Dict = Dict> (
     query: Query,
     parameters?: any,
     transactionConfig?: TransactionConfig
-  ): Result<Entries> {
+  ): Result<RecordShape> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/neo4j-driver-deno/lib/core/transaction-managed.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction-managed.ts
@@ -61,7 +61,7 @@ class ManagedTransaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run<Entries=Dict> (query: Query, parameters?: any): Result<Entries> {
+  run<RecordShape extends Dict =Dict> (query: Query, parameters?: any): Result<RecordShape> {
     return this._run(query, parameters)
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/transaction-managed.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction-managed.ts
@@ -20,6 +20,7 @@
 import Result from './result.ts'
 import Transaction from './transaction.ts'
 import { Query } from './types.ts'
+import { Dict } from './record.ts'
 
 type Run = (query: Query, parameters?: any) => Result
 
@@ -60,7 +61,7 @@ class ManagedTransaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run (query: Query, parameters?: any): Result {
+  run<Entries=Dict> (query: Query, parameters?: any): Result<Entries> {
     return this._run(query, parameters)
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/transaction.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction.ts
@@ -175,7 +175,7 @@ class Transaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run<Entries = Dict> (query: Query, parameters?: any): Result<Entries> {
+  run<RecordShape extends Dict = Dict> (query: Query, parameters?: any): Result<RecordShape> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/neo4j-driver-deno/lib/core/transaction.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction.ts
@@ -37,6 +37,7 @@ import {
 import { newError } from './error.ts'
 import Result from './result.ts'
 import { Query } from './types.ts'
+import { Dict } from './record.ts'
 
 /**
  * Represents a transaction in the Neo4j database.
@@ -109,7 +110,7 @@ class Transaction {
     this._lowRecordWatermak = lowRecordWatermark
     this._highRecordWatermark = highRecordWatermark
     this._bookmarks = Bookmarks.empty()
-    this._acceptActive = () => { } // satisfy DenoJS 
+    this._acceptActive = () => { } // satisfy DenoJS
     this._activePromise = new Promise((resolve, reject) => {
       this._acceptActive = resolve
     })
@@ -174,7 +175,7 @@ class Transaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run (query: Query, parameters?: any): Result {
+  run<Entries = Dict> (query: Query, parameters?: any): Result<Entries> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters

--- a/packages/neo4j-driver/test/types/graph-types.test.ts
+++ b/packages/neo4j-driver/test/types/graph-types.test.ts
@@ -163,3 +163,26 @@ const path2Start: Node<number> = path2.start
 const path2End: Node<number> = path2.end
 const path2Segments: Array<PathSegment<number>> = path2.segments
 const isPath2: boolean = path2 instanceof Path
+
+interface Person {
+  age: number
+  name: string
+}
+
+const dummy: any = null
+
+{
+  const personNode: Node<number, Person> = dummy
+  const age: number = personNode.properties.age
+  const name: string = personNode.properties.name
+  // @ts-expect-error
+  const nameInt: number = personNode.properties.name
+}
+
+{
+  const personRel: Relationship<number, Person> = dummy
+  const age: number = personRel.properties.age
+  const name: string = personRel.properties.name
+  // @ts-expect-error
+  const nameInt: number = personRel.properties.name
+}

--- a/packages/neo4j-driver/test/types/session.test.ts
+++ b/packages/neo4j-driver/test/types/session.test.ts
@@ -27,7 +27,9 @@ import {
   Result,
   Transaction,
   Session,
-  TransactionConfig
+  TransactionConfig,
+  Node,
+  Relationship
 } from 'neo4j-driver-core'
 
 const dummy: any = null
@@ -176,3 +178,78 @@ const promise6: Promise<number> = session.writeTransaction(
 )
 
 const lastBookmarks: string[] = session.lastBookmarks()
+
+interface Person {
+  age: Integer
+  name: string
+}
+
+interface Friendship {
+  since: Integer
+}
+
+interface PersonAndFriendship {
+  p: Node<number, Person>
+  f: Relationship<number, Friendship>
+}
+
+const personSessionRun = session.run<Person>('MATCH (p:Person) RETURN p.name, p.age')
+personSessionRun.then(({ records }) => {
+  for (const person of records) {
+    const age: Integer = person.get('age')
+    const name: string = person.get('name')
+
+    // @ts-expect-error
+    const nameInt: Integer = person.get('name')
+  }
+}).catch(err => console.error(err))
+
+const personAndFriend = session.run<PersonAndFriendship>('MATCH (p:Person)-[f:Friendship]-() RETURN p, f')
+personAndFriend.then(({ records }) => {
+  for (const r of records) {
+    const person = r.get('p')
+
+    const age: Integer = person.properties.age
+    const name: string = person.properties.name
+
+    // @ts-expect-error
+    const nameInt: Integer = person.properties.name
+
+    // @ts-expect-error
+    const err: string = person.properties.err
+
+    const friendship = r.get('f')
+
+    const since: Integer = friendship.properties.since
+
+    // @ts-expect-error
+    const sinceString: string = friendship.properties.since
+
+    // @ts-expect-error
+    const err2: string = friendship.properties.err
+  }
+}).catch(error => console.error(error))
+
+const personExecuteRead = session.executeRead(tx => tx.run<Person>('MATCH (p:Person) RETURN p.name, p.age'))
+
+personExecuteRead.then(({ records }) => {
+  for (const person of records) {
+    const age: Integer = person.get('age')
+    const name: string = person.get('name')
+
+    // @ts-expect-error
+    const nameInt: Integer = person.get('name')
+  }
+}).catch(err => console.error(err))
+
+const personExecuteWrite = session.executeWrite(tx => tx.run<Person>('MATCH (p:Person) RETURN p.name, p.age'))
+
+personExecuteWrite.then(({ records }) => {
+  for (const person of records) {
+    const age: Integer = person.get('age')
+    const name: string = person.get('name')
+
+    // @ts-expect-error
+    const nameInt: Integer = person.get('name')
+  }
+}).catch(err => console.error(err))

--- a/packages/neo4j-driver/test/types/session.test.ts
+++ b/packages/neo4j-driver/test/types/session.test.ts
@@ -234,11 +234,16 @@ const personExecuteRead = session.executeRead(tx => tx.run<Person>('MATCH (p:Per
 
 personExecuteRead.then(({ records }) => {
   for (const person of records) {
-    const age: Integer = person.get('age')
-    const name: string = person.get('name')
+    let age: Integer = person.get('age')
+    let name: string = person.get('name')
 
     // @ts-expect-error
     const nameInt: Integer = person.get('name')
+
+    const p = person.toObject()
+
+    age = p.age
+    name = p.name
   }
 }).catch(err => console.error(err))
 

--- a/packages/neo4j-driver/test/types/transaction.test.ts
+++ b/packages/neo4j-driver/test/types/transaction.test.ts
@@ -24,7 +24,10 @@ import {
   ResultSummary,
   Result,
   QueryResult,
-  Transaction
+  Transaction,
+  Integer,
+  Node,
+  Relationship
 } from 'neo4j-driver-core'
 
 const dummy: any = null
@@ -94,4 +97,55 @@ tx.commit().then(() => {
 
 tx.rollback().then(() => {
   console.log('transaction rolled back')
+}).catch(error => console.error(error))
+
+interface Person {
+  age: Integer
+  name: string
+}
+
+interface Friendship {
+  since: Integer
+}
+
+interface PersonAndFriendship {
+  p: Node<number, Person>
+  f: Relationship<number, Friendship>
+}
+
+const personTxRun = tx.run<Person>('MATCH (p:Person) RETURN p.name, p.age')
+personTxRun.then(({ records }) => {
+  for (const person of records) {
+    const age: Integer = person.get('age')
+    const name: string = person.get('name')
+
+    // @ts-expect-error
+    const nameInt: Integer = person.get('name')
+  }
+}).catch(error => console.error(error))
+
+const personAndFriend = tx.run<PersonAndFriendship>('MATCH (p:Person)-[f:Friendship]-() RETURN p, f')
+personAndFriend.then(({ records }) => {
+  for (const r of records) {
+    const person = r.get('p')
+
+    const age: Integer = person.properties.age
+    const name: string = person.properties.name
+
+    // @ts-expect-error
+    const nameInt: Integer = person.properties.name
+
+    // @ts-expect-error
+    const err: string = person.properties.err
+
+    const friendship = r.get('f')
+
+    const since: Integer = friendship.properties.since
+
+    // @ts-expect-error
+    const sinceString: string = friendship.properties.since
+
+    // @ts-expect-error
+    const err2: string = friendship.properties.err
+  }
 }).catch(error => console.error(error))


### PR DESCRIPTION
The new generic typing allow mapping the records of these running queries to type-mapped Record.

Given the following Person and Friendship definitions.

```typescript
interface Person {
  age: Integer
  name: string
}

interface Friendship {
  since: Integer
}

interface PersonAndFriendship {
  p: Node<number, Person>
  f: Relationship<number, Friendship>
}
```

The new type-mapping allow safe access the properties of query which return `Record<Person>`

```typescript
const { records } = await session.run<Person>('MATCH (p:Person) RETURN p.name as name, p.age as age')

for (const person of records) {
    const age: Integer = person.get('age')
    const name: string = person.get('name')

    // @ts-expect-error
    const nameInt: Integer = person.get('name')
}
```

The type-mapping can be also extended for `Node` and `Relationship`.

```typescript
const { records } = await session.run<PersonAndFriendship>('MATCH (p:Person)-[f:Friendship]-() RETURN p, f')

for (const r of records) {
    const person = r.get('p')

    const age: Integer = person.properties.age
    const name: string = person.properties.name

    // @ts-expect-error
    const nameInt: Integer = person.properties.name

    // @ts-expect-error
    const err: string = person.properties.err

    const friendship = r.get('f')

    const since: Integer = friendship.properties.since

    // @ts-expect-error
    const sinceString: string = friendship.properties.since

    // @ts-expect-error
    const err2: string = friendship.properties.err
}
```

The usage in combination with `executeRead` and `executeWrite` is also possible.

```typescript
const { records } = await session.executeRead(tx => tx.run<Person>('MATCH (p:Person) RETURN p.name as name, p.age as age'))

for (const person of records) {
    const age: Integer = person.get('age')
    const name: string = person.get('name')

    // @ts-expect-error
    const nameInt: Integer = person.get('name')
}
```

With some async iterator usage:

```typescript 
const personList = await session.executeRead(async (tx) => {
    const result = tx.run<Person>('MATCH (p:Person) RETURN p.name as name, p.age as age')
    const objects: Person[] = []
    // iterate while streaming the objects
    for await (const record of result) {
        objects.push(record.toObject())
    }
    return objects
})

for (const person of personList) {
    const age: Integer = person.age
    const name: string = person.name

    // @ts-expect-error
    const nameInt: Integer = person.name

    // @ts-expect-error
    const nome: string = person.nome
}
```

⚠️ This type definitions are not asserted in runtime. Thus mismatched type records coming from the database will not trigger type errors.