### PR TITLE
Enables Deno specific tests in Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "build::notci": "lerna bootstrap",
     "docs": "lerna run docs --stream --concurrency 1",
     "test::unit": "lerna run test::unit --stream",
+    "test::deno": "lerna run test::deno --stream",
     "test::integration": "lerna run test::integration --stream",
     "test::browser": "lerna run test::browser --stream",
     "test::stress": "lerna run test::stress  --stream",

--- a/packages/core/jest.config.ts
+++ b/packages/core/jest.config.ts
@@ -152,9 +152,10 @@ export default {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "/test/deno/"
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "test": "jest",
     "test::watch": "jest --watch",
     "test::unit": "npm run test",
+    "test::deno": "deno test --allow-none ./test/deno/",
     "predocs": "npm run build && npm run build::es6",
     "docs": "esdoc -c esdoc.json",
     "prepare": "npm run build",

--- a/testkit/unittests.py
+++ b/testkit/unittests.py
@@ -14,3 +14,6 @@ if __name__ == "__main__":
 
     run_in_driver_repo(["npm", "run", "lint"])
     run_in_driver_repo(["npm", "run", "test::unit", "--", ignore])
+
+    if is_deno():
+        run_in_driver_repo(["npm" "run", "test::deno"])


### PR DESCRIPTION
Core features which are environment dependent will need to be implemented. For testing this features, environment dependent tests need to be setup.

The `deno` tests can be run by `npm run test::deno` and they need to be located under `./packages/core/test/deno`. The testkit pipeline is configured to run these tests only when configured for test `deno`.