### PR TITLE
Add error logs for connecting to HTTP server

### DIFF
--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -53,7 +53,7 @@ export function createChannelConnection (
 
   const channel = createChannel(channelConfig)
 
-  return Bolt.handshake(channel)
+  return Bolt.handshake(channel, log)
     .then(({ protocolVersion: version, consumeRemainingBuffer }) => {
       const chunker = new Chunker(channel)
       const dechunker = new Dechunker()

--- a/packages/bolt-connection/test/bolt/index.test.js
+++ b/packages/bolt-connection/test/bolt/index.test.js
@@ -115,7 +115,7 @@ describe('#unit Bolt', () => {
       channel.onmessage(packedHandshakeMessage(httpMagicNumber))
     })
 
-    it('should log error if the server responds with http server', async () => {
+    it('should log error if the server responds with http payload', async () => {
       const { channel, handshakePromise, log } = subject()
       const httpMagicNumber = 1213486160
       const logErrorSpy = jest.spyOn(log, 'error')
@@ -126,7 +126,7 @@ describe('#unit Bolt', () => {
       expect(logErrorSpy).toHaveBeenCalledWith('Handshake failed since server responded with HTTP.')
     })
 
-    it('should not log error if the server responds valid protocol version', async () => {
+    it('should not log error if the server responds with a valid protocol version', async () => {
       const { channel, handshakePromise, log } = subject()
       const expectedProtocolVersion = 4.3
       const logErrorSpy = jest.spyOn(log, 'error')

--- a/packages/bolt-connection/test/bolt/index.test.js
+++ b/packages/bolt-connection/test/bolt/index.test.js
@@ -74,7 +74,7 @@ describe('#unit Bolt', () => {
       channel.onmessage(packedHandshakeMessage(expectedProtocolVersion))
     })
 
-    it('should handle a successful handshake with reaining buffer', done => {
+    it('should handle a successful handshake with remaining buffer', done => {
       const { channel, handshakePromise } = subject()
       const expectedProtocolVersion = 4.3
       const expectedExtraBuffer = createExtraBuffer()
@@ -114,6 +114,29 @@ describe('#unit Bolt', () => {
 
       channel.onmessage(packedHandshakeMessage(httpMagicNumber))
     })
+
+    it('should log error if the server responds with http server', async () => {
+      const { channel, handshakePromise, log } = subject()
+      const httpMagicNumber = 1213486160
+      const logErrorSpy = jest.spyOn(log, 'error')
+
+      channel.onmessage(packedHandshakeMessage(httpMagicNumber))
+
+      await expect(handshakePromise).rejects.toThrow()
+      expect(logErrorSpy).toHaveBeenCalledWith('Handshake failed since server responded with HTTP.')
+    })
+
+    it('should not log error if the server responds valid protocol version', async () => {
+      const { channel, handshakePromise, log } = subject()
+      const expectedProtocolVersion = 4.3
+      const logErrorSpy = jest.spyOn(log, 'error')
+
+      channel.onmessage(packedHandshakeMessage(expectedProtocolVersion))
+
+      await expect(handshakePromise).resolves.not.toThrow()
+      expect(logErrorSpy).not.toBeCalled()
+    })
+
     it('should handle a failed handshake', done => {
       const { channel, handshakePromise } = subject()
       const expectedError = new Error('Something got wrong')
@@ -143,9 +166,11 @@ describe('#unit Bolt', () => {
     })
 
     function subject ({ channel = new DummyChannel() } = {}) {
+      const log = new Logger('debug', () => {})
       return {
+        log,
         channel,
-        handshakePromise: Bolt.handshake(channel)
+        handshakePromise: Bolt.handshake(channel, log)
       }
     }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
@@ -53,7 +53,7 @@ export function createChannelConnection (
 
   const channel = createChannel(channelConfig)
 
-  return Bolt.handshake(channel)
+  return Bolt.handshake(channel, log)
     .then(({ protocolVersion: version, consumeRemainingBuffer }) => {
       const chunker = new Chunker(channel)
       const dechunker = new Dechunker()

--- a/packages/neo4j-driver/test/internal/connection-channel.test.js
+++ b/packages/neo4j-driver/test/internal/connection-channel.test.js
@@ -133,7 +133,7 @@ describe('#integration ChannelConnection', () => {
   it('should provide error message when connecting to http-port', async done => {
     await createConnection(`bolt://${sharedNeo4j.hostname}:7474`, {
       encrypted: false
-    })
+    }, null, new Logger('error', () => {}))
       .then(done.fail.bind(done))
       .catch(error => {
         expect(error).toBeDefined()


### PR DESCRIPTION
The driver already throws an appropriated erro when the server returns HTTP. Add this information to the log helps with future debugging process.
