### PR TITLE
Fix Integer primitive type representation

### DIFF
--- a/packages/core/src/integer.ts
+++ b/packages/core/src/integer.ts
@@ -198,6 +198,21 @@ class Integer {
   }
 
   /**
+   * Converts the Integer to it primitive value.
+   *
+   * @since 5.4.0
+   * @returns {bigint}
+   *
+   * @see {@link Integer#toBigInt}
+   * @see {@link Integer#toInt}
+   * @see {@link Integer#toNumber}
+   * @see {@link Integer#toString}
+   */
+  valueOf (): bigint {
+    return this.toBigInt()
+  }
+
+  /**
    * Gets the high 32 bits as a signed integer.
    * @returns {number} Signed high bits
    * @expose

--- a/packages/core/test/integer.test.ts
+++ b/packages/core/test/integer.test.ts
@@ -398,6 +398,70 @@ describe('Integer', () => {
     )
   })
 
+  test('Integer should be able to use + operator as bigint', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        (num1, num2) =>
+          // @ts-expect-error
+          // eslint-disable-next-line  @typescript-eslint/restrict-plus-operands
+          num1 + int(num2) === num1 + num2 &&
+          // @ts-expect-error
+          // eslint-disable-next-line  @typescript-eslint/restrict-plus-operands
+          int(num1) + num2 === num1 + num2 &&
+          // @ts-expect-error
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+          int(num1) + int(num2) === num1 + num2
+      ))
+  })
+
+  test('Integer should be able to use - operator as bigint', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        (num1, num2) =>
+          // @ts-expect-error
+          num1 - int(num2) === num1 - num2 &&
+          // @ts-expect-error
+          int(num1) - num2 === num1 - num2 &&
+          // @ts-expect-error
+          int(num1) - int(num2) === num1 - num2
+      ))
+  })
+
+  test('Integer should be able to use * operator as bigint', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        (num1, num2) =>
+          // @ts-expect-error
+          num1 * int(num2) === num1 * num2 &&
+          // @ts-expect-error
+          int(num1) * num2 === num1 * num2 &&
+          // @ts-expect-error
+          int(num1) * int(num2) === num1 * num2
+      ))
+  })
+
+  test('Integer should be able to use / operator as bigint', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        (num1, num2) =>
+          // @ts-expect-error
+          num1 / int(num2) === num1 / num2 &&
+          // @ts-expect-error
+          int(num1) / num2 === num1 / num2 &&
+          // @ts-expect-error
+          int(num1) / int(num2) === num1 / num2
+      ))
+  })
+
+
   test('int(string) should match int(Integer)', () => {
     fc.assert(fc.property(fc.integer(), i => int(i).equals(int(i.toString()))))
   })

--- a/packages/core/test/integer.test.ts
+++ b/packages/core/test/integer.test.ts
@@ -450,7 +450,7 @@ describe('Integer', () => {
     fc.assert(
       fc.property(
         fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
-        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }).filter(n => n !== BigInt(0)),
         (num1, num2) =>
           // @ts-expect-error
           num1 / int(num2) === num1 / num2 &&
@@ -460,7 +460,6 @@ describe('Integer', () => {
           int(num1) / int(num2) === num1 / num2
       ))
   })
-
 
   test('int(string) should match int(Integer)', () => {
     fc.assert(fc.property(fc.integer(), i => int(i).equals(int(i.toString()))))

--- a/packages/core/test/integer.test.ts
+++ b/packages/core/test/integer.test.ts
@@ -370,6 +370,34 @@ describe('Integer', () => {
     fc.assert(fc.property(fc.integer(), i => i.toString() === int(i).toString()))
   })
 
+  test('Integer.valueOf should be equivalent to the Integer.toBigInt', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        num => int(num).toBigInt() === int(num).valueOf()
+      )
+    )
+  })
+
+  test('Integer should concatenate with a string', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        num => 'string' + int(num) + 'str' === 'string' + int(num).toString() + 'str'
+      )
+    )
+  })
+
+  test('Integer should be able to used in the string interpolation', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),
+        num => `string${int(num)}str` === 'string' + int(num).toString() + 'str'
+      )
+    )
+  })
+
   test('int(string) should match int(Integer)', () => {
     fc.assert(fc.property(fc.integer(), i => int(i).equals(int(i.toString()))))
   })

--- a/packages/core/test/integer.test.ts
+++ b/packages/core/test/integer.test.ts
@@ -389,7 +389,7 @@ describe('Integer', () => {
     )
   })
 
-  test('Integer should be able to used in the string interpolation', () => {
+  test('Integer should be able to be used in the string interpolation', () => {
     fc.assert(
       fc.property(
         fc.bigInt({ max: Integer.MAX_SAFE_VALUE.toBigInt(), min: Integer.MIN_SAFE_VALUE.toBigInt() }),

--- a/packages/neo4j-driver-deno/lib/core/integer.ts
+++ b/packages/neo4j-driver-deno/lib/core/integer.ts
@@ -198,6 +198,21 @@ class Integer {
   }
 
   /**
+   * Converts the Integer to it primitive value.
+   *
+   * @since 5.4.0
+   * @returns {bigint}
+   *
+   * @see {@link Integer#toBigInt}
+   * @see {@link Integer#toInt}
+   * @see {@link Integer#toNumber}
+   * @see {@link Integer#toString}
+   */
+  valueOf (): bigint {
+    return this.toBigInt()
+  }
+
+  /**
    * Gets the high 32 bits as a signed integer.
    * @returns {number} Signed high bits
    * @expose

--- a/packages/neo4j-driver/test/internal/routing-table.test.js
+++ b/packages/neo4j-driver/test/internal/routing-table.test.js
@@ -265,7 +265,7 @@ describe('#unit RoutingTable', () => {
       }))
 
     it('should return Integer.MAX_VALUE as expirationTime when ttl overflowed', async () => {
-      const ttl = int(Integer.MAX_VALUE - 2)
+      const ttl = int(Integer.MAX_VALUE - 2n)
       const routers = ['router:7699']
       const readers = ['reader1:7699', 'reader2:7699']
       const writers = ['writer1:7693', 'writer2:7692', 'writer3:7629']


### PR DESCRIPTION
Given the scenario where:

```javascript
const one = neo4j.int(1)
const two = neo4j.int(2)
```

The following operations was resulting in string concatenation:

```javascript
console.log( one + two ) // '12'
console.log( 1 + one ) // '11'

console.log( one.add(two).toInt() ) // 3, which is correct
console.log( '1' + one ) // '11', correct
```

This is issue is solved by defining the method `Integer.valueOf` which defines the primitive type representation. The primitive representation of `Integer` is set as `BigInt`.

This way:

```javascript
console.log( one + two ) // 3n
console.log( 1 + one ) // thrown an exception since we can not add bigint to number
console.log( 1n + one ) // 2n
console.log( -one ) // -1n
console.log( '1' + one ) // '11', correct
```