### PR TITLE
Reduce number of `ROUTE` requests when routing table is stale (#1119)

### DIFF
--- a/packages/bolt-connection/src/lang/functional.js
+++ b/packages/bolt-connection/src/lang/functional.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { json } from 'neo4j-driver-core'
+
+/**
+ * Identity function.
+ *
+ * Identity functions are function which returns the input as output.
+ *
+ * @param {any} x
+ * @returns {any} the x
+ */
+export function identity (x) {
+  return x
+}
+
+/**
+ * Makes the function able to share ongoing requests
+ *
+ * @param {function(...args): Promise} func The function to be decorated
+ * @param {any} thisArg The `this` which should be used in the function call
+ * @return {function(...args): Promise} The decorated function
+ */
+export function reuseOngoingRequest (func, thisArg = null) {
+  const ongoingRequests = new Map()
+
+  return function (...args) {
+    const key = json.stringify(args)
+    if (ongoingRequests.has(key)) {
+      return ongoingRequests.get(key)
+    }
+
+    const promise = func.apply(thisArg, args)
+
+    ongoingRequests.set(key, promise)
+
+    return promise.finally(() => {
+      ongoingRequests.delete(key)
+    })
+  }
+}

--- a/packages/bolt-connection/src/lang/index.js
+++ b/packages/bolt-connection/src/lang/index.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * as functional from './functional'

--- a/packages/bolt-connection/test/lang/functional.test.js
+++ b/packages/bolt-connection/test/lang/functional.test.js
@@ -1,0 +1,170 @@
+import { reuseOngoingRequest } from '../../src/lang/functional.js'
+
+describe('functional', () => {
+  describe('reuseOnGoingRequest', () => {
+    it('should call supplied function with the params', async () => {
+      const expectedParams = ['a', 1, { a: 'a' }]
+      const func = jest.fn(() => Promise.resolve())
+
+      const decoratedFunction = reuseOngoingRequest(func)
+      await decoratedFunction(...expectedParams)
+
+      expect(func).toHaveBeenCalledWith(...expectedParams)
+    })
+
+    it('should call supplied function with this', async () => {
+      const expectedParams = ['a', 1, { a: 'a' }]
+      const thisArg = { t: 'his' }
+      const func = jest.fn(async function () {
+        return this
+      })
+
+      const decoratedFunction = reuseOngoingRequest(func, thisArg)
+      const receivedThis = await decoratedFunction(...expectedParams)
+
+      expect(receivedThis).toBe(thisArg)
+    })
+
+    it('should return values returned by the supplied function', async () => {
+      const expectedResult = { a: 'abc' }
+      const func = jest.fn(() => Promise.resolve(expectedResult))
+
+      const decoratedFunction = reuseOngoingRequest(func)
+      const result = await decoratedFunction()
+
+      expect(result).toBe(expectedResult)
+    })
+
+    it('should throw value thrown by supplied function', async () => {
+      const error = new Error('Oops, I did it again!')
+      const func = jest.fn(() => Promise.reject(error))
+
+      const decoratedFunction = reuseOngoingRequest(func)
+      const promise = decoratedFunction()
+      expect(promise).rejects.toThrow(error)
+    })
+
+    it('should share ongoing request with same params', async () => {
+      const expectedParams = ['a', 1, [3]]
+      const expectedResult = { a: 'abc' }
+      const { promises, func } = mockPromiseFunction()
+
+      const decoratedFunction = reuseOngoingRequest(func)
+
+      const resultPromises = [
+        decoratedFunction(...expectedParams),
+        decoratedFunction(...expectedParams),
+        decoratedFunction(...expectedParams)
+      ]
+
+      expect(func).toBeCalledTimes(1)
+      expect(promises.length).toBe(1)
+
+      promises[0].resolve(expectedResult) // closing ongoing request
+
+      const results = await Promise.all(resultPromises)
+
+      expect(results).toEqual([expectedResult, expectedResult, expectedResult])
+    })
+
+    it('should not share ongoing request with different params', async () => {
+      const expectedParams1 = ['a', 1, [3]]
+      const expectedResult1 = { a: 'abc' }
+      const expectedParams2 = [4, 'a', []]
+      const expectedResult2 = { k: 'bbk' }
+      const { promises, func } = mockPromiseFunction()
+
+      const decoratedFunction = reuseOngoingRequest(func)
+
+      const resultPromises = [
+        decoratedFunction(...expectedParams1),
+        decoratedFunction(...expectedParams2)
+      ]
+
+      expect(func).toBeCalledTimes(2)
+      expect(func).toBeCalledWith(...expectedParams1)
+      expect(func).toBeCalledWith(...expectedParams2)
+
+      expect(promises.length).toBe(2)
+
+      promises[0].resolve(expectedResult1) // closing ongoing request 1
+      promises[1].resolve(expectedResult2) // closing ongoing request 2
+
+      const results = await Promise.all(resultPromises)
+
+      expect(results).toEqual([expectedResult1, expectedResult2])
+    })
+
+    it('should not share resolved requests with same params', async () => {
+      const expectedParams = ['a', 1, [3]]
+      const expectedResult1 = { a: 'abc' }
+      const expectedResult2 = { k: 'bbk' }
+      const { promises, func } = mockPromiseFunction()
+
+      const decoratedFunction = reuseOngoingRequest(func)
+
+      const resultPromises = [
+        decoratedFunction(...expectedParams)
+      ]
+
+      expect(func).toBeCalledTimes(1)
+      expect(promises.length).toBe(1)
+
+      promises[0].resolve(expectedResult1) // closing ongoing request
+
+      const results = await Promise.all(resultPromises)
+
+      resultPromises.push(decoratedFunction(...expectedParams))
+
+      expect(func).toBeCalledTimes(2)
+      expect(promises.length).toBe(2)
+
+      promises[1].resolve(expectedResult2) // closing ongoing request
+
+      results.push(await resultPromises[1])
+
+      expect(results).toEqual([expectedResult1, expectedResult2])
+    })
+
+    it('should not share rejected requests with same params', async () => {
+      const expectedParams = ['a', 1, [3]]
+      const expectedResult1 = new Error('Ops, I did it again!')
+      const expectedResult2 = { k: 'bbk' }
+      const { promises, func } = mockPromiseFunction()
+
+      const decoratedFunction = reuseOngoingRequest(func)
+
+      const resultPromises = [
+        decoratedFunction(...expectedParams)
+      ]
+
+      expect(func).toBeCalledTimes(1)
+      expect(promises.length).toBe(1)
+
+      promises[0].reject(expectedResult1) // closing ongoing request
+
+      const results = await Promise.all(
+        resultPromises.map(promise => promise.catch(error => error))
+      )
+
+      resultPromises.push(decoratedFunction(...expectedParams))
+
+      expect(func).toBeCalledTimes(2)
+      expect(promises.length).toBe(2)
+
+      promises[1].resolve(expectedResult2) // closing ongoing request
+
+      results.push(await resultPromises[1])
+
+      expect(results).toEqual([expectedResult1, expectedResult2])
+    })
+
+    function mockPromiseFunction () {
+      const promises = []
+      const func = jest.fn(() => new Promise((resolve, reject) => {
+        promises.push({ resolve, reject })
+      }))
+      return { promises, func }
+    }
+  })
+})


### PR DESCRIPTION
The driver was starting a rediscovery process of each acquireConnection causing more load than needed in the cluster. Keeping track of the ongoing requests and use it when possible reduces the load in the process and speeds up the connection acquisition.

Backports #1119