### PR TITLE
Fix DateTime with ZoneId unpacking

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js
@@ -185,6 +185,8 @@ function getTimeInZoneId (timeZoneId, epochSecond, nano) {
         currentValue.value.toUpperCase() === 'B'
           ? year => year.subtract(1).negate() // 1BC equals to year 0 in astronomical year numbering
           : identity
+    } else if (currentValue.type === 'hour') {
+      obj.hour = int(currentValue.value).modulo(24)
     } else if (currentValue.type !== 'literal') {
       obj[currentValue.type] = int(currentValue.value)
     }

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
@@ -713,13 +713,6 @@ describe('#unit BoltProtocolV4x4', () => {
         'DateTimeWithZoneId',
         new structure.Structure(0x66, [1, 2, 'America/Sao_Paulo']),
         new DateTime(1970, 1, 1, 0, 0, 1, 2, undefined, 'America/Sao_Paulo')
-      ],
-      [
-        'DateTimeWithZoneId / Midnight',
-        new structure.Structure(0x69, [
-          1685397950, 183_000_000, 'Europe/Berlin'
-        ]),
-        new DateTime(2023, 5, 30, 0, 5, 50, 183_000_000, 2 * 60 * 60, 'Europe/Berlin')
       ]
     ])('should unpack spatial types and temporal types (%s)', (_, struct, object) => {
       const buffer = alloc(256)
@@ -1042,6 +1035,13 @@ describe('#unit BoltProtocolV4x4', () => {
             1655212878, 183_000_000, 'Australia/Eucla'
           ]),
           new DateTime(2022, 6, 14, 22, 6, 18, 183_000_000, 8 * 60 * 60 + 45 * 60, 'Australia/Eucla')
+        ],
+        [
+          'DateTimeWithZoneId / Midnight',
+          new structure.Structure(0x69, [
+            1685397950, 183_000_000, 'Europe/Berlin'
+          ]),
+          new DateTime(2023, 5, 30, 0, 5, 50, 183_000_000, 2 * 60 * 60, 'Europe/Berlin')
         ]
       ])('should unpack temporal types (%s)', (_, struct, object) => {
         const packable = protocol.packable(struct)

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
@@ -713,6 +713,13 @@ describe('#unit BoltProtocolV4x4', () => {
         'DateTimeWithZoneId',
         new structure.Structure(0x66, [1, 2, 'America/Sao_Paulo']),
         new DateTime(1970, 1, 1, 0, 0, 1, 2, undefined, 'America/Sao_Paulo')
+      ],
+      [
+        'DateTimeWithZoneId / Midnight',
+        new structure.Structure(0x69, [
+          1685397950, 183_000_000, 'Europe/Berlin'
+        ]),
+        new DateTime(2023, 5, 30, 0, 5, 50, 183_000_000, 2 * 60 * 60, 'Europe/Berlin')
       ]
     ])('should unpack spatial types and temporal types (%s)', (_, struct, object) => {
       const buffer = alloc(256)

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v5x0.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v5x0.test.js
@@ -1001,6 +1001,13 @@ describe('#unit BoltProtocolV5x0', () => {
           1592231400, 183_000_000, 'Pacific/Honolulu'
         ]),
         new DateTime(2020, 6, 15, 4, 30, 0, 183_000_000, -10 * 60 * 60, 'Pacific/Honolulu')
+      ],
+      [
+        'DateTimeWithZoneId / Midnight',
+        new structure.Structure(0x69, [
+          1685397950, 183_000_000, 'Europe/Berlin'
+        ]),
+        new DateTime(2023, 5, 30, 0, 5, 50, 183_000_000, 2 * 60 * 60, 'Europe/Berlin')
       ]
     ])('should unpack spatial types and temporal types (%s)', (_, struct, object) => {
       const buffer = alloc(256)

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v5x1.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v5x1.test.js
@@ -1078,6 +1078,13 @@ describe('#unit BoltProtocolV5x1', () => {
           1592231400, 183_000_000, 'Pacific/Honolulu'
         ]),
         new DateTime(2020, 6, 15, 4, 30, 0, 183_000_000, -10 * 60 * 60, 'Pacific/Honolulu')
+      ],
+      [
+        'DateTimeWithZoneId / Midnight',
+        new structure.Structure(0x69, [
+          1685397950, 183_000_000, 'Europe/Berlin'
+        ]),
+        new DateTime(2023, 5, 30, 0, 5, 50, 183_000_000, 2 * 60 * 60, 'Europe/Berlin')
       ]
     ])('should unpack spatial types and temporal types (%s)', (_, struct, object) => {
       const buffer = alloc(256)

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v5x2.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v5x2.test.js
@@ -1084,6 +1084,13 @@ describe('#unit BoltProtocolV5x2', () => {
           1592231400, 183_000_000, 'Pacific/Honolulu'
         ]),
         new DateTime(2020, 6, 15, 4, 30, 0, 183_000_000, -10 * 60 * 60, 'Pacific/Honolulu')
+      ],
+      [
+        'DateTimeWithZoneId / Midnight',
+        new structure.Structure(0x69, [
+          1685397950, 183_000_000, 'Europe/Berlin'
+        ]),
+        new DateTime(2023, 5, 30, 0, 5, 50, 183_000_000, 2 * 60 * 60, 'Europe/Berlin')
       ]
     ])('should unpack spatial types and temporal types (%s)', (_, struct, object) => {
       const buffer = alloc(256)

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v5x3.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v5x3.test.js
@@ -1093,6 +1093,13 @@ describe('#unit BoltProtocolV5x3', () => {
           1592231400, 183_000_000, 'Pacific/Honolulu'
         ]),
         new DateTime(2020, 6, 15, 4, 30, 0, 183_000_000, -10 * 60 * 60, 'Pacific/Honolulu')
+      ],
+      [
+        'DateTimeWithZoneId / Midnight',
+        new structure.Structure(0x69, [
+          1685397950, 183_000_000, 'Europe/Berlin'
+        ]),
+        new DateTime(2023, 5, 30, 0, 5, 50, 183_000_000, 2 * 60 * 60, 'Europe/Berlin')
       ]
     ])('should unpack spatial types and temporal types (%s)', (_, struct, object) => {
       const buffer = alloc(256)

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.utc.transformer.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.utc.transformer.js
@@ -185,6 +185,8 @@ function getTimeInZoneId (timeZoneId, epochSecond, nano) {
         currentValue.value.toUpperCase() === 'B'
           ? year => year.subtract(1).negate() // 1BC equals to year 0 in astronomical year numbering
           : identity
+    } else if (currentValue.type === 'hour') {
+      obj.hour = int(currentValue.value).modulo(24)
     } else if (currentValue.type !== 'literal') {
       obj[currentValue.type] = int(currentValue.value)
     }


### PR DESCRIPTION
The timezone offset was miss-calculated because of an error on extracting timezone information when the hour equals to `0`. The problems happens because `Intl.DateTimeFormat` when configured with `hour12: false` returns `0` hour as `24`.

The solution for this is convert `24` to `0` before calculate the `offset`.

NOTE:
Other valid solution would be change `hourCycle` to `h23`. However, this solution is not supported by all javascript environment.