### PR TITLE
Fail fast for more rediscovery failures

### DIFF
--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -50,6 +50,7 @@ const AUTHORIZATION_EXPIRED_CODE =
   'Neo.ClientError.Security.AuthorizationExpired'
 const INVALID_ARGUMENT_ERROR = 'Neo.ClientError.Statement.ArgumentError'
 const INVALID_REQUEST_ERROR = 'Neo.ClientError.Request.Invalid'
+const STATEMENT_TYPE_ERROR = 'Neo.ClientError.Statement.TypeError'
 
 const SYSTEM_DB_NAME = 'system'
 const DEFAULT_DB_NAME = null
@@ -707,7 +708,8 @@ function _isFailFastError (error) {
     INVALID_BOOKMARK_CODE,
     INVALID_BOOKMARK_MIXTURE_CODE,
     INVALID_ARGUMENT_ERROR,
-    INVALID_REQUEST_ERROR
+    INVALID_REQUEST_ERROR,
+    STATEMENT_TYPE_ERROR
   ].includes(error.code)
 }
 

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -49,6 +49,7 @@ const INVALID_BOOKMARK_MIXTURE_CODE =
 const AUTHORIZATION_EXPIRED_CODE =
   'Neo.ClientError.Security.AuthorizationExpired'
 const INVALID_ARGUMENT_ERROR = 'Neo.ClientError.Statement.ArgumentError'
+const INVALID_REQUEST_ERROR = 'Neo.ClientError.Request.Invalid'
 
 const SYSTEM_DB_NAME = 'system'
 const DEFAULT_DB_NAME = null
@@ -705,7 +706,8 @@ function _isFailFastError (error) {
     DATABASE_NOT_FOUND_CODE,
     INVALID_BOOKMARK_CODE,
     INVALID_BOOKMARK_MIXTURE_CODE,
-    INVALID_ARGUMENT_ERROR
+    INVALID_ARGUMENT_ERROR,
+    INVALID_REQUEST_ERROR
   ].includes(error.code)
 }
 

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -48,6 +48,7 @@ const INVALID_BOOKMARK_MIXTURE_CODE =
   'Neo.ClientError.Transaction.InvalidBookmarkMixture'
 const AUTHORIZATION_EXPIRED_CODE =
   'Neo.ClientError.Security.AuthorizationExpired'
+const INVALID_ARGUMENT_ERROR = 'Neo.ClientError.Statement.ArgumentError'
 
 const SYSTEM_DB_NAME = 'system'
 const DEFAULT_DB_NAME = null
@@ -703,7 +704,8 @@ function _isFailFastError (error) {
   return [
     DATABASE_NOT_FOUND_CODE,
     INVALID_BOOKMARK_CODE,
-    INVALID_BOOKMARK_MIXTURE_CODE
+    INVALID_BOOKMARK_MIXTURE_CODE,
+    INVALID_ARGUMENT_ERROR
   ].includes(error.code)
 }
 

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -1669,6 +1669,7 @@ describe.each([
       'Neo.ClientError.Database.DatabaseNotFound',
       'Neo.ClientError.Transaction.InvalidBookmark',
       'Neo.ClientError.Transaction.InvalidBookmarkMixture',
+      'Neo.ClientError.Statement.ArgumentError',
       'Neo.ClientError.Security.Forbidden',
       'Neo.ClientError.Security.IWontTellYou'
     ])('with "%s"', errorCode => {

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -1669,6 +1669,7 @@ describe.each([
       'Neo.ClientError.Database.DatabaseNotFound',
       'Neo.ClientError.Transaction.InvalidBookmark',
       'Neo.ClientError.Transaction.InvalidBookmarkMixture',
+      'Neo.ClientError.Request.Invalid',
       'Neo.ClientError.Statement.ArgumentError',
       'Neo.ClientError.Security.Forbidden',
       'Neo.ClientError.Security.IWontTellYou'

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -1671,6 +1671,7 @@ describe.each([
       'Neo.ClientError.Transaction.InvalidBookmarkMixture',
       'Neo.ClientError.Request.Invalid',
       'Neo.ClientError.Statement.ArgumentError',
+      'Neo.ClientError.Statement.TypeError',
       'Neo.ClientError.Security.Forbidden',
       'Neo.ClientError.Security.IWontTellYou'
     ])('with "%s"', errorCode => {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -50,6 +50,7 @@ const AUTHORIZATION_EXPIRED_CODE =
   'Neo.ClientError.Security.AuthorizationExpired'
 const INVALID_ARGUMENT_ERROR = 'Neo.ClientError.Statement.ArgumentError'
 const INVALID_REQUEST_ERROR = 'Neo.ClientError.Request.Invalid'
+const STATEMENT_TYPE_ERROR = 'Neo.ClientError.Statement.TypeError'
 
 const SYSTEM_DB_NAME = 'system'
 const DEFAULT_DB_NAME = null
@@ -707,7 +708,8 @@ function _isFailFastError (error) {
     INVALID_BOOKMARK_CODE,
     INVALID_BOOKMARK_MIXTURE_CODE,
     INVALID_ARGUMENT_ERROR,
-    INVALID_REQUEST_ERROR
+    INVALID_REQUEST_ERROR,
+    STATEMENT_TYPE_ERROR
   ].includes(error.code)
 }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -49,6 +49,7 @@ const INVALID_BOOKMARK_MIXTURE_CODE =
 const AUTHORIZATION_EXPIRED_CODE =
   'Neo.ClientError.Security.AuthorizationExpired'
 const INVALID_ARGUMENT_ERROR = 'Neo.ClientError.Statement.ArgumentError'
+const INVALID_REQUEST_ERROR = 'Neo.ClientError.Request.Invalid'
 
 const SYSTEM_DB_NAME = 'system'
 const DEFAULT_DB_NAME = null
@@ -705,7 +706,8 @@ function _isFailFastError (error) {
     DATABASE_NOT_FOUND_CODE,
     INVALID_BOOKMARK_CODE,
     INVALID_BOOKMARK_MIXTURE_CODE,
-    INVALID_ARGUMENT_ERROR
+    INVALID_ARGUMENT_ERROR,
+    INVALID_REQUEST_ERROR
   ].includes(error.code)
 }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -48,6 +48,7 @@ const INVALID_BOOKMARK_MIXTURE_CODE =
   'Neo.ClientError.Transaction.InvalidBookmarkMixture'
 const AUTHORIZATION_EXPIRED_CODE =
   'Neo.ClientError.Security.AuthorizationExpired'
+const INVALID_ARGUMENT_ERROR = 'Neo.ClientError.Statement.ArgumentError'
 
 const SYSTEM_DB_NAME = 'system'
 const DEFAULT_DB_NAME = null
@@ -703,7 +704,8 @@ function _isFailFastError (error) {
   return [
     DATABASE_NOT_FOUND_CODE,
     INVALID_BOOKMARK_CODE,
-    INVALID_BOOKMARK_MIXTURE_CODE
+    INVALID_BOOKMARK_MIXTURE_CODE,
+    INVALID_ARGUMENT_ERROR
   ].includes(error.code)
 }
 


### PR DESCRIPTION
When trying to impersonate an invalid user, the routing procedure returns `Neo.ClientError.Statement.ArgumentError`. This type of failure is not in the fail fast list, thus this is wrapped up in the generic rediscovery error triggering the retry in the transaction functions. Since this kind of error is not recoverable, retrying on it is not need and desirable.

Then, failing fast on `Neo.ClientError.Statement.ArgumentError` failures speeds up the error bubbling and avoids unnecessary load in the client and server.

Other rediscovery failures to be fast failed are:

* `Neo.ClientError.Statement.TypeError`
* `Neo.ClientError.Request.Invalid`