### PR TITLE
Release `BookmarkManager` and `Driver.executeQuery`

### DIFF
--- a/packages/core/src/bookmark-manager.ts
+++ b/packages/core/src/bookmark-manager.ts
@@ -21,7 +21,6 @@
  * Interface for the piece of software responsible for keeping track of current active bookmarks accross the driver.
  * @interface
  * @since 5.0
- * @experimental
  */
 export default class BookmarkManager {
   /**
@@ -66,7 +65,6 @@ export interface BookmarkManagerConfig {
  * @typedef {Object} BookmarkManagerConfig
  *
  * @since 5.0
- * @experimental
  * @property {Iterable<string>} [initialBookmarks] Defines the initial set of bookmarks. The key is the database name and the values are the bookmarks.
  * @property {function():Promise<Iterable<string>>} [bookmarksSupplier] Called for supplying extra bookmarks to the BookmarkManager
  * @property {function(bookmarks: Iterable<string>): Promise<void>} [bookmarksConsumer] Called when the set of bookmarks  get updated
@@ -75,7 +73,6 @@ export interface BookmarkManagerConfig {
  * Provides an configured {@link BookmarkManager} instance.
  *
  * @since 5.0
- * @experimental
  * @param {BookmarkManagerConfig} [config={}]
  * @returns {BookmarkManager}
  */

--- a/packages/core/src/internal/query-executor.ts
+++ b/packages/core/src/internal/query-executor.ts
@@ -28,7 +28,7 @@ type SessionFactory = (config: { database?: string, bookmarkManager?: BookmarkMa
 type TransactionFunction<T> = (transactionWork: (tx: ManagedTransaction) => Promise<T>) => Promise<T>
 
 interface ExecutionConfig<T> {
-  routing: 'WRITERS' | 'READERS'
+  routing: 'WRITE' | 'READ'
   database?: string
   impersonatedUser?: string
   bookmarkManager?: BookmarkManager
@@ -47,7 +47,7 @@ export default class QueryExecutor {
       impersonatedUser: config.impersonatedUser
     })
     try {
-      const executeInTransaction: TransactionFunction<T> = config.routing === 'READERS'
+      const executeInTransaction: TransactionFunction<T> = config.routing === 'READ'
         ? session.executeRead.bind(session)
         : session.executeWrite.bind(session)
 

--- a/packages/core/src/result-transformers.ts
+++ b/packages/core/src/result-transformers.ts
@@ -35,17 +35,12 @@ type ResultTransformer<T> = (result: Result) => Promise<T>
  *
  * @typedef {function<T>(result:Result):Promise<T>} ResultTransformer
  * @interface
- * @experimental This can be changed or removed anytime.
  *
  * @see {@link resultTransformers} for provided implementations.
  * @see {@link Driver#executeQuery} for usage.
- * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
  */
 /**
  * Defines the object which holds the common {@link ResultTransformer} used with {@link Driver#executeQuery}.
- *
- * @experimental This can be changed or removed anytime.
- * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
  */
 class ResultTransformers {
   /**
@@ -62,10 +57,7 @@ class ResultTransformers {
    * // is equivalent to:
    * const { keys, records, summary } = await driver.executeQuery('CREATE (p:Person{ name: $name }) RETURN p', { name: 'Person1'})
    *
-   *
-   * @experimental This can be changed or removed anytime.
    * @returns {ResultTransformer<EagerResult<Entries>>} The result transformer
-   * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
   eagerResultTransformer<Entries extends Dict = Dict>(): ResultTransformer<EagerResult<Entries>> {
     return createEagerResultFromResult
@@ -126,14 +118,12 @@ class ResultTransformers {
    * const objects = await session.executeRead(tx => getRecordsAsObjects(tx.run('MATCH (p:Person{ age: $age }) RETURN p.name as name')))
    * objects.forEach(object => console.log(`${object.name} has 25`))
    *
-   * @experimental This can be changed or removed anytime.
    * @param {object} config The result transformer configuration
    * @param {function(record:Record):R} [config.map=function(record) {  return record }] Method called for mapping each record
    * @param {function(records:R[], summary:ResultSummary, keys:string[]):T} [config.collect=function(records, summary, keys) { return { records, summary, keys }}] Method called for mapping
    * the result data to the transformer output.
    * @returns {ResultTransformer<T>} The result transformer
    * @see {@link Driver#executeQuery}
-   * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
   mappedResultTransformer <
     R = Record, T = { records: R[], keys: string[], summary: ResultSummary }
@@ -178,9 +168,6 @@ class ResultTransformers {
 
 /**
  * Holds the common {@link ResultTransformer} used with {@link Driver#executeQuery}.
- *
- * @experimental This can be changed or removed anytime.
- * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
  */
 const resultTransformers = new ResultTransformers()
 

--- a/packages/core/test/driver.test.ts
+++ b/packages/core/test/driver.test.ts
@@ -397,8 +397,8 @@ describe('Driver', () => {
         expect(eagerResult).toEqual(expected)
         expect(spiedExecute).toBeCalledWith({
           resultTransformer: resultTransformers.eagerResultTransformer(),
-          bookmarkManager: driver?.defaultExecuteQueryBookmarkManager,
-          routing: routing.WRITERS,
+          bookmarkManager: driver?.executeQueryBookmarkManager,
+          routing: routing.WRITE,
           database: undefined,
           impersonatedUser: undefined
         }, query, params)
@@ -423,8 +423,8 @@ describe('Driver', () => {
         expect(summary).toEqual(expected.summary)
         expect(spiedExecute).toBeCalledWith({
           resultTransformer: resultTransformers.eagerResultTransformer(),
-          bookmarkManager: driver?.defaultExecuteQueryBookmarkManager,
-          routing: routing.WRITERS,
+          bookmarkManager: driver?.executeQueryBookmarkManager,
+          routing: routing.WRITE,
           database: undefined,
           impersonatedUser: undefined
         }, query, params)
@@ -476,8 +476,8 @@ describe('Driver', () => {
 
       it.each([
         ['empty config', 'the query', {}, {}, extendsDefaultWith({})],
-        ['config.routing=WRITERS', 'another query $s', { s: 'str' }, { routing: routing.WRITERS }, extendsDefaultWith({ routing: routing.WRITERS })],
-        ['config.routing=READERS', 'create num $d', { d: 1 }, { routing: routing.READERS }, extendsDefaultWith({ routing: routing.READERS })],
+        ['config.routing=WRITE', 'another query $s', { s: 'str' }, { routing: routing.WRITE }, extendsDefaultWith({ routing: routing.WRITE })],
+        ['config.routing=READ', 'create num $d', { d: 1 }, { routing: routing.READ }, extendsDefaultWith({ routing: routing.READ })],
         ['config.database="dbname"', 'q', {}, { database: 'dbname' }, extendsDefaultWith({ database: 'dbname' })],
         ['config.impersonatedUser="the_user"', 'q', {}, { impersonatedUser: 'the_user' }, extendsDefaultWith({ impersonatedUser: 'the_user' })],
         ['config.bookmarkManager=null', 'q', {}, { bookmarkManager: null }, extendsDefaultWith({ bookmarkManager: undefined })],
@@ -547,8 +547,8 @@ describe('Driver', () => {
         return () => {
           const defaultConfig = {
             resultTransformer: resultTransformers.eagerResultTransformer(),
-            bookmarkManager: driver?.defaultExecuteQueryBookmarkManager,
-            routing: routing.WRITERS,
+            bookmarkManager: driver?.executeQueryBookmarkManager,
+            routing: routing.WRITE,
             database: undefined,
             impersonatedUser: undefined
           }

--- a/packages/core/test/internal/query-executor.test.ts
+++ b/packages/core/test/internal/query-executor.test.ts
@@ -39,7 +39,7 @@ describe('QueryExecutor', () => {
     const { queryExecutor, createSession } = createExecutor()
 
     await queryExecutor.execute({
-      routing: 'WRITERS',
+      routing: 'WRITE',
       resultTransformer: async (result: Result) => await Promise.resolve(),
       ...executorConfig
     }, 'query')
@@ -47,12 +47,12 @@ describe('QueryExecutor', () => {
     expect(createSession).toBeCalledWith(expectConfig)
   })
 
-  describe('when routing="READERS"', () => {
+  describe('when routing="READ"', () => {
     const baseConfig: {
-      routing: 'READERS'
+      routing: 'READ'
       resultTransformer: (result: Result) => Promise<void>
     } = {
-      routing: 'READERS',
+      routing: 'READ',
       resultTransformer: async (result: Result) => await Promise.resolve()
     }
 
@@ -174,12 +174,12 @@ describe('QueryExecutor', () => {
     })
   })
 
-  describe('when routing="WRITERS"', () => {
+  describe('when routing="WRITE"', () => {
     const baseConfig: {
-      routing: 'WRITERS'
+      routing: 'WRITE'
       resultTransformer: (result: Result) => Promise<void>
     } = {
-      routing: 'WRITERS',
+      routing: 'WRITE',
       resultTransformer: async (result: Result) => await Promise.resolve()
     }
 

--- a/packages/neo4j-driver-deno/lib/core/bookmark-manager.ts
+++ b/packages/neo4j-driver-deno/lib/core/bookmark-manager.ts
@@ -21,7 +21,6 @@
  * Interface for the piece of software responsible for keeping track of current active bookmarks accross the driver.
  * @interface
  * @since 5.0
- * @experimental
  */
 export default class BookmarkManager {
   /**
@@ -66,7 +65,6 @@ export interface BookmarkManagerConfig {
  * @typedef {Object} BookmarkManagerConfig
  *
  * @since 5.0
- * @experimental
  * @property {Iterable<string>} [initialBookmarks] Defines the initial set of bookmarks. The key is the database name and the values are the bookmarks.
  * @property {function():Promise<Iterable<string>>} [bookmarksSupplier] Called for supplying extra bookmarks to the BookmarkManager
  * @property {function(bookmarks: Iterable<string>): Promise<void>} [bookmarksConsumer] Called when the set of bookmarks  get updated
@@ -75,7 +73,6 @@ export interface BookmarkManagerConfig {
  * Provides an configured {@link BookmarkManager} instance.
  *
  * @since 5.0
- * @experimental
  * @param {BookmarkManagerConfig} [config={}]
  * @returns {BookmarkManager}
  */

--- a/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
@@ -28,7 +28,7 @@ type SessionFactory = (config: { database?: string, bookmarkManager?: BookmarkMa
 type TransactionFunction<T> = (transactionWork: (tx: ManagedTransaction) => Promise<T>) => Promise<T>
 
 interface ExecutionConfig<T> {
-  routing: 'WRITERS' | 'READERS'
+  routing: 'WRITE' | 'READ'
   database?: string
   impersonatedUser?: string
   bookmarkManager?: BookmarkManager
@@ -47,7 +47,7 @@ export default class QueryExecutor {
       impersonatedUser: config.impersonatedUser
     })
     try {
-      const executeInTransaction: TransactionFunction<T> = config.routing === 'READERS'
+      const executeInTransaction: TransactionFunction<T> = config.routing === 'READ'
         ? session.executeRead.bind(session)
         : session.executeWrite.bind(session)
 

--- a/packages/neo4j-driver-deno/lib/core/result-transformers.ts
+++ b/packages/neo4j-driver-deno/lib/core/result-transformers.ts
@@ -35,17 +35,12 @@ type ResultTransformer<T> = (result: Result) => Promise<T>
  *
  * @typedef {function<T>(result:Result):Promise<T>} ResultTransformer
  * @interface
- * @experimental This can be changed or removed anytime.
  *
  * @see {@link resultTransformers} for provided implementations.
  * @see {@link Driver#executeQuery} for usage.
- * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
  */
 /**
  * Defines the object which holds the common {@link ResultTransformer} used with {@link Driver#executeQuery}.
- *
- * @experimental This can be changed or removed anytime.
- * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
  */
 class ResultTransformers {
   /**
@@ -62,10 +57,7 @@ class ResultTransformers {
    * // is equivalent to:
    * const { keys, records, summary } = await driver.executeQuery('CREATE (p:Person{ name: $name }) RETURN p', { name: 'Person1'})
    *
-   *
-   * @experimental This can be changed or removed anytime.
    * @returns {ResultTransformer<EagerResult<Entries>>} The result transformer
-   * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
   eagerResultTransformer<Entries extends Dict = Dict>(): ResultTransformer<EagerResult<Entries>> {
     return createEagerResultFromResult
@@ -126,14 +118,12 @@ class ResultTransformers {
    * const objects = await session.executeRead(tx => getRecordsAsObjects(tx.run('MATCH (p:Person{ age: $age }) RETURN p.name as name')))
    * objects.forEach(object => console.log(`${object.name} has 25`))
    *
-   * @experimental This can be changed or removed anytime.
    * @param {object} config The result transformer configuration
    * @param {function(record:Record):R} [config.map=function(record) {  return record }] Method called for mapping each record
    * @param {function(records:R[], summary:ResultSummary, keys:string[]):T} [config.collect=function(records, summary, keys) { return { records, summary, keys }}] Method called for mapping
    * the result data to the transformer output.
    * @returns {ResultTransformer<T>} The result transformer
    * @see {@link Driver#executeQuery}
-   * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
    */
   mappedResultTransformer <
     R = Record, T = { records: R[], keys: string[], summary: ResultSummary }
@@ -178,9 +168,6 @@ class ResultTransformers {
 
 /**
  * Holds the common {@link ResultTransformer} used with {@link Driver#executeQuery}.
- *
- * @experimental This can be changed or removed anytime.
- * @see https://github.com/neo4j/neo4j-javascript-driver/discussions/1052
  */
 const resultTransformers = new ResultTransformers()
 

--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -408,8 +408,8 @@ describe('index', () => {
 
   it('should export routing', () => {
     expect(neo4j.routing).toBeDefined()
-    expect(neo4j.routing.WRITERS).toBeDefined()
-    expect(neo4j.routing.READERS).toBeDefined()
+    expect(neo4j.routing.WRITE).toBeDefined()
+    expect(neo4j.routing.READ).toBeDefined()
   })
 
   it('should export notificationSeverityLevel', () => {

--- a/packages/neo4j-driver/test/types/index.test.ts
+++ b/packages/neo4j-driver/test/types/index.test.ts
@@ -90,10 +90,10 @@ const driver4: Driver = driver(
 const readMode1: string = session.READ
 const writeMode1: string = session.WRITE
 
-const writersString: string = routing.WRITERS
-const readersString: string = routing.READERS
-const writersRoutingControl: RoutingControl = routing.WRITERS
-const readersRoutingControl: RoutingControl = routing.READERS
+const writersString: string = routing.WRITE
+const readersString: string = routing.READ
+const writersRoutingControl: RoutingControl = routing.WRITE
+const readersRoutingControl: RoutingControl = routing.READ
 
 const serviceUnavailable1: string = error.SERVICE_UNAVAILABLE
 const sessionExpired1: string = error.SESSION_EXPIRED

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -633,10 +633,10 @@ export function ExecuteQuery ({ neo4j }, context, { driverId, cypher, params, co
     if ('routing' in config && config.routing != null) {
       switch (config.routing) {
         case 'w':
-          configuration.routing = neo4j.routing.WRITERS
+          configuration.routing = neo4j.routing.WRITE
           break
         case 'r':
-          configuration.routing = neo4j.routing.READERS
+          configuration.routing = neo4j.routing.READ
           break
         default:
           wire.writeBackendError('Unknown routing: ' + config.routing)


### PR DESCRIPTION
These new APIs are ready to be released in the Javascript Driver 5.8. This change remove the experimental tags from related APIs while makes the final adjustments to the API.

`neo4j.routing.WRITERS` and `neo4j.routing.READERS` were renamed to `neo4j.routing.WRITE` and `neo4j.routing.READ`, respectively. Or, `'WRITE'`/`'READ'` in plain string.

`Driver.defaultExecuteQueryBookmarkManager` was renamed to `Driver.executeQueryBookmarkManager`.