### PR TITLE
Fix DateTime with ZoneId unpacking

### DIFF
--- a/packages/bolt-connection/src/packstream/packstream-utc.js
+++ b/packages/bolt-connection/src/packstream/packstream-utc.js
@@ -279,6 +279,8 @@ export function packDateTime (value, packer) {
         currentValue.value.toUpperCase() === 'B'
           ? year => year.subtract(1).negate() // 1BC equals to year 0 in astronomical year numbering
           : year => year
+    } else if (currentValue.type === 'hour') {
+       obj.hour = int(currentValue.value).modulo(24)
     } else if (currentValue.type !== 'literal') {
        obj[currentValue.type] = int(currentValue.value)
      }


### PR DESCRIPTION
The timezone offset was miss-calculated because of an error on extracting timezone information when the hour equals to `0`. The problems happens because `Intl.DateTimeFormat` when configured with `hour12: false` returns `0` hour as `24`.

The solution for this is convert `24` to `0` before calculate the `offset`.

NOTE:
Other valid solution would be change `hourCycle` to `h23`. However, this solution is not supported by all javascript environment.

Backports: https://github.com/neo4j/neo4j-javascript-driver/pull/1097