### PR TITLE
Fix RxResult performance issue in Browser

### DIFF
--- a/packages/neo4j-driver/src/result-rx.js
+++ b/packages/neo4j-driver/src/result-rx.js
@@ -251,7 +251,8 @@ function createFullyControlledSubject (
       } else {
         subject.next(value)
         if (!streamControl.paused) {
-          setImmediate(async () => await pushNextValue(iterator.next()))
+          pushNextValue(iterator.next())
+            .catch(() => {})
         }
       }
     } catch (error) {


### PR DESCRIPTION
`setImmediate` was slowing down the result consumption since it postpone the execution to the next cycle. Since the cycle in Browser is longer, the issue was more perceptive there.

The remove of `setImmediate` doesn't cause any issue with the back-pressure mechanics.