### PR TITLE
Improve record shapping mapping in `Driver#executeQuery`

### DIFF
--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -47,6 +47,7 @@ import resultTransformers, { ResultTransformer } from './result-transformers'
 import QueryExecutor from './internal/query-executor'
 import { newError } from './error'
 import NotificationFilter from './notification-filter'
+import { Dict } from './record'
 
 const DEFAULT_MAX_CONNECTION_LIFETIME: number = 60 * 60 * 1000 // 1 hour
 
@@ -331,12 +332,12 @@ Object.freeze(routing)
  * @experimental This can be changed or removed anytime.
  * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
  */
-class QueryConfig<T = EagerResult> {
+class QueryConfig<RecordShape extends Dict = Dict, T = EagerResult<RecordShape>> {
   routing?: RoutingControl
   database?: string
   impersonatedUser?: string
   bookmarkManager?: BookmarkManager | null
-  resultTransformer?: ResultTransformer<T>
+  resultTransformer?: ResultTransformer<T, RecordShape>
 
   /**
    * @constructor
@@ -539,9 +540,9 @@ class Driver {
    * @see {@link resultTransformers} for provided result transformers.
    * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
-  async executeQuery<T = EagerResult> (query: Query, parameters?: any, config: QueryConfig<T> = {}): Promise<T> {
+  async executeQuery<RecordShape extends Dict = Dict, T = EagerResult<RecordShape>> (query: Query, parameters?: any, config: QueryConfig<RecordShape, T> = {}): Promise<T> {
     const bookmarkManager = config.bookmarkManager === null ? undefined : (config.bookmarkManager ?? this.defaultExecuteQueryBookmarkManager)
-    const resultTransformer = (config.resultTransformer ?? resultTransformers.eagerResultTransformer()) as ResultTransformer<T>
+    const resultTransformer = (config.resultTransformer ?? resultTransformers.eagerResultTransformer()) as ResultTransformer<T, RecordShape>
     const routingConfig: string = config.routing ?? routing.WRITERS
 
     if (routingConfig !== routing.READERS && routingConfig !== routing.WRITERS) {

--- a/packages/core/src/result-transformers.ts
+++ b/packages/core/src/result-transformers.ts
@@ -29,7 +29,8 @@ async function createEagerResultFromResult<Entries extends Dict> (result: Result
   return new EagerResult<Entries>(keys, records, summary)
 }
 
-type ResultTransformer<T> = (result: Result) => Promise<T>
+type ResultTransformer<T, RecordShape extends Dict = Dict> = (result: Result<RecordShape>) => Promise<T>
+
 /**
  * Protocol for transforming {@link Result}.
  *
@@ -64,10 +65,10 @@ class ResultTransformers {
    *
    *
    * @experimental This can be changed or removed anytime.
-   * @returns {ResultTransformer<EagerResult<Entries>>} The result transformer
+   * @returns {ResultTransformer<EagerResult<RecordShape>>} The result transformer
    * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
-  eagerResultTransformer<Entries extends Dict = Dict>(): ResultTransformer<EagerResult<Entries>> {
+  eagerResultTransformer<RecordShape extends Dict = Dict>(): ResultTransformer<EagerResult<RecordShape>> {
     return createEagerResultFromResult
   }
 

--- a/packages/core/test/driver.test.ts
+++ b/packages/core/test/driver.test.ts
@@ -551,7 +551,7 @@ describe('Driver', () => {
         expect(output).toEqual(expected)
       })
 
-      it('should handle correct record shape type mapping for a custom result transformer', async () => {
+      it('should handle correct explicity record shape type mapping for a custom result transformer', async () => {
         interface Person {
           name: string
           age: number
@@ -586,7 +586,7 @@ describe('Driver', () => {
         const query = 'Query'
         const params = {}
 
-        const output = driver?.executeQuery<Dict, string>(query, params, {
+        const output = driver?.executeQuery(query, params, {
           // @ts-expect-error
           routing: 'GO FIGURE'
         })

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -47,6 +47,7 @@ import resultTransformers, { ResultTransformer } from './result-transformers.ts'
 import QueryExecutor from './internal/query-executor.ts'
 import { newError } from './error.ts'
 import NotificationFilter from './notification-filter.ts'
+import { Dict } from './record.ts'
 
 const DEFAULT_MAX_CONNECTION_LIFETIME: number = 60 * 60 * 1000 // 1 hour
 
@@ -331,12 +332,12 @@ Object.freeze(routing)
  * @experimental This can be changed or removed anytime.
  * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
  */
-class QueryConfig<T = EagerResult> {
+class QueryConfig<RecordShape extends Dict = Dict, T = EagerResult<RecordShape>> {
   routing?: RoutingControl
   database?: string
   impersonatedUser?: string
   bookmarkManager?: BookmarkManager | null
-  resultTransformer?: ResultTransformer<T>
+  resultTransformer?: ResultTransformer<T, RecordShape>
 
   /**
    * @constructor
@@ -539,9 +540,9 @@ class Driver {
    * @see {@link resultTransformers} for provided result transformers.
    * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
-  async executeQuery<T = EagerResult> (query: Query, parameters?: any, config: QueryConfig<T> = {}): Promise<T> {
+  async executeQuery<RecordShape extends Dict = Dict, T = EagerResult<RecordShape>> (query: Query, parameters?: any, config: QueryConfig<RecordShape, T> = {}): Promise<T> {
     const bookmarkManager = config.bookmarkManager === null ? undefined : (config.bookmarkManager ?? this.defaultExecuteQueryBookmarkManager)
-    const resultTransformer = (config.resultTransformer ?? resultTransformers.eagerResultTransformer()) as ResultTransformer<T>
+    const resultTransformer = (config.resultTransformer ?? resultTransformers.eagerResultTransformer()) as ResultTransformer<T, RecordShape>
     const routingConfig: string = config.routing ?? routing.WRITERS
 
     if (routingConfig !== routing.READERS && routingConfig !== routing.WRITERS) {

--- a/packages/neo4j-driver-deno/lib/core/result-transformers.ts
+++ b/packages/neo4j-driver-deno/lib/core/result-transformers.ts
@@ -29,7 +29,8 @@ async function createEagerResultFromResult<Entries extends Dict> (result: Result
   return new EagerResult<Entries>(keys, records, summary)
 }
 
-type ResultTransformer<T> = (result: Result) => Promise<T>
+type ResultTransformer<T, RecordShape extends Dict = Dict> = (result: Result<RecordShape>) => Promise<T>
+
 /**
  * Protocol for transforming {@link Result}.
  *
@@ -64,10 +65,10 @@ class ResultTransformers {
    *
    *
    * @experimental This can be changed or removed anytime.
-   * @returns {ResultTransformer<EagerResult<Entries>>} The result transformer
+   * @returns {ResultTransformer<EagerResult<RecordShape>>} The result transformer
    * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
-  eagerResultTransformer<Entries extends Dict = Dict>(): ResultTransformer<EagerResult<Entries>> {
+  eagerResultTransformer<RecordShape extends Dict = Dict>(): ResultTransformer<EagerResult<RecordShape>> {
     return createEagerResultFromResult
   }
 


### PR DESCRIPTION
The changes allows the `RecordShape` to be passed through the `executeQuery` method. This way, removing the need of access the `EagerResult` type for passing the type.

Transforming:

```typescript
const result: EagerResult<Person> = driver.executeQuery("My Query")
const person = result.records.map(record => record.toObject()) // the type infered is Person[]

```

to:

```typescript
const result = driver.executeQuery<Person>("My Query") // the type infered is EagerResult<Person>
const person = result.records.map(record => record.toObject()) // the type infered is Person[]
```

Altough, this a breaking changing on the generic types for `executeQuery`. It isn't possible to define the return from the transformer without defining the record shape. However, this is a more advanced use case where the user wants to define their own result transformer.

