### PR TITLE
Export `isNode`, `isRelationship`, `isPath`, `isPathSegment` and `isUnboundedRelationship` function

### DIFF
--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -40,7 +40,12 @@ import {
   isDuration,
   isLocalDateTime,
   isLocalTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
   isTime,
+  isUnboundRelationship,
   LocalDateTime,
   LocalTime,
   Time,
@@ -414,6 +419,17 @@ const temporal = {
 }
 
 /**
+ * Object containing functions to work with graph types, like {@link Node} or {@link Relationship}.
+ */
+const graph = {
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship
+}
+
+/**
  * @private
  */
 const forExport = {
@@ -428,6 +444,11 @@ const forExport = {
   isDate,
   isLocalDateTime,
   isDateTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship,
   integer,
   Neo4jError,
   isRetriableError,
@@ -436,6 +457,7 @@ const forExport = {
   types,
   session,
   error,
+  graph,
   spatial,
   temporal,
   Driver,
@@ -481,6 +503,11 @@ export {
   isDate,
   isLocalDateTime,
   isDateTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship,
   integer,
   Neo4jError,
   isRetriableError,
@@ -489,6 +516,7 @@ export {
   types,
   session,
   error,
+  graph,
   spatial,
   temporal,
   Driver,

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -40,7 +40,12 @@ import {
   isDuration,
   isLocalDateTime,
   isLocalTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
   isTime,
+  isUnboundRelationship,
   LocalDateTime,
   LocalTime,
   Time,
@@ -413,6 +418,17 @@ const temporal = {
 }
 
 /**
+ * Object containing functions to work with graph types, like {@link Node} or {@link Relationship}.
+ */
+const graph = {
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship
+}
+
+/**
  * @private
  */
 const forExport = {
@@ -427,6 +443,11 @@ const forExport = {
   isDate,
   isLocalDateTime,
   isDateTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship,
   integer,
   Neo4jError,
   isRetriableError,
@@ -435,6 +456,7 @@ const forExport = {
   types,
   session,
   error,
+  graph,
   spatial,
   temporal,
   Driver,
@@ -480,6 +502,11 @@ export {
   isDate,
   isLocalDateTime,
   isDateTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship,
   integer,
   Neo4jError,
   isRetriableError,
@@ -488,6 +515,7 @@ export {
   types,
   session,
   error,
+  graph,
   spatial,
   temporal,
   Driver,

--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -50,7 +50,13 @@ import neo4j, {
   Date,
   LocalDateTime,
   DateTime,
-  BookmarkManager
+  BookmarkManager,
+  graph,
+  isNode,
+  isRelationship,
+  isPath,
+  isPathSegment,
+  isUnboundRelationship
 } from '../../'
 
 describe('index', () => {
@@ -300,5 +306,101 @@ describe('index', () => {
   it('should export an instanciable DateTime', () => {
     const date: DateTime<number> = new DateTime(1, 2, 3, 3, 5, 6, 6, 5)
     expect(date).toBeDefined()
+  })
+
+  it('should export isNode', () => {
+    const node = new Node(int(123), ['abc'], [1])
+
+    expect(isNode(node)).toBe(true)
+  })
+
+  it('should export graph.isNode', () => {
+    const node = new Node(int(123), ['abc'], [1])
+
+    expect(graph.isNode(node)).toBe(true)
+  })
+
+  it('should export isRelationship', () => {
+    const rel = new Relationship(
+      int(123),
+      int(1),
+      int(1),
+      'rel',
+      {}
+    )
+
+    expect(isRelationship(rel)).toBe(true)
+  })
+
+  it('should export graph.isRelationship', () => {
+    const rel = new Relationship(
+      int(123),
+      int(1),
+      int(1),
+      'rel',
+      {}
+    )
+
+    expect(graph.isRelationship(rel)).toBe(true)
+  })
+
+  it('should export isUnboundRelationship', () => {
+    const rel = new UnboundRelationship(
+      int(123),
+      'rel',
+      {}
+    )
+
+    expect(isUnboundRelationship(rel)).toBe(true)
+  })
+
+  it('should export graph.isUnboundRelationship', () => {
+    const rel = new UnboundRelationship(
+      int(123),
+      'rel',
+      {}
+    )
+
+    expect(graph.isUnboundRelationship(rel)).toBe(true)
+  })
+
+  it('should export isPath', () => {
+    const path = new Path(
+      new Node(int(1), ['a'], ['1']),
+      new Node(int(1), ['a'], ['1']),
+      []
+    )
+
+    expect(isPath(path)).toBe(true)
+  })
+
+  it('should export graph.isPath', () => {
+    const path = new Path(
+      new Node(int(1), ['a'], ['1']),
+      new Node(int(1), ['a'], ['1']),
+      []
+    )
+
+    expect(graph.isPath(path)).toBe(true)
+  })
+
+  it('should export isPathSegment', () => {
+    const pathSeg = new PathSegment(
+      new Node(int(1), ['a'], ['1']),
+      new Relationship(int(123), int(1), int(1), 'rel', {}),
+      new Node(int(1), ['a'], ['1'])
+    )
+
+    expect(isPathSegment(pathSeg)).toBe(true)
+  })
+
+  it('should export graph.isPath', () => {
+    const pathSeg = new PathSegment(
+      new Node(int(1), ['a'], ['1']),
+      new Relationship(int(123), int(1), int(1), 'rel', {}),
+      new Node(int(1), ['a'], ['1'])
+    )
+
+    expect(graph.isPathSegment(pathSeg)).toBe(true)
   })
 })

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -40,7 +40,12 @@ import {
   isDuration,
   isLocalDateTime,
   isLocalTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
   isTime,
+  isUnboundRelationship,
   LocalDateTime,
   LocalTime,
   Time,
@@ -402,6 +407,17 @@ const temporal = {
 }
 
 /**
+ * Object containing functions to work with graph types, like {@link Node} or {@link Relationship}.
+ */
+const graph = {
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship
+}
+
+/**
  * @private
  */
 const forExport = {
@@ -416,6 +432,11 @@ const forExport = {
   isDate,
   isLocalDateTime,
   isDateTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship,
   integer,
   Neo4jError,
   isRetryableError,
@@ -424,6 +445,7 @@ const forExport = {
   types,
   session,
   error,
+  graph,
   spatial,
   temporal,
   Driver,
@@ -470,6 +492,11 @@ export {
   isDate,
   isLocalDateTime,
   isDateTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship,
   integer,
   Neo4jError,
   isRetryableError,
@@ -478,6 +505,7 @@ export {
   types,
   session,
   error,
+  graph,
   spatial,
   temporal,
   Driver,

--- a/packages/neo4j-driver/test/index.test.js
+++ b/packages/neo4j-driver/test/index.test.js
@@ -28,7 +28,14 @@ import neo4j, {
   Time,
   Date,
   LocalDateTime,
-  DateTime
+  int,
+  DateTime,
+  graph,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship
 } from '../src'
 
 import {
@@ -508,5 +515,101 @@ describe('#unit index', () => {
         return new InternalDateTime(1, 1, 1, 1, 1, 1, 1, 1)
       }
     })
+  })
+
+  it('should export isNode', () => {
+    const node = new Node(int(123), ['abc'], [1])
+
+    expect(isNode(node)).toBe(true)
+  })
+
+  it('should export graph.isNode', () => {
+    const node = new Node(int(123), ['abc'], [1])
+
+    expect(graph.isNode(node)).toBe(true)
+  })
+
+  it('should export isRelationship', () => {
+    const rel = new Relationship(
+      int(123),
+      int(1),
+      int(1),
+      'rel',
+      {}
+    )
+
+    expect(isRelationship(rel)).toBe(true)
+  })
+
+  it('should export graph.isRelationship', () => {
+    const rel = new Relationship(
+      int(123),
+      int(1),
+      int(1),
+      'rel',
+      {}
+    )
+
+    expect(graph.isRelationship(rel)).toBe(true)
+  })
+
+  it('should export isUnboundRelationship', () => {
+    const rel = new UnboundRelationship(
+      int(123),
+      'rel',
+      {}
+    )
+
+    expect(isUnboundRelationship(rel)).toBe(true)
+  })
+
+  it('should export graph.isUnboundRelationship', () => {
+    const rel = new UnboundRelationship(
+      int(123),
+      'rel',
+      {}
+    )
+
+    expect(graph.isUnboundRelationship(rel)).toBe(true)
+  })
+
+  it('should export isPath', () => {
+    const path = new Path(
+      new Node(int(1), ['a'], ['1']),
+      new Node(int(1), ['a'], ['1']),
+      []
+    )
+
+    expect(isPath(path)).toBe(true)
+  })
+
+  it('should export graph.isPath', () => {
+    const path = new Path(
+      new Node(int(1), ['a'], ['1']),
+      new Node(int(1), ['a'], ['1']),
+      []
+    )
+
+    expect(graph.isPath(path)).toBe(true)
+  })
+
+  it('should export isPathSegment', () => {
+    const pathSeg = new PathSegment(
+      new Node(int(1), ['a'], ['1']),
+      new Relationship(int(123), int(1), int(1), 'rel', {}),
+      new Node(int(1), ['a'], ['1'])
+    )
+
+    expect(isPathSegment(pathSeg)).toBe(true)
+  })
+
+  it('should export graph.isPath', () => {
+    const pathSeg = new PathSegment(
+      new Node(int(1), ['a'], ['1']),
+      new Relationship(int(123), int(1), int(1), 'rel', {}),
+      new Node(int(1), ['a'], ['1'])
+    )
+
+    expect(graph.isPathSegment(pathSeg)).toBe(true)
   })
 })

--- a/packages/neo4j-driver/test/types/index.test.ts
+++ b/packages/neo4j-driver/test/types/index.test.ts
@@ -28,7 +28,13 @@ import {
   session,
   spatial,
   temporal,
-  DateTime
+  DateTime,
+  graph,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship
 } from '../../types/index'
 
 import Driver from '../../types/driver'
@@ -86,3 +92,15 @@ const isNeo4jLocalDateTime: boolean = temporal.isLocalDateTime({})
 const isNeo4jLocalTime: boolean = temporal.isLocalTime({})
 const isNeo4jTime: boolean = temporal.isTime({})
 const dateTime = DateTime.fromStandardDate(new Date())
+
+const graphIsNode: boolean = graph.isNode({})
+const graphIsPath: boolean = graph.isPath({})
+const graphIsPathSegment: boolean = graph.isPathSegment({})
+const graphIsRelationship: boolean = graph.isRelationship({})
+const graphIsUnboundRelationship: boolean = graph.isUnboundRelationship({})
+
+const neo4jIsNode: boolean = isNode({})
+const neo4jIsPath: boolean = isPath({})
+const neo4jIsPathSegment: boolean = isPathSegment({})
+const neo4jIsRelationship: boolean = isRelationship({})
+const neo4jIsUnboundRelationship: boolean = isUnboundRelationship({})

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -38,6 +38,11 @@ import {
   isLocalDateTime,
   isLocalTime,
   isTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship,
   LocalDateTime,
   LocalTime,
   Time,
@@ -156,6 +161,14 @@ declare const temporal: {
   isDateTime: typeof isDateTime
 }
 
+declare const graph: {
+  isNode: typeof isNode
+  isPath: typeof isPath
+  isPathSegment: typeof isPathSegment
+  isRelationship: typeof isRelationship
+  isUnboundRelationship: typeof isUnboundRelationship
+}
+
 /*
  Both default and non-default exports declare all visible types so that they can be used in client code like this:
 
@@ -175,6 +188,7 @@ declare const forExport: {
   types: typeof types
   session: typeof session
   error: typeof error
+  graph: typeof graph
   spatial: typeof spatial
   temporal: typeof temporal
   Driver: Driver
@@ -224,6 +238,11 @@ declare const forExport: {
   isDate: typeof isDate
   isLocalDateTime: typeof isLocalDateTime
   isDateTime: typeof isDateTime
+  isNode: typeof isNode
+  isPath: typeof isPath
+  isPathSegment: typeof isPathSegment
+  isRelationship: typeof isRelationship
+  isUnboundRelationship: typeof isUnboundRelationship
   bookmarkManager: typeof bookmarkManager
 }
 
@@ -237,6 +256,7 @@ export {
   types,
   session,
   error,
+  graph,
   spatial,
   temporal,
   Driver,
@@ -286,6 +306,11 @@ export {
   isDate,
   isLocalDateTime,
   isDateTime,
+  isNode,
+  isPath,
+  isPathSegment,
+  isRelationship,
+  isUnboundRelationship,
   bookmarkManager
 }
 


### PR DESCRIPTION
This functions were not exposed before.
Exposing these functions give more power to the user introspect the values in the records.

Example:
```typescript 
import neo4j from 'neo4j-driver'

neo4j.isNode({}) // should return false
neo4j.graph.isNode({}) // should return false
```
