### PR TITLE
Fix browser `boltAgent` in web workers context

### DIFF
--- a/packages/core/src/internal/bolt-agent/browser/bolt-agent.ts
+++ b/packages/core/src/internal/bolt-agent/browser/bolt-agent.ts
@@ -35,8 +35,12 @@ export function fromVersion (
   version: string, 
   getSystemInfo: () => SystemInfo = () => ({ 
     get userAgent()  {
+      // this should be defined as an `var` since we need to get information
+      // came from the global scope which not always will be defined
+      // and we don't want to override the information
+      var navigator
       // @ts-ignore: browser code so must be skipped by ts
-      return window.navigator.userAgent
+      return navigator?.userAgent
     } 
   })
 ): BoltAgent {

--- a/packages/core/test/internal/bolt-agent/browser/bolt-agent.test.ts
+++ b/packages/core/test/internal/bolt-agent/browser/bolt-agent.test.ts
@@ -66,4 +66,14 @@ describe('#unit boltAgent', () => {
       product: 'neo4j-javascript/5.3'
     })
   })
+
+  it('should handle navigator object does not exist in the default getSystemInfo', () => {
+    const version = '5.3'
+
+    const boltAgent = fromVersion(version)
+
+    expect(boltAgent).toEqual({
+      product: 'neo4j-javascript/5.3'
+    })
+  })
 })

--- a/packages/neo4j-driver-deno/lib/core/internal/bolt-agent/browser/bolt-agent.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/bolt-agent/browser/bolt-agent.ts
@@ -35,8 +35,12 @@ export function fromVersion (
   version: string, 
   getSystemInfo: () => SystemInfo = () => ({ 
     get userAgent()  {
+      // this should be defined as an `var` since we need to get information
+      // came from the global scope which not always will be defined
+      // and we don't want to override the information
+      var navigator
       // @ts-ignore: browser code so must be skipped by ts
-      return window.navigator.userAgent
+      return navigator?.userAgent
     } 
   })
 ): BoltAgent {


### PR DESCRIPTION
The driver was trying to access the `window` object inside web workers. This object doesn't exist in this context.
So, the driver was throwing an error and not creating connections at all.

This problem is solved by access the `navigator` directly from the global scope (which is the `window` outside the web workers). Some guards were added to avoid the code break in case `navigator` is not defined.