### PR TITLE
Fix exported types

### DIFF
--- a/packages/neo4j-driver/test/types/export.test.ts
+++ b/packages/neo4j-driver/test/types/export.test.ts
@@ -20,13 +20,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { Bookmarks } from 'neo4j-driver-core/types/internal/bookmarks'
+import { ConnectionProvider } from 'neo4j-driver-core'
 import driver, {
   DateTime,
   RxSession,
   RxTransaction,
   RxResult,
   Session,
-  ConnectionProvider,
   Record,
   types
 } from '../../'
@@ -89,3 +89,38 @@ const instanceOfInteger: boolean = dummy instanceof types.Integer
 const instanceOfResult: boolean = dummy instanceof types.Result
 const instanceOfResultSummary: boolean = dummy instanceof types.ResultSummary
 const instanceOfRecord: boolean = dummy instanceof types.Record
+const instanceOfRxSession: boolean = dummy instanceof types.RxSession
+const instanceOfRxTransaction: boolean = dummy instanceof types.RxTransaction
+const instanceOfRxManagedTransaction: boolean = dummy instanceof types.RxManagedTransaction
+const instanceOfRxResult: boolean = dummy instanceof types.RxResult
+
+const instanceOfDriverDriver: boolean = dummy instanceof driver.Driver
+const instanceOfDriverNeo4jError: boolean = dummy instanceof driver.Neo4jError
+const instanceOfDriverNode: boolean = dummy instanceof driver.Node
+const instanceOfDriverRelationship: boolean = dummy instanceof driver.Relationship
+const instanceOfDriverUnboundRelationship: boolean = dummy instanceof driver.UnboundRelationship
+const instanceOfDriverPathSegment: boolean = dummy instanceof driver.PathSegment
+const instanceOfDriverPath: boolean = dummy instanceof driver.Path
+const instanceOfDriverInteger: boolean = dummy instanceof driver.Integer
+const instanceOfDriverRecord: boolean = dummy instanceof driver.Record
+const instanceOfDriverResult: boolean = dummy instanceof driver.Result
+const instanceOfDriverResultSummary: boolean = dummy instanceof driver.ResultSummary
+const instanceOfDriverPlan: boolean = dummy instanceof driver.Plan
+const instanceOfDriverProfiledPlan: boolean = dummy instanceof driver.ProfiledPlan
+const instanceOfDriverQueryStatistics: boolean = dummy instanceof driver.QueryStatistics
+const instanceOfDriverNotification: boolean = dummy instanceof driver.Notification
+const instanceOfDriverServerInfo: boolean = dummy instanceof driver.ServerInfo
+const instanceOfDriverSession: boolean = dummy instanceof driver.Session
+const instanceOfDriverTransaction: boolean = dummy instanceof driver.Transaction
+const instanceOfDriverManagedTransaction: boolean = dummy instanceof driver.ManagedTransaction
+const instanceOfDriverPoint: boolean = dummy instanceof driver.Point
+const instanceOfDriverDuration: boolean = dummy instanceof driver.Duration
+const instanceOfDriverLocalTime: boolean = dummy instanceof driver.LocalTime
+const instanceOfDriverTime: boolean = dummy instanceof driver.Time
+const instanceOfDriverDate: boolean = dummy instanceof driver.Date
+const instanceOfDriverLocalDateTime: boolean = dummy instanceof driver.LocalDateTime
+const instanceOfDriverDateTime: boolean = dummy instanceof driver.DateTime
+const instanceOfDriverRxSession: boolean = dummy instanceof driver.RxSession
+const instanceOfDriverRxTransaction: boolean = dummy instanceof driver.RxTransaction
+const instanceOfDriverRxManagedTransaction: boolean = dummy instanceof driver.RxManagedTransaction
+const instanceOfDriverRxResult: boolean = dummy instanceof driver.RxResult

--- a/packages/neo4j-driver/types/driver.d.ts
+++ b/packages/neo4j-driver/types/driver.d.ts
@@ -34,7 +34,7 @@ declare type SessionMode = types.SessionMode
 declare const READ: SessionMode
 declare const WRITE: SessionMode
 
-declare interface Driver extends CoreDriver {
+declare class Driver extends CoreDriver {
   rxSession: (sessionParams?: SessionConfig) => RxSession
 }
 

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -60,7 +60,6 @@ import {
   Transaction,
   ManagedTransaction,
   Session,
-  ConnectionProvider,
   BookmarkManager,
   bookmarkManager,
   BookmarkManagerConfig,
@@ -126,10 +125,10 @@ declare const types: {
   LocalDateTime: typeof LocalDateTime
   DateTime: typeof DateTime
   Integer: typeof Integer
-  RxSession: RxSession
-  RxTransaction: RxTransaction
-  RxManagedTransaction: RxManagedTransaction
-  RxResult: RxResult
+  RxSession: typeof RxSession
+  RxTransaction: typeof RxTransaction
+  RxManagedTransaction: typeof RxManagedTransaction
+  RxResult: typeof RxResult
 }
 
 declare const session: {
@@ -177,47 +176,46 @@ declare const forExport: {
   error: typeof error
   spatial: typeof spatial
   temporal: typeof temporal
-  Driver: Driver
+  Driver: typeof Driver
   AuthToken: AuthToken
   Config: Config
   EncryptionLevel: EncryptionLevel
   TrustStrategy: TrustStrategy
   SessionMode: SessionMode
-  Neo4jError: Neo4jError
+  Neo4jError: typeof Neo4jError
   isRetriableError: typeof isRetriableError
-  Node: Node
-  Relationship: Relationship
-  UnboundRelationship: UnboundRelationship
-  PathSegment: PathSegment
-  Path: Path
-  Integer: Integer
-  Record: Record
-  Result: Result
+  Node: typeof Node
+  Relationship: typeof Relationship
+  UnboundRelationship: typeof UnboundRelationship
+  PathSegment: typeof PathSegment
+  Path: typeof Path
+  Integer: typeof Integer
+  Record: typeof Record
+  Result: typeof Result
   QueryResult: QueryResult
   ResultObserver: ResultObserver
-  ResultSummary: ResultSummary
-  Plan: Plan
-  ProfiledPlan: ProfiledPlan
-  QueryStatistic: QueryStatistics
-  Notification: Notification
-  ServerInfo: ServerInfo
+  ResultSummary: typeof ResultSummary
+  Plan: typeof Plan
+  ProfiledPlan: typeof ProfiledPlan
+  QueryStatistics: typeof QueryStatistics
+  Notification: typeof Notification
+  ServerInfo: typeof ServerInfo
   NotificationPosition: NotificationPosition
-  Session: Session
-  Transaction: Transaction
-  ManagedTransaction: ManagedTransaction
-  Point: Point
+  Session: typeof Session
+  Transaction: typeof Transaction
+  ManagedTransaction: typeof ManagedTransaction
+  Point: typeof Point
   isPoint: typeof isPoint
-  Duration: Duration
-  LocalTime: LocalTime
-  Time: Time
-  Date: Date
-  LocalDateTime: LocalDateTime
-  DateTime: DateTime
-  RxSession: RxSession
-  RxTransaction: RxTransaction
-  RxManagedTransaction: RxManagedTransaction
-  RxResult: RxResult
-  ConnectionProvider: ConnectionProvider
+  Duration: typeof Duration
+  LocalTime: typeof LocalTime
+  Time: typeof Time
+  Date: typeof Date
+  LocalDateTime: typeof LocalDateTime
+  DateTime: typeof DateTime
+  RxSession: typeof RxSession
+  RxTransaction: typeof RxTransaction
+  RxManagedTransaction: typeof RxManagedTransaction
+  RxResult: typeof RxResult
   isDuration: typeof isDuration
   isLocalTime: typeof isLocalTime
   isTime: typeof isTime
@@ -279,7 +277,6 @@ export {
   RxTransaction,
   RxManagedTransaction,
   RxResult,
-  ConnectionProvider,
   isDuration,
   isLocalTime,
   isTime,

--- a/packages/neo4j-driver/types/result-rx.d.ts
+++ b/packages/neo4j-driver/types/result-rx.d.ts
@@ -19,7 +19,7 @@
 import { Observable } from 'rxjs'
 import { Record, ResultSummary } from 'neo4j-driver-core'
 
-declare interface RxResult {
+declare class RxResult {
   keys: () => Observable<string[]>
 
   records: () => Observable<Record>

--- a/packages/neo4j-driver/types/session-rx.d.ts
+++ b/packages/neo4j-driver/types/session-rx.d.ts
@@ -24,7 +24,7 @@ import { Observable } from 'rxjs'
 
 declare type RxTransactionWork<T> = (tx: RxTransaction) => Observable<T>
 
-declare interface RxSession {
+declare class RxSession {
   run: (
     query: string,
     parameters?: Parameters,

--- a/packages/neo4j-driver/types/transaction-managed-rx.d.ts
+++ b/packages/neo4j-driver/types/transaction-managed-rx.d.ts
@@ -19,7 +19,7 @@
 import { Parameters } from './query-runner'
 import RxResult from './result-rx'
 
-declare interface RxManagedTransaction {
+declare class RxManagedTransaction {
   run: (query: string, parameters?: Parameters) => RxResult
 }
 

--- a/packages/neo4j-driver/types/transaction-rx.d.ts
+++ b/packages/neo4j-driver/types/transaction-rx.d.ts
@@ -20,7 +20,7 @@ import { Observable } from 'rxjs'
 import { Parameters } from './query-runner'
 import RxResult from './result-rx'
 
-declare interface RxTransaction {
+declare class RxTransaction {
   run: (query: string, parameters?: Parameters) => RxResult
 
   isOpen: () => boolean


### PR DESCRIPTION
Types accessed by `neo4j.types.` or `neo4j.` where not being able to perform `instanceof` because of the wrong exporting.
