### PR TITLE
Add generic types for Node#labels, Relationship#type and UnboundRelationship#type

### DIFF
--- a/packages/core/src/graph-types.ts
+++ b/packages/core/src/graph-types.ts
@@ -47,9 +47,9 @@ function hasIdentifierProperty (obj: any, property: string): boolean {
 /**
  * Class for Node Type.
  */
-class Node<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
+class Node<T extends NumberOrInteger = Integer, P extends Properties = Properties, Label extends string = string> {
   identity: T
-  labels: string[]
+  labels: Label[]
   properties: P
   elementId: string
   /**
@@ -60,7 +60,7 @@ class Node<T extends NumberOrInteger = Integer, P extends Properties = Propertie
    * @param {Properties} properties - Map with node properties
    * @param {string} elementId - Node element identifier
    */
-  constructor (identity: T, labels: string[], properties: P, elementId?: string) {
+  constructor (identity: T, labels: Label[], properties: P, elementId?: string) {
     /**
      * Identity of the node.
      * @type {NumberOrInteger}
@@ -124,11 +124,11 @@ function isNode (obj: object): obj is Node {
 /**
  * Class for Relationship Type.
  */
-class Relationship<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
+class Relationship<T extends NumberOrInteger = Integer, P extends Properties = Properties, Type extends string = string> {
   identity: T
   start: T
   end: T
-  type: string
+  type: Type
   properties: P
   elementId: string
   startNodeElementId: string
@@ -147,7 +147,7 @@ class Relationship<T extends NumberOrInteger = Integer, P extends Properties = P
    * @param {string} endNodeElementId - End Node element identifier
    */
   constructor (
-    identity: T, start: T, end: T, type: string, properties: P,
+    identity: T, start: T, end: T, type: Type, properties: P,
     elementId?: string, startNodeElementId?: string, endNodeElementId?: string
   ) {
     /**
@@ -236,9 +236,9 @@ function isRelationship (obj: object): obj is Relationship {
  * Class for UnboundRelationship Type.
  * @access private
  */
-class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
+class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Properties = Properties, Type extends string = string> {
   identity: T
-  type: string
+  type: Type
   properties: P
   elementId: string
 
@@ -250,7 +250,7 @@ class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Propert
    * @param {Properties} properties - Map with relationship properties
    * @param {string} elementId - Relationship element identifier
    */
-  constructor (identity: T, type: string, properties: any, elementId?: string) {
+  constructor (identity: T, type: Type, properties: any, elementId?: string) {
     /**
      * Identity of the relationship.
      * @type {NumberOrInteger}

--- a/packages/core/test/graph-types.test.ts
+++ b/packages/core/test/graph-types.test.ts
@@ -78,6 +78,22 @@ describe('Node', () => {
     expect(isNode(nonNode)).toBe(false)
   })
 
+  test('should type mapping labels', () => {
+    type PersonLabels = 'Person' | 'Actor'
+    const labels: PersonLabels[] = ['Actor', 'Person']
+    type Person = Node<number, {}, PersonLabels>
+
+    const p: Person = new Node(1, labels, {})
+
+    const receivedLabels: PersonLabels[] = p.labels
+
+    expect(receivedLabels).toEqual(labels)
+
+    // @ts-expect-error
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _: 'Movie'|Array<'TvShow'> = p.labels
+  })
+
   function validNodes (): any[] {
     return [
       [new Node(1, ['label'], {}, 'elementId')],
@@ -189,6 +205,18 @@ describe('Relationship', () => {
 
   test.each(nonRelationships())('should not consider a non-relationship object as relationship', nonRelationship => {
     expect(isRelationship(nonRelationship)).toBe(false)
+  })
+
+  test('should type mapping relationship type', () => {
+    type ActedIn = Relationship<number, { [key in string]: any }, 'ACTED_IN'>
+    const a: ActedIn = new Relationship(1, 1, 2, 'ACTED_IN', {})
+
+    const receivedType: 'ACTED_IN' = a.type
+    expect(receivedType).toEqual('ACTED_IN')
+
+    // @ts-expect-error
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _: 'DIRECTED' = a.type
   })
 
   function validRelationships (): any[] {
@@ -304,6 +332,18 @@ describe('UnboundRelationship', () => {
           endNode.elementId
         )
       )
+  })
+
+  test('should type mapping relationship type', () => {
+    type ActedIn = UnboundRelationship<number, { [key in string]: any }, 'ACTED_IN'>
+    const a: ActedIn = new UnboundRelationship(1, 'ACTED_IN', {})
+
+    const receivedType: 'ACTED_IN' = a.type
+    expect(receivedType).toEqual('ACTED_IN')
+
+    // @ts-expect-error
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _: 'DIRECTED' = a.type
   })
 
   function validUnboundRelationships (): any[] {

--- a/packages/neo4j-driver-deno/lib/core/graph-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/graph-types.ts
@@ -47,9 +47,9 @@ function hasIdentifierProperty (obj: any, property: string): boolean {
 /**
  * Class for Node Type.
  */
-class Node<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
+class Node<T extends NumberOrInteger = Integer, P extends Properties = Properties, Label extends string = string> {
   identity: T
-  labels: string[]
+  labels: Label[]
   properties: P
   elementId: string
   /**
@@ -60,7 +60,7 @@ class Node<T extends NumberOrInteger = Integer, P extends Properties = Propertie
    * @param {Properties} properties - Map with node properties
    * @param {string} elementId - Node element identifier
    */
-  constructor (identity: T, labels: string[], properties: P, elementId?: string) {
+  constructor (identity: T, labels: Label[], properties: P, elementId?: string) {
     /**
      * Identity of the node.
      * @type {NumberOrInteger}
@@ -124,11 +124,11 @@ function isNode (obj: object): obj is Node {
 /**
  * Class for Relationship Type.
  */
-class Relationship<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
+class Relationship<T extends NumberOrInteger = Integer, P extends Properties = Properties, Type extends string = string> {
   identity: T
   start: T
   end: T
-  type: string
+  type: Type
   properties: P
   elementId: string
   startNodeElementId: string
@@ -147,7 +147,7 @@ class Relationship<T extends NumberOrInteger = Integer, P extends Properties = P
    * @param {string} endNodeElementId - End Node element identifier
    */
   constructor (
-    identity: T, start: T, end: T, type: string, properties: P,
+    identity: T, start: T, end: T, type: Type, properties: P,
     elementId?: string, startNodeElementId?: string, endNodeElementId?: string
   ) {
     /**
@@ -236,9 +236,9 @@ function isRelationship (obj: object): obj is Relationship {
  * Class for UnboundRelationship Type.
  * @access private
  */
-class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Properties = Properties> {
+class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Properties = Properties, Type extends string = string> {
   identity: T
-  type: string
+  type: Type
   properties: P
   elementId: string
 
@@ -250,7 +250,7 @@ class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Propert
    * @param {Properties} properties - Map with relationship properties
    * @param {string} elementId - Relationship element identifier
    */
-  constructor (identity: T, type: string, properties: any, elementId?: string) {
+  constructor (identity: T, type: Type, properties: any, elementId?: string) {
     /**
      * Identity of the relationship.
      * @type {NumberOrInteger}


### PR DESCRIPTION
This generic types enable defining a list string like values accepted for an specific node labels list or relationship type.

Node example:

```typescript
type PersonLabels = 'Person' | 'Actor'

// get the person from a non-typed record. If the record is correctly type-mapped
// the Node type can be omitted since it will be inferred.
const person: Node<Integer, PersonProps, PersonLabels> = record.get('person')

// get labels
// the type inferred for the labels will be PersonLabels[]
const labels = person.labels

// @ts-exepct-error
const wrongLabels: 'Car'|'Bicycle'[] = person.labels
```

Relationship/UnboundRelationship example:

```typescript
type ActedInType = 'ACTED_IN'

// get the relationship from a non-typed record. If the record is correctly type mapped
// the Relationship type can be omitted since it will be inferred.
const actedIn: Relationship<Integer, ActedInProps, ActedInType> = record.get('actedIn')

// get type
// the type inferred for the relType will be 'ACTED_IN'
const relType = actedIn.type

// @ts-expect-error
const directed: 'DIRECTED' = actedIn.type
```

⚠️ This type definitions are not asserted in runtime. Thus mismatched type records coming from the database will not trigger type errors.