### PR TITLE
Fix `executeQuery` default return type

### DIFF
--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -471,7 +471,7 @@ class Driver {
    * @see {@link resultTransformers} for provided result transformers.
    * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
-  async executeQuery<T> (query: Query, parameters?: any, config: QueryConfig<T> = {}): Promise<T> {
+  async executeQuery<T = EagerResult> (query: Query, parameters?: any, config: QueryConfig<T> = {}): Promise<T> {
     const bookmarkManager = config.bookmarkManager === null ? undefined : (config.bookmarkManager ?? this.queryBookmarkManager)
     const resultTransformer = (config.resultTransformer ?? resultTransformers.eagerResultTransformer()) as ResultTransformer<T>
     const routingConfig: string = config.routing ?? routing.WRITERS

--- a/packages/core/test/driver.test.ts
+++ b/packages/core/test/driver.test.ts
@@ -342,6 +342,32 @@ describe('Driver', () => {
         }, query, params)
       })
 
+      it('should be able to destruct the result in records, keys and summary', async () => {
+        const query = 'Query'
+        const params = {}
+        const spiedExecute = jest.spyOn(queryExecutor, 'execute')
+        const expected: EagerResult = {
+          keys: ['a'],
+          records: [],
+          summary: new ResultSummary(query, params, {}, 5.0)
+        }
+        spiedExecute.mockResolvedValue(expected)
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const { records, keys, summary } = await driver!.executeQuery(query, params)
+
+        expect(records).toEqual(expected.records)
+        expect(keys).toEqual(expected.keys)
+        expect(summary).toEqual(expected.summary)
+        expect(spiedExecute).toBeCalledWith({
+          resultTransformer: resultTransformers.eagerResultTransformer(),
+          bookmarkManager: driver?.queryBookmarkManager,
+          routing: routing.WRITERS,
+          database: undefined,
+          impersonatedUser: undefined
+        }, query, params)
+      })
+
       it('should be able get type-safe Records', async () => {
         interface Person {
           name: string

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -471,7 +471,7 @@ class Driver {
    * @see {@link resultTransformers} for provided result transformers.
    * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
-  async executeQuery<T> (query: Query, parameters?: any, config: QueryConfig<T> = {}): Promise<T> {
+  async executeQuery<T = EagerResult> (query: Query, parameters?: any, config: QueryConfig<T> = {}): Promise<T> {
     const bookmarkManager = config.bookmarkManager === null ? undefined : (config.bookmarkManager ?? this.queryBookmarkManager)
     const resultTransformer = (config.resultTransformer ?? resultTransformers.eagerResultTransformer()) as ResultTransformer<T>
     const routingConfig: string = config.routing ?? routing.WRITERS


### PR DESCRIPTION
The executeQuery method was returning `Promise<unknown>` when no transformer or typing was provided like in the example bellow:

```typescript
// works
const { records } = await driver.executeQuery<EegerResult>(`query`)

// works
const { records }: EagerResult = await driver.executeQuery(`query`)

// doesn't work, but it is fixed by this change
const { records } = await driver.executeQuery(`query`)
```

Defining a default generic type solves the issue.