### PR TITLE
Handle when a Sub Millisecond Tx Timeout is specified

### DIFF
--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -98,6 +98,7 @@ type CreateSession = (args: {
   bookmarkManager?: BookmarkManager
   notificationFilter?: NotificationFilter
   auth?: AuthToken
+  log: Logger
 }) => Session
 
 type CreateQueryExecutor = (createSession: (config: { database?: string, bookmarkManager?: BookmarkManager }) => Session) => QueryExecutor
@@ -827,7 +828,8 @@ class Driver {
       fetchSize,
       bookmarkManager,
       notificationFilter,
-      auth
+      auth,
+      log: this._log
     })
   }
 

--- a/packages/core/src/integer.ts
+++ b/packages/core/src/integer.ts
@@ -908,14 +908,18 @@ class Integer {
    * @param {!Integer|number|string|bigint|!{low: number, high: number}} val Value
    * @param {Object} [opts={}] Configuration options
    * @param {boolean} [opts.strictStringValidation=false] Enable strict validation generated Integer.
+   * @param {boolean} [opts.ceilFloat=false] Enable round up float to the nearest Integer.
    * @returns {!Integer}
    * @expose
    */
-  static fromValue (val: Integerable, opts: { strictStringValidation?: boolean} = {}): Integer {
+  static fromValue (val: Integerable, opts: { strictStringValidation?: boolean, ceilFloat?: boolean } = {}): Integer {
     if (val /* is compatible */ instanceof Integer) {
       return val
     }
     if (typeof val === 'number') {
+      if (opts.ceilFloat === true) {
+        val = Math.ceil(val)
+      }
       return Integer.fromNumber(val)
     }
     if (typeof val === 'string') {
@@ -1066,6 +1070,7 @@ const TWO_PWR_24 = Integer.fromInt(TWO_PWR_24_DBL)
  * @param {Mixed} value - The value to use.
  * @param {Object} [opts={}] Configuration options
  * @param {boolean} [opts.strictStringValidation=false] Enable strict validation generated Integer.
+ * @param {boolean} [opts.ceilFloat=false] Enable round up float to the nearest Integer.
  * @return {Integer} - An object of type Integer.
  */
 const int = Integer.fromValue

--- a/packages/core/src/internal/tx-config.ts
+++ b/packages/core/src/internal/tx-config.ts
@@ -66,7 +66,7 @@ const EMPTY_CONFIG = new TxConfig({})
 function extractTimeout (config: any): Integer | null {
   if (util.isObject(config) && config.timeout != null) {
     util.assertNumberOrInteger(config.timeout, 'Transaction timeout')
-    const timeout = int(config.timeout)
+    const timeout = int(config.timeout, { ceilFloat: true })
     if (timeout.isNegative()) {
       throw newError('Transaction timeout should not be negative')
     }

--- a/packages/core/src/internal/tx-config.ts
+++ b/packages/core/src/internal/tx-config.ts
@@ -69,7 +69,7 @@ function extractTimeout (config: any, log?: Logger): Integer | null {
     util.assertNumberOrInteger(config.timeout, 'Transaction timeout')
     if (isTimeoutFloat(config) && log?.isInfoEnabled() === true) {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      log?.info(`Transaction timeout expected to be an integer, got: ${config.timeout}. The value will be round up.`)
+      log?.info(`Transaction timeout expected to be an integer, got: ${config.timeout}. The value will be rounded up.`)
     }
     const timeout = int(config.timeout, { ceilFloat: true })
     if (timeout.isNegative()) {

--- a/packages/core/test/driver.test.ts
+++ b/packages/core/test/driver.test.ts
@@ -625,6 +625,8 @@ describe('Driver', () => {
       mode: 'WRITE',
       reactive: false,
       impersonatedUser: undefined,
+      // @ts-expect-error
+      log: driver?._log,
       ...extra
     }
   }

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -542,7 +542,7 @@ describe('session', () => {
 
             expect(loggerFunction).not.toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
+              expect.any(String)
             )
           }
         )
@@ -741,7 +741,7 @@ describe('session', () => {
 
             expect(loggerFunction).not.toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
+              expect.any(String)
             )
           }
         )
@@ -1143,7 +1143,7 @@ describe('session', () => {
 
             expect(loggerFunction).not.toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
+              expect.any(String)
             )
           }
         )

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -518,7 +518,7 @@ describe('session', () => {
 
             expect(loggerFunction).toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be round up.`
+              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
             )
           }
         )
@@ -542,7 +542,7 @@ describe('session', () => {
 
             expect(loggerFunction).not.toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be round up.`
+              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
             )
           }
         )
@@ -711,7 +711,7 @@ describe('session', () => {
 
             expect(loggerFunction).toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be round up.`
+              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
             )
           }
         )
@@ -741,7 +741,7 @@ describe('session', () => {
 
             expect(loggerFunction).not.toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be round up.`
+              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
             )
           }
         )
@@ -1119,7 +1119,7 @@ describe('session', () => {
 
             expect(loggerFunction).toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be round up.`
+              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
             )
           }
         )
@@ -1143,7 +1143,7 @@ describe('session', () => {
 
             expect(loggerFunction).not.toBeCalledWith(
               'info',
-              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be round up.`
+              `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
             )
           }
         )

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -499,7 +499,7 @@ describe('session', () => {
       )
     })
 
-    it('should log a warning for timeout configurations with sub milliseconds', async () => {
+    it('should log when a timeout is configured with sub milliseconds', async () => {
       return await fc.assert(
         fc.asyncProperty(
           fc

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -98,6 +98,7 @@ type CreateSession = (args: {
   bookmarkManager?: BookmarkManager
   notificationFilter?: NotificationFilter
   auth?: AuthToken
+  log: Logger
 }) => Session
 
 type CreateQueryExecutor = (createSession: (config: { database?: string, bookmarkManager?: BookmarkManager }) => Session) => QueryExecutor
@@ -827,7 +828,8 @@ class Driver {
       fetchSize,
       bookmarkManager,
       notificationFilter,
-      auth
+      auth,
+      log: this._log
     })
   }
 

--- a/packages/neo4j-driver-deno/lib/core/integer.ts
+++ b/packages/neo4j-driver-deno/lib/core/integer.ts
@@ -908,14 +908,18 @@ class Integer {
    * @param {!Integer|number|string|bigint|!{low: number, high: number}} val Value
    * @param {Object} [opts={}] Configuration options
    * @param {boolean} [opts.strictStringValidation=false] Enable strict validation generated Integer.
+   * @param {boolean} [opts.ceilFloat=false] Enable round up float to the nearest Integer.
    * @returns {!Integer}
    * @expose
    */
-  static fromValue (val: Integerable, opts: { strictStringValidation?: boolean} = {}): Integer {
+  static fromValue (val: Integerable, opts: { strictStringValidation?: boolean, ceilFloat?: boolean } = {}): Integer {
     if (val /* is compatible */ instanceof Integer) {
       return val
     }
     if (typeof val === 'number') {
+      if (opts.ceilFloat === true) {
+        val = Math.ceil(val)
+      }
       return Integer.fromNumber(val)
     }
     if (typeof val === 'string') {
@@ -1066,6 +1070,7 @@ const TWO_PWR_24 = Integer.fromInt(TWO_PWR_24_DBL)
  * @param {Mixed} value - The value to use.
  * @param {Object} [opts={}] Configuration options
  * @param {boolean} [opts.strictStringValidation=false] Enable strict validation generated Integer.
+ * @param {boolean} [opts.ceilFloat=false] Enable round up float to the nearest Integer.
  * @return {Integer} - An object of type Integer.
  */
 const int = Integer.fromValue

--- a/packages/neo4j-driver-deno/lib/core/internal/tx-config.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/tx-config.ts
@@ -20,6 +20,7 @@
 import * as util from './util.ts'
 import { newError } from '../error.ts'
 import Integer, { int } from '../integer.ts'
+import { Logger } from './logger.ts'
 
 /**
  * Internal holder of the transaction configuration.
@@ -35,9 +36,9 @@ export class TxConfig {
    * @constructor
    * @param {Object} config the raw configuration object.
    */
-  constructor (config: any) {
+  constructor (config: any, log?: Logger) {
     assertValidConfig(config)
-    this.timeout = extractTimeout(config)
+    this.timeout = extractTimeout(config, log)
     this.metadata = extractMetadata(config)
   }
 
@@ -63,16 +64,24 @@ const EMPTY_CONFIG = new TxConfig({})
 /**
  * @return {Integer|null}
  */
-function extractTimeout (config: any): Integer | null {
+function extractTimeout (config: any, log?: Logger): Integer | null {
   if (util.isObject(config) && config.timeout != null) {
     util.assertNumberOrInteger(config.timeout, 'Transaction timeout')
-    const timeout = int(config.timeout)
+    if (isTimeoutFloat(config) && log?.isInfoEnabled() === true) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      log?.info(`Transaction timeout expected to be an integer, got: ${config.timeout}. The value will be round up.`)
+    }
+    const timeout = int(config.timeout, { ceilFloat: true })
     if (timeout.isNegative()) {
       throw newError('Transaction timeout should not be negative')
     }
     return timeout
   }
   return null
+}
+
+function isTimeoutFloat (config: any): boolean {
+  return typeof config.timeout === 'number' && !Number.isInteger(config.timeout)
 }
 
 /**

--- a/packages/neo4j-driver-deno/lib/core/internal/tx-config.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/tx-config.ts
@@ -69,7 +69,7 @@ function extractTimeout (config: any, log?: Logger): Integer | null {
     util.assertNumberOrInteger(config.timeout, 'Transaction timeout')
     if (isTimeoutFloat(config) && log?.isInfoEnabled() === true) {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      log?.info(`Transaction timeout expected to be an integer, got: ${config.timeout}. The value will be round up.`)
+      log?.info(`Transaction timeout expected to be an integer, got: ${config.timeout}. The value will be rounded up.`)
     }
     const timeout = int(config.timeout, { ceilFloat: true })
     if (timeout.isNegative()) {

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -38,6 +38,7 @@ import ManagedTransaction from './transaction-managed.ts'
 import BookmarkManager from './bookmark-manager.ts'
 import { Dict } from './record.ts'
 import NotificationFilter from './notification-filter.ts'
+import { Logger } from './internal/logger.ts'
 
 type ConnectionConsumer = (connection: Connection | null) => any | undefined | Promise<any> | Promise<undefined>
 type TransactionWork<T> = (tx: Transaction) => Promise<T> | T
@@ -74,6 +75,7 @@ class Session {
   private readonly _results: Result[]
   private readonly _bookmarkManager?: BookmarkManager
   private readonly _notificationFilter?: NotificationFilter
+  private readonly _log?: Logger
   /**
    * @constructor
    * @protected
@@ -100,7 +102,8 @@ class Session {
     impersonatedUser,
     bookmarkManager,
     notificationFilter,
-    auth
+    auth,
+    log
   }: {
     mode: SessionMode
     connectionProvider: ConnectionProvider
@@ -113,6 +116,7 @@ class Session {
     bookmarkManager?: BookmarkManager
     notificationFilter?: NotificationFilter
     auth?: AuthToken
+    log: Logger
   }) {
     this._mode = mode
     this._database = database
@@ -153,6 +157,7 @@ class Session {
     this._results = []
     this._bookmarkManager = bookmarkManager
     this._notificationFilter = notificationFilter
+    this._log = log
   }
 
   /**
@@ -176,7 +181,7 @@ class Session {
       parameters
     )
     const autoCommitTxConfig = (transactionConfig != null)
-      ? new TxConfig(transactionConfig)
+      ? new TxConfig(transactionConfig, this._log)
       : TxConfig.empty()
 
     const result = this._run(validatedQuery, params, async connection => {
@@ -279,7 +284,7 @@ class Session {
 
     let txConfig = TxConfig.empty()
     if (arg != null) {
-      txConfig = new TxConfig(arg)
+      txConfig = new TxConfig(arg, this._log)
     }
 
     return this._beginTransaction(this._mode, txConfig)
@@ -385,7 +390,7 @@ class Session {
     transactionWork: TransactionWork<T>,
     transactionConfig?: TransactionConfig
   ): Promise<T> {
-    const config = new TxConfig(transactionConfig)
+    const config = new TxConfig(transactionConfig, this._log)
     return this._runTransaction(ACCESS_MODE_READ, config, transactionWork)
   }
 
@@ -410,7 +415,7 @@ class Session {
     transactionWork: TransactionWork<T>,
     transactionConfig?: TransactionConfig
   ): Promise<T> {
-    const config = new TxConfig(transactionConfig)
+    const config = new TxConfig(transactionConfig, this._log)
     return this._runTransaction(ACCESS_MODE_WRITE, config, transactionWork)
   }
 
@@ -443,7 +448,7 @@ class Session {
     transactionWork: ManagedTransactionWork<T>,
     transactionConfig?: TransactionConfig
   ): Promise<T> {
-    const config = new TxConfig(transactionConfig)
+    const config = new TxConfig(transactionConfig, this._log)
     return this._executeInTransaction(ACCESS_MODE_READ, config, transactionWork)
   }
 
@@ -465,7 +470,7 @@ class Session {
     transactionWork: ManagedTransactionWork<T>,
     transactionConfig?: TransactionConfig
   ): Promise<T> {
-    const config = new TxConfig(transactionConfig)
+    const config = new TxConfig(transactionConfig, this._log)
     return this._executeInTransaction(ACCESS_MODE_WRITE, config, transactionWork)
   }
 

--- a/packages/neo4j-driver-lite/test/unit/index.test.ts
+++ b/packages/neo4j-driver-lite/test/unit/index.test.ts
@@ -59,6 +59,12 @@ import neo4j, {
   isUnboundRelationship
 } from '../../'
 
+import { internal } from 'neo4j-driver-core'
+
+const {
+  logger: { Logger }
+} = internal
+
 describe('index', () => {
   it('should export an instanciable Result', () => {
     const result: Result = new Result(
@@ -248,6 +254,7 @@ describe('index', () => {
       fetchSize: 123,
       mode: 'READ',
       reactive: false,
+      log: new Logger('info', () => {}),
       connectionProvider: {
         acquireConnection: async () => { throw Error('something wrong') },
         close: async () => {},

--- a/packages/neo4j-driver/src/driver.js
+++ b/packages/neo4j-driver/src/driver.js
@@ -72,9 +72,11 @@ class Driver extends CoreDriver {
         reactive: false,
         fetchSize: validateFetchSizeValue(fetchSize, this._config.fetchSize),
         bookmarkManager,
-        notificationFilter
+        notificationFilter,
+        log: this._log
       }),
-      config: this._config
+      config: this._config,
+      log: this._log
     })
   }
 }

--- a/packages/neo4j-driver/src/session-rx.js
+++ b/packages/neo4j-driver/src/session-rx.js
@@ -41,9 +41,10 @@ export default class RxSession {
    * @param {Object} param - Object parameter
    * @param {Session} param.session - The underlying session instance to relay requests
    */
-  constructor ({ session, config } = {}) {
+  constructor ({ session, config, log } = {}) {
     this._session = session
     this._retryLogic = _createRetryLogic(config)
+    this._log = log
   }
 
   /**
@@ -200,7 +201,7 @@ export default class RxSession {
   _beginTransaction (accessMode, transactionConfig) {
     let txConfig = TxConfig.empty()
     if (transactionConfig) {
-      txConfig = new TxConfig(transactionConfig)
+      txConfig = new TxConfig(transactionConfig, this._log)
     }
 
     return new Observable(observer => {

--- a/packages/neo4j-driver/test/driver.test.js
+++ b/packages/neo4j-driver/test/driver.test.js
@@ -174,6 +174,18 @@ describe('#unit driver', () => {
         expect(session._session._bookmarkManager).toEqual(configuredBookmarkManager)
       })
     })
+
+    it('should redirect logger to session', () => {
+      driver = neo4j.driver(
+        `neo4j+ssc://${sharedNeo4j.hostname}`,
+        sharedNeo4j.authToken
+      )
+
+      const session = driver.rxSession()
+
+      expect(session._log).toBe(driver._log)
+      expect(session._session._log).toBe(driver._log)
+    })
   })
 })
 

--- a/packages/neo4j-driver/test/rx/session.test.js
+++ b/packages/neo4j-driver/test/rx/session.test.js
@@ -517,7 +517,7 @@ describe('#unit rx-session', () => {
 
       expect(capture[0]).toEqual([
         'info',
-        `Transaction timeout expected to be an integer, got: ${timeout}. The value will be round up.`
+        `Transaction timeout expected to be an integer, got: ${timeout}. The value will be rounded up.`
       ])
     })
 

--- a/packages/neo4j-driver/test/rx/session.test.js
+++ b/packages/neo4j-driver/test/rx/session.test.js
@@ -462,7 +462,7 @@ describe('#unit rx-session', () => {
       const session = new RxSession({ session: _session })
       const query = 'the query'
       const params = {}
-      const txConfig = { timeout: 1000 }
+      const txConfig = { timeout: 1000.120 }
 
       session.run(query, params, txConfig).records().subscribe()
 

--- a/packages/neo4j-driver/test/rx/session.test.js
+++ b/packages/neo4j-driver/test/rx/session.test.js
@@ -443,7 +443,7 @@ describe('#unit rx-session', () => {
   })
 
   describe('.run()', () => {
-    it('should redirect run to the underline session', () => {
+    it('should redirect run to the underlying session', () => {
       const capture = []
       const _session = {
         run: (...args) => {

--- a/packages/neo4j-driver/test/types/export.test.ts
+++ b/packages/neo4j-driver/test/types/export.test.ts
@@ -20,7 +20,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { Bookmarks } from 'neo4j-driver-core/types/internal/bookmarks'
-import { ConnectionProvider } from 'neo4j-driver-core'
+import { ConnectionProvider, internal } from 'neo4j-driver-core'
 import driver, {
   DateTime,
   RxSession,
@@ -30,6 +30,12 @@ import driver, {
   Record,
   types
 } from '../../'
+
+const {
+  logger: {
+    Logger
+  }
+} = internal
 
 const dateTime = DateTime.fromStandardDate(new Date())
 const dateTime2 = new DateTime(2, 2, 2, 2, 2, 3, 4, 6, null)
@@ -63,7 +69,9 @@ const session = new Session({
   database: 'default',
   config: {},
   reactive: false,
-  fetchSize: 100
+  fetchSize: 100,
+  log: new Logger('debug', () => {})
+
 })
 
 const dummy: any = null


### PR DESCRIPTION
If a user sets a timeout with a fractional millisecond value it will be rounded up to the next integer value. e.g

> 0.1 → 1
> 1.4 → 2.0
> 1.8 → 2.0

A warning that a rounding has taken place should be logged under info level.