### PR TITLE
Remove testkit-backend from the Snyk security analysis

### DIFF
--- a/.github/workflows/SECURITY.yaml
+++ b/.github/workflows/SECURITY.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Snyk monitor dependencies
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk monitor --all-projects --strict-out-of-sync=false --target-reference=${GITHUB_REF}
+        run: snyk monitor --all-projects --exclude=testkit-backend --strict-out-of-sync=false --target-reference=${GITHUB_REF}

--- a/.github/workflows/SECURITY_PR.yaml
+++ b/.github/workflows/SECURITY_PR.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Snyk test dependencies
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk test --all-projects --strict-out-of-sync=false --severity-threshold=medium --fail-on=all
+        run: snyk test --all-projects --exclude=testkit-backend --strict-out-of-sync=false --severity-threshold=medium --fail-on=all

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,3 @@
+exclude:
+ global:
+   - packages/testkit-backend/**

--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-exclude:
- global:
-   - packages/testkit-backend/**
-

--- a/.snyk
+++ b/.snyk
@@ -1,3 +1,4 @@
 exclude:
  global:
    - packages/testkit-backend/**
+


### PR DESCRIPTION
Testkit backend is not released in production.