### PR TITLE
Decrease integration tests duration

### DIFF
--- a/packages/neo4j-driver/test/temporal-types.test.js
+++ b/packages/neo4j-driver/test/temporal-types.test.js
@@ -1403,9 +1403,16 @@ describe('#integration temporal-types', () => {
   })
 
   function testSendAndReceiveRandomTemporalValues (temporalType, valueGenerator) {
+    let setImmediate
+    if (typeof setImmediate !== 'function') {
+      return
+    }
+
     for (let i = 0; i < RANDOM_VALUES_TO_TEST; i++) {
-      it(`should send and receive random ${temporalType} [index=${i}]`, async () => {
-        await testSendReceiveTemporalValue(valueGenerator())
+      setImmediate(() => {
+        it(`should send and receive random ${temporalType} [index=${i}]`, async () => {
+          await testSendReceiveTemporalValue(valueGenerator())
+        })
       })
     }
   }

--- a/packages/neo4j-driver/test/temporal-types.test.js
+++ b/packages/neo4j-driver/test/temporal-types.test.js
@@ -26,7 +26,7 @@ const {
   temporalUtil: { timeZoneOffsetInSeconds, totalNanoseconds }
 } = internal
 
-const RANDOM_VALUES_TO_TEST = 2000
+const RANDOM_VALUES_TO_TEST = 500
 const MIN_TEMPORAL_ARRAY_LENGTH = 20
 const MAX_TEMPORAL_ARRAY_LENGTH = 1000
 /**
@@ -1403,16 +1403,9 @@ describe('#integration temporal-types', () => {
   })
 
   function testSendAndReceiveRandomTemporalValues (temporalType, valueGenerator) {
-    let setImmediate
-    if (typeof setImmediate !== 'function') {
-      return
-    }
-
     for (let i = 0; i < RANDOM_VALUES_TO_TEST; i++) {
-      setImmediate(() => {
-        it(`should send and receive random ${temporalType} [index=${i}]`, async () => {
-          await testSendReceiveTemporalValue(valueGenerator())
-        })
+      it(`should send and receive random ${temporalType} [index=${i}]`, async () => {
+        await testSendReceiveTemporalValue(valueGenerator())
       })
     }
   }


### PR DESCRIPTION
80% of the integration tests was related to random temporal types tests.
Decrease the number of random test speeds up the process.

This is not a issue since these tests paths are already cover by property tests in the bolt-connection unit tests suite and in Testkit.