### PR TITLE
Add default info for `fetchSize` session config

### DIFF
--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -196,6 +196,7 @@ class SessionConfig {
      * The record fetch size of each batch of this session.
      *
      * Use {@link FETCH_ALL} to always pull all records in one batch. This will override the config value set on driver config.
+     * **Default**: {@link DEFAULT_FETCH_SIZE}
      *
      * @type {number|undefined}
      */


### PR DESCRIPTION
The current undefined is a bit misleading, as it doesn't give away what the actual value is. I would then assume that no value => fetch all. I'd even advocate for putting 1000 into the docstring there, but this is a decision for @bigmontz