### PR TITLE
Improve `AuthTokenManager` interface and factory method

### DIFF
--- a/packages/bolt-connection/src/connection-provider/authentication-provider.js
+++ b/packages/bolt-connection/src/connection-provider/authentication-provider.js
@@ -56,12 +56,10 @@ export default class AuthenticationProvider {
   handleError ({ connection, code }) {
     if (
       connection &&
-      [
-        'Neo.ClientError.Security.Unauthorized',
-        'Neo.ClientError.Security.TokenExpired'
-      ].includes(code)
+      code.startsWith('Neo.ClientError.Security.')
     ) {
-      this._authTokenManager.onTokenExpired(connection.authToken)
+      return this._authTokenManager.handleSecurityException(connection.authToken, code)
     }
+    return false
   }
 }

--- a/packages/bolt-connection/src/connection-provider/authentication-provider.js
+++ b/packages/bolt-connection/src/connection-provider/authentication-provider.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { expirationBasedAuthTokenManager } from 'neo4j-driver-core'
+import { staticAuthTokenManager } from 'neo4j-driver-core'
 import { object } from '../lang'
 
 /**
@@ -25,9 +25,7 @@ import { object } from '../lang'
  */
 export default class AuthenticationProvider {
   constructor ({ authTokenManager, userAgent, boltAgent }) {
-    this._authTokenManager = authTokenManager || expirationBasedAuthTokenManager({
-      tokenProvider: () => {}
-    })
+    this._authTokenManager = authTokenManager || staticAuthTokenManager({})
     this._userAgent = userAgent
     this._boltAgent = boltAgent
   }

--- a/packages/bolt-connection/src/connection-provider/connection-provider-direct.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-direct.js
@@ -50,8 +50,8 @@ export default class DirectConnectionProvider extends PooledConnectionProvider {
   async acquireConnection ({ accessMode, database, bookmarks, auth, forceReAuth } = {}) {
     const databaseSpecificErrorHandler = ConnectionErrorHandler.create({
       errorCode: SERVICE_UNAVAILABLE,
-      handleAuthorizationExpired: (error, address, conn) =>
-        this._handleAuthorizationExpired(error, address, conn, database)
+      handleSecurityError: (error, address, conn) =>
+        this._handleSecurityError(error, address, conn, database)
     })
 
     const connection = await this._connectionPool.acquire({ auth, forceReAuth }, this._address)
@@ -68,12 +68,12 @@ export default class DirectConnectionProvider extends PooledConnectionProvider {
     return new DelegateConnection(connection, databaseSpecificErrorHandler)
   }
 
-  _handleAuthorizationExpired (error, address, connection, database) {
+  _handleSecurityError (error, address, connection, database) {
     this._log.warn(
       `Direct driver ${this._id} will close connection to ${address} for database '${database}' because of an error ${error.code} '${error.message}'`
     )
 
-    return super._handleAuthorizationExpired(error, address, connection)
+    return super._handleSecurityError(error, address, connection)
   }
 
   async _hasProtocolVersion (versionPredicate) {

--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -19,7 +19,7 @@
 
 import { createChannelConnection, ConnectionErrorHandler } from '../connection'
 import Pool, { PoolConfig } from '../pool'
-import { error, ConnectionProvider, ServerInfo, newError, isStaticAuthTokenManger } from 'neo4j-driver-core'
+import { error, ConnectionProvider, ServerInfo, newError } from 'neo4j-driver-core'
 import AuthenticationProvider from './authentication-provider'
 import { object } from '../lang'
 
@@ -41,7 +41,6 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     this._id = id
     this._config = config
     this._log = log
-    this._authTokenManager = authTokenManager
     this._authenticationProvider = new AuthenticationProvider({ authTokenManager, userAgent, boltAgent })
     this._userAgent = userAgent
     this._boltAgent = boltAgent
@@ -225,7 +224,11 @@ export default class PooledConnectionProvider extends ConnectionProvider {
   }
 
   _handleAuthorizationExpired (error, address, connection) {
-    this._authenticationProvider.handleError({ connection, code: error.code })
+    const handled = this._authenticationProvider.handleError({ connection, code: error.code })
+
+    if (handled) {
+      error.retriable = true
+    }
 
     if (error.code === 'Neo.ClientError.Security.AuthorizationExpired') {
       this._connectionPool.apply(address, (conn) => { conn.authToken = null })
@@ -233,10 +236,6 @@ export default class PooledConnectionProvider extends ConnectionProvider {
 
     if (connection) {
       connection.close().catch(() => undefined)
-    }
-
-    if (error.code === 'Neo.ClientError.Security.TokenExpired' && !isStaticAuthTokenManger(this._authTokenManager)) {
-      error.retriable = true
     }
 
     return error

--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -223,7 +223,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     conn._updateCurrentObserver()
   }
 
-  _handleAuthorizationExpired (error, address, connection) {
+  _handleSecurityError (error, address, connection) {
     const handled = this._authenticationProvider.handleError({ connection, code: error.code })
 
     if (handled) {

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -116,12 +116,12 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     return error
   }
 
-  _handleAuthorizationExpired (error, address, connection, database) {
+  _handleSecurityError (error, address, connection, database) {
     this._log.warn(
       `Routing driver ${this._id} will close connections to ${address} for database '${database}' because of an error ${error.code} '${error.message}'`
     )
 
-    return super._handleAuthorizationExpired(error, address, connection, database)
+    return super._handleSecurityError(error, address, connection, database)
   }
 
   _handleWriteFailure (error, address, database) {
@@ -150,7 +150,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
       (error, address) => this._handleUnavailability(error, address, context.database),
       (error, address) => this._handleWriteFailure(error, address, context.database),
       (error, address, conn) =>
-        this._handleAuthorizationExpired(error, address, conn, context.database)
+        this._handleSecurityError(error, address, conn, context.database)
     )
 
     const routingTable = await this._freshRoutingTable({
@@ -584,7 +584,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
 
       const databaseSpecificErrorHandler = ConnectionErrorHandler.create({
         errorCode: SESSION_EXPIRED,
-        handleAuthorizationExpired: (error, address, conn) => this._handleAuthorizationExpired(error, address, conn)
+        handleSecurityError: (error, address, conn) => this._handleSecurityError(error, address, conn)
       })
 
       const delegateConnection = !connection._sticky

--- a/packages/bolt-connection/src/connection/connection-error-handler.js
+++ b/packages/bolt-connection/src/connection/connection-error-handler.js
@@ -26,25 +26,25 @@ export default class ConnectionErrorHandler {
     errorCode,
     handleUnavailability,
     handleWriteFailure,
-    handleAuthorizationExpired
+    handleSecurityError
   ) {
     this._errorCode = errorCode
     this._handleUnavailability = handleUnavailability || noOpHandler
     this._handleWriteFailure = handleWriteFailure || noOpHandler
-    this._handleAuthorizationExpired = handleAuthorizationExpired || noOpHandler
+    this._handleSecurityError = handleSecurityError || noOpHandler
   }
 
   static create ({
     errorCode,
     handleUnavailability,
     handleWriteFailure,
-    handleAuthorizationExpired
+    handleSecurityError
   }) {
     return new ConnectionErrorHandler(
       errorCode,
       handleUnavailability,
       handleWriteFailure,
-      handleAuthorizationExpired
+      handleSecurityError
     )
   }
 
@@ -63,8 +63,8 @@ export default class ConnectionErrorHandler {
    * @return {Neo4jError} new error that should be propagated to the user.
    */
   handleAndTransformError (error, address, connection) {
-    if (isAutorizationExpiredError(error)) {
-      return this._handleAuthorizationExpired(error, address, connection)
+    if (isSecurityError(error)) {
+      return this._handleSecurityError(error, address, connection)
     }
     if (isAvailabilityError(error)) {
       return this._handleUnavailability(error, address, connection)
@@ -76,11 +76,10 @@ export default class ConnectionErrorHandler {
   }
 }
 
-function isAutorizationExpiredError (error) {
-  return error && (
-    error.code === 'Neo.ClientError.Security.AuthorizationExpired' ||
-      error.code === 'Neo.ClientError.Security.TokenExpired'
-  )
+function isSecurityError (error) {
+  return error != null &&
+    error.code != null &&
+    error.code.startsWith('Neo.ClientError.Security.')
 }
 
 function isAvailabilityError (error) {

--- a/packages/bolt-connection/test/connection-provider/authentication-provider.test.js
+++ b/packages/bolt-connection/test/connection-provider/authentication-provider.test.js
@@ -642,8 +642,15 @@ describe('AuthenticationProvider', () => {
         authenticationProvider
       } = createScenario()
 
+      const handleSecurityExceptionSpy = jest.spyOn(authenticationProvider._authTokenManager, 'handleSecurityException')
+
       authenticationProvider.handleError({ code, connection })
 
+      if (code.startsWith('Neo.ClientError.Security.')) {
+        expect(handleSecurityExceptionSpy).toBeCalledWith(connection.authToken, code)
+      } else {
+        expect(handleSecurityExceptionSpy).not.toBeCalled()
+      }
       expect(authTokenProvider).not.toHaveBeenCalled()
     })
 

--- a/packages/bolt-connection/test/connection-provider/authentication-provider.test.js
+++ b/packages/bolt-connection/test/connection-provider/authentication-provider.test.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expirationBasedAuthTokenManager } from 'neo4j-driver-core'
+import { authTokenManagers } from 'neo4j-driver-core'
 import AuthenticationProvider from '../../src/connection-provider/authentication-provider'
 
 describe('AuthenticationProvider', () => {
@@ -785,7 +785,7 @@ describe('AuthenticationProvider', () => {
   })
 
   function createAuthenticationProvider (authTokenProvider, mocks) {
-    const authTokenManager = expirationBasedAuthTokenManager({ tokenProvider: authTokenProvider })
+    const authTokenManager = authTokenManagers.bearer({ tokenProvider: authTokenProvider })
     const provider = new AuthenticationProvider({
       authTokenManager,
       userAgent: USER_AGENT,

--- a/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
@@ -20,7 +20,7 @@
 import DirectConnectionProvider from '../../src/connection-provider/connection-provider-direct'
 import { Pool } from '../../src/pool'
 import { Connection, DelegateConnection } from '../../src/connection'
-import { internal, newError, ServerInfo, staticAuthTokenManager, expirationBasedAuthTokenManager } from 'neo4j-driver-core'
+import { authTokenManagers, internal, newError, ServerInfo, staticAuthTokenManager } from 'neo4j-driver-core'
 import AuthenticationProvider from '../../src/connection-provider/authentication-provider'
 import { functional } from '../../src/lang'
 
@@ -209,7 +209,7 @@ it('should call authenticationAuthProvider.handleError when TokenExpired happens
 it('should change error to retriable when error when TokenExpired happens and staticAuthTokenManager is not being used', async () => {
   const address = ServerAddress.fromUrl('localhost:123')
   const pool = newPool()
-  const connectionProvider = newDirectConnectionProvider(address, pool, expirationBasedAuthTokenManager({ tokenProvider: () => null }))
+  const connectionProvider = newDirectConnectionProvider(address, pool, authTokenManagers.bearer({ tokenProvider: () => null }))
 
   const conn = await connectionProvider.acquireConnection({
     accessMode: 'READ',

--- a/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
@@ -246,6 +246,26 @@ it('should not change error to retriable when error when TokenExpired happens an
   expect(error.retriable).toBe(false)
 })
 
+it('should not change error to retriable when error when TokenExpired happens and authTokenManagers.basic is being used', async () => {
+  const address = ServerAddress.fromUrl('localhost:123')
+  const pool = newPool()
+  const connectionProvider = newDirectConnectionProvider(address, pool, authTokenManagers.basic({ tokenProvider: () => null }))
+
+  const conn = await connectionProvider.acquireConnection({
+    accessMode: 'READ',
+    database: ''
+  })
+
+  const expectedError = newError(
+    'Message',
+    'Neo.ClientError.Security.TokenExpired'
+  )
+
+  const error = conn.handleAndTransformError(expectedError, address)
+
+  expect(error.retriable).toBe(false)
+})
+
 describe('constructor', () => {
   describe('newPool', () => {
     const server0 = ServerAddress.fromUrl('localhost:123')

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -26,7 +26,7 @@ import {
   internal,
   ServerInfo,
   staticAuthTokenManager,
-  expirationBasedAuthTokenManager
+  authTokenManagers
 } from 'neo4j-driver-core'
 import { RoutingTable } from '../../src/rediscovery/'
 import { Pool } from '../../src/pool'
@@ -1719,7 +1719,7 @@ describe.each([
       pool
     )
 
-    setupAuthTokenManager(connectionProvider, expirationBasedAuthTokenManager({ tokenProvider: () => null }))
+    setupAuthTokenManager(connectionProvider, authTokenManagers.bearer({ tokenProvider: () => null }))
 
     const error = newError(
       'Message',

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -1718,7 +1718,8 @@ describe.each([
       ],
       pool
     )
-    connectionProvider._authTokenManager = expirationBasedAuthTokenManager({ tokenProvider: () => null })
+
+    setupAuthTokenManager(connectionProvider, expirationBasedAuthTokenManager({ tokenProvider: () => null }))
 
     const error = newError(
       'Message',
@@ -1756,8 +1757,10 @@ describe.each([
         )
       ],
       pool
+
     )
-    connectionProvider._authTokenManager = staticAuthTokenManager({ authToken: null })
+
+    setupAuthTokenManager(connectionProvider, staticAuthTokenManager({ authToken: null }))
 
     const error = newError(
       'Message',
@@ -3943,4 +3946,8 @@ class FakeDnsResolver {
   resolve (seedRouter) {
     return Promise.resolve(this._addresses ? this._addresses : [seedRouter])
   }
+}
+
+function setupAuthTokenManager (provider, authTokenManager) {
+  provider._authenticationProvider._authTokenManager = authTokenManager
 }

--- a/packages/bolt-connection/test/connection/connection-error-handler.test.js
+++ b/packages/bolt-connection/test/connection/connection-error-handler.test.js
@@ -79,35 +79,7 @@ describe('#unit ConnectionErrorHandler', () => {
     ])
   })
 
-  it('should handle and transform authorization expired error', () => {
-    const errors = []
-    const addresses = []
-    const transformedError = newError('Message', 'Code')
-    const handler = ConnectionErrorHandler.create({
-      errorCode: SERVICE_UNAVAILABLE,
-      handleAuthorizationExpired: (error, address) => {
-        errors.push(error)
-        addresses.push(address)
-        return transformedError
-      }
-    })
-
-    const error1 = newError(
-      'C',
-      'Neo.ClientError.Security.AuthorizationExpired'
-    )
-
-    const errorTransformed1 = handler.handleAndTransformError(
-      error1,
-      ServerAddress.fromUrl('localhost:0')
-    )
-
-    expect(errorTransformed1).toEqual(transformedError)
-
-    expect(addresses).toEqual([ServerAddress.fromUrl('localhost:0')])
-  })
-
-  it('should return original erro if authorization expired handler is not informed', () => {
+  it('should return original error if authorization expired handler is not informed', () => {
     const errors = []
     const addresses = []
     const transformedError = newError('Message', 'Code')
@@ -140,13 +112,18 @@ describe('#unit ConnectionErrorHandler', () => {
     expect(addresses).toEqual([])
   })
 
-  it('should handle and transform token expired error', () => {
+  it.each([
+    'Neo.ClientError.Security.TokenExpired',
+    'Neo.ClientError.Security.AuthorizationExpired',
+    'Neo.ClientError.Security.Unauthorized',
+    'Neo.ClientError.Security.MadeUp'
+  ])('should handle and transform "%s"', (code) => {
     const errors = []
     const addresses = []
     const transformedError = newError('Message', 'Code')
     const handler = ConnectionErrorHandler.create({
       errorCode: SERVICE_UNAVAILABLE,
-      handleAuthorizationExpired: (error, address) => {
+      handleSecurityError: (error, address) => {
         errors.push(error)
         addresses.push(address)
         return transformedError
@@ -155,7 +132,7 @@ describe('#unit ConnectionErrorHandler', () => {
 
     const error1 = newError(
       'C',
-      'Neo.ClientError.Security.TokenExpired'
+      code
     )
 
     const errorTransformed1 = handler.handleAndTransformError(
@@ -168,7 +145,12 @@ describe('#unit ConnectionErrorHandler', () => {
     expect(addresses).toEqual([ServerAddress.fromUrl('localhost:0')])
   })
 
-  it('should return original erro if token expired handler is not informed', () => {
+  it.each([
+    'Neo.ClientError.Security.TokenExpired',
+    'Neo.ClientError.Security.AuthorizationExpired',
+    'Neo.ClientError.Security.Unauthorized',
+    'Neo.ClientError.Security.MadeUp'
+  ])('should return original error code equals "%s" if security error handler is not informed', (code) => {
     const errors = []
     const addresses = []
     const transformedError = newError('Message', 'Code')
@@ -188,7 +170,7 @@ describe('#unit ConnectionErrorHandler', () => {
 
     const error1 = newError(
       'C',
-      'Neo.ClientError.Security.TokenExpired'
+      code
     )
 
     const errorTransformed1 = handler.handleAndTransformError(

--- a/packages/core/src/auth-token-manager.ts
+++ b/packages/core/src/auth-token-manager.ts
@@ -21,7 +21,7 @@ import auth from './auth'
 import { AuthToken } from './types'
 import { util } from './internal'
 
-type SecurityErrorCode = `Neo.ClientError.Security.${string}`
+export type SecurityErrorCode = `Neo.ClientError.Security.${string}`
 
 /**
  * Interface for the piece of software responsible for keeping track of current active {@link AuthToken} across the driver.

--- a/packages/core/src/auth-token-manager.ts
+++ b/packages/core/src/auth-token-manager.ts
@@ -120,7 +120,7 @@ class AuthTokenManagers {
    * **Warning**: `tokenProvider` must only ever return auth information belonging to the same identity.
    * Switching identities using the `AuthTokenManager` is undefined behavior.
    *
-   * @param param0 - The params
+   * @param {object} param0 - The params
    * @param {function(): Promise<AuthToken>} param0.tokenProvider - Retrieves a new valid auth token.
    * Must only ever return auth information belonging to the same identity.
    * @returns {AuthTokenManager} The basic auth data manager.
@@ -139,8 +139,16 @@ class AuthTokenManagers {
 
 /**
  * Holds the common {@link AuthTokenManagers} used in the Driver
+ *
+ * @experimental Exposed as preview feature.
  */
-export const authTokenManagers: AuthTokenManagers = Object.freeze(new AuthTokenManagers())
+const authTokenManagers: AuthTokenManagers = new AuthTokenManagers()
+
+Object.freeze(authTokenManagers)
+
+export {
+  authTokenManagers
+}
 
 export type {
   AuthTokenManagers

--- a/packages/core/src/auth-token-manager.ts
+++ b/packages/core/src/auth-token-manager.ts
@@ -21,6 +21,8 @@ import auth from './auth'
 import { AuthToken } from './types'
 import { util } from './internal'
 
+type SecurityErrorCode = `Neo.ClientError.Security.${string}`
+
 /**
  * Interface for the piece of software responsible for keeping track of current active {@link AuthToken} across the driver.
  * @interface
@@ -41,12 +43,13 @@ export default class AuthTokenManager {
   }
 
   /**
-   * Called to notify a token expiration.
+   * Handles an error notification emitted by the server if a security error happened.
    *
    * @param {AuthToken} token The expired token.
-   * @return {void}
+   * @param {`Neo.ClientError.Security.${string}`} securityErrorCode the security error code returned by the server
+   * @return {boolean} whether the exception was handled by the manager, so the driver knows if it can be retried..
    */
-  onTokenExpired (token: AuthToken): void {
+  handleSecurityException (token: AuthToken, securityErrorCode: SecurityErrorCode): boolean {
     throw new Error('Not implemented')
   }
 }
@@ -101,7 +104,10 @@ export function expirationBasedAuthTokenManager ({ tokenProvider }: { tokenProvi
   if (typeof tokenProvider !== 'function') {
     throw new TypeError(`tokenProvider should be function, but got: ${typeof tokenProvider}`)
   }
-  return new ExpirationBasedAuthTokenManager(tokenProvider)
+  return new ExpirationBasedAuthTokenManager(tokenProvider, [
+    'Neo.ClientError.Security.Unauthorized',
+    'Neo.ClientError.Security.TokenExpired'
+  ])
 }
 
 /**
@@ -114,18 +120,6 @@ export function expirationBasedAuthTokenManager ({ tokenProvider }: { tokenProvi
  */
 export function staticAuthTokenManager ({ authToken }: { authToken: AuthToken }): AuthTokenManager {
   return new StaticAuthTokenManager(authToken)
-}
-
-/**
- * Checks if the manager is a StaticAuthTokenManager
- *
- * @private
- * @experimental
- * @param {AuthTokenManager} manager The auth token manager to be checked.
- * @returns {boolean} Manager is StaticAuthTokenManager
- */
-export function isStaticAuthTokenManger (manager: AuthTokenManager): manager is StaticAuthTokenManager {
-  return manager instanceof StaticAuthTokenManager
 }
 
 interface TokenRefreshObserver {
@@ -154,6 +148,7 @@ class TokenRefreshObservable implements TokenRefreshObserver {
 class ExpirationBasedAuthTokenManager implements AuthTokenManager {
   constructor (
     private readonly _tokenProvider: () => Promise<AuthTokenAndExpiration>,
+    private readonly _handledSecurityCodes: SecurityErrorCode[],
     private _currentAuthData?: AuthTokenAndExpiration,
     private _refreshObservable?: TokenRefreshObservable) {
 
@@ -171,10 +166,14 @@ class ExpirationBasedAuthTokenManager implements AuthTokenManager {
     return this._currentAuthData?.token as AuthToken
   }
 
-  onTokenExpired (token: AuthToken): void {
-    if (util.equals(token, this._currentAuthData?.token)) {
-      this._scheduleRefreshAuthToken()
+  handleSecurityException (token: AuthToken, securityErrorCode: SecurityErrorCode): boolean {
+    if (this._handledSecurityCodes.includes(securityErrorCode)) {
+      if (util.equals(token, this._currentAuthData?.token)) {
+        this._scheduleRefreshAuthToken()
+      }
+      return true
     }
+    return false
   }
 
   private _scheduleRefreshAuthToken (observer?: TokenRefreshObserver): void {
@@ -221,7 +220,7 @@ class StaticAuthTokenManager implements AuthTokenManager {
     return this._authToken
   }
 
-  onTokenExpired (_: AuthToken): void {
-    // nothing to do here
+  handleSecurityException (_: AuthToken, __: SecurityErrorCode): boolean {
+    return false
   }
 }

--- a/packages/core/src/auth-token-manager.ts
+++ b/packages/core/src/auth-token-manager.ts
@@ -113,6 +113,28 @@ class AuthTokenManagers {
       'Neo.ClientError.Security.TokenExpired'
     ])
   }
+
+  /**
+   * Creates a {@link AuthTokenManager} for handle {@link AuthToken} and password rotation.
+   *
+   * **Warning**: `tokenProvider` must only ever return auth information belonging to the same identity.
+   * Switching identities using the `AuthTokenManager` is undefined behavior.
+   *
+   * @param param0 - The params
+   * @param {function(): Promise<AuthToken>} param0.tokenProvider - Retrieves a new valid auth token.
+   * Must only ever return auth information belonging to the same identity.
+   * @returns {AuthTokenManager} The basic auth data manager.
+   * @experimental Exposed as preview feature.
+   */
+  basic ({ tokenProvider }: { tokenProvider: () => Promise<AuthToken> }): AuthTokenManager {
+    if (typeof tokenProvider !== 'function') {
+      throw new TypeError(`tokenProvider should be function, but got: ${typeof tokenProvider}`)
+    }
+
+    return new ExpirationBasedAuthTokenManager(async () => {
+      return { token: await tokenProvider() }
+    }, ['Neo.ClientError.Security.Unauthorized'])
+  }
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,7 +87,7 @@ import Session, { TransactionConfig } from './session'
 import Driver, * as driver from './driver'
 import auth from './auth'
 import BookmarkManager, { BookmarkManagerConfig, bookmarkManager } from './bookmark-manager'
-import AuthTokenManager, { expirationBasedAuthTokenManager, staticAuthTokenManager, AuthTokenAndExpiration } from './auth-token-manager'
+import AuthTokenManager, { authTokenManagers, AuthTokenManagers, staticAuthTokenManager, AuthTokenAndExpiration } from './auth-token-manager'
 import { SessionConfig, QueryConfig, RoutingControl, routing } from './driver'
 import { Config } from './types'
 import * as types from './types'
@@ -108,6 +108,7 @@ const error = {
  * @private
  */
 const forExport = {
+  authTokenManagers,
   newError,
   Neo4jError,
   isRetriableError,
@@ -165,7 +166,6 @@ const forExport = {
   json,
   auth,
   bookmarkManager,
-  expirationBasedAuthTokenManager,
   routing,
   resultTransformers,
   notificationCategory,
@@ -175,6 +175,7 @@ const forExport = {
 }
 
 export {
+  authTokenManagers,
   newError,
   Neo4jError,
   isRetriableError,
@@ -233,7 +234,6 @@ export {
   json,
   auth,
   bookmarkManager,
-  expirationBasedAuthTokenManager,
   staticAuthTokenManager,
   routing,
   resultTransformers,
@@ -253,6 +253,7 @@ export type {
   BookmarkManager,
   BookmarkManagerConfig,
   AuthTokenManager,
+  AuthTokenManagers,
   AuthTokenAndExpiration,
   Config,
   SessionConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,7 +87,7 @@ import Session, { TransactionConfig } from './session'
 import Driver, * as driver from './driver'
 import auth from './auth'
 import BookmarkManager, { BookmarkManagerConfig, bookmarkManager } from './bookmark-manager'
-import AuthTokenManager, { expirationBasedAuthTokenManager, staticAuthTokenManager, isStaticAuthTokenManger, AuthTokenAndExpiration } from './auth-token-manager'
+import AuthTokenManager, { expirationBasedAuthTokenManager, staticAuthTokenManager, AuthTokenAndExpiration } from './auth-token-manager'
 import { SessionConfig, QueryConfig, RoutingControl, routing } from './driver'
 import { Config } from './types'
 import * as types from './types'
@@ -235,7 +235,6 @@ export {
   bookmarkManager,
   expirationBasedAuthTokenManager,
   staticAuthTokenManager,
-  isStaticAuthTokenManger,
   routing,
   resultTransformers,
   notificationCategory,

--- a/packages/core/test/auth-token-manager.test.ts
+++ b/packages/core/test/auth-token-manager.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { auth } from '../src'
-import AuthTokenManager, { SecurityErrorCode, authTokenManagers } from '../src/auth-token-manager'
+import AuthTokenManager, { AuthTokenAndExpiration, SecurityErrorCode, authTokenManagers } from '../src/auth-token-manager'
 import { AuthToken } from '../src/types'
 
 describe('authTokenManagers', () => {
@@ -153,6 +153,143 @@ describe('authTokenManagers', () => {
 
         await expect(basic.getToken()).resolves.toBe(newAuthToken)
         await expect(basic.getToken()).resolves.toBe(newAuthToken)
+
+        expect(tokenProvider).toHaveBeenCalledTimes(2)
+      })
+    })
+  })
+
+  describe('.bearer()', () => {
+    const BEARER_HANDLED_ERROR_CODES = Object.freeze(['Neo.ClientError.Security.Unauthorized', 'Neo.ClientError.Security.TokenExpired'])
+    const BEARER_NOT_HANDLED_ERROR_CODES = Object.freeze(SECURITY_ERROR_CODES.filter(code => !BEARER_HANDLED_ERROR_CODES.includes(code)))
+
+    it.each([
+      undefined,
+      null,
+      {},
+      { tokenProvider: null },
+      { tokenProvider: undefined },
+      { tokenProvider: false },
+      { tokenProvider: auth.bearer('THE BEAR') }
+    ])('should throw when instantiate with wrong parameters (params=%o)', (param) => {
+      // @ts-expect-error
+      expect(() => authTokenManagers.bearer(param)).toThrowError(TypeError)
+    })
+
+    it('should create an AuthTokenManager instance', () => {
+      const bearer: AuthTokenManager = authTokenManagers.bearer({
+        tokenProvider: async () => {
+          return {
+            token: auth.bearer('bearer my_bear')
+          }
+        }
+      })
+
+      expect(bearer).toBeDefined()
+      expect(bearer.getToken).toBeInstanceOf(Function)
+      expect(bearer.handleSecurityException).toBeInstanceOf(Function)
+    })
+
+    describe('.handleSecurityException()', () => {
+      let bearer: AuthTokenManager
+      let tokenProvider: jest.Mock<Promise<AuthTokenAndExpiration>>
+      let authToken: AuthToken
+
+      beforeEach(async () => {
+        authToken = auth.bearer('bearer my_bear')
+        tokenProvider = jest.fn(async () => ({ token: authToken }))
+        bearer = authTokenManagers.bearer({ tokenProvider })
+        // init auth token
+        await bearer.getToken()
+        tokenProvider.mockReset()
+      })
+
+      describe.each(BEARER_HANDLED_ERROR_CODES)('when error code equals to "%s"', (code: SecurityErrorCode) => {
+        describe('and same auth token', () => {
+          it('should call tokenProvider and return true', () => {
+            const handled = bearer.handleSecurityException(authToken, code)
+
+            expect(handled).toBe(true)
+            expect(tokenProvider).toHaveBeenCalled()
+          })
+
+          it('should call tokenProvider only if there is not an ongoing call', async () => {
+            const promise = { resolve: (_: AuthTokenAndExpiration) => { } }
+            tokenProvider.mockReturnValue(new Promise<AuthTokenAndExpiration>((resolve) => { promise.resolve = resolve }))
+
+            expect(bearer.handleSecurityException(authToken, code)).toBe(true)
+            expect(tokenProvider).toHaveBeenCalled()
+
+            await triggerEventLoop()
+
+            expect(bearer.handleSecurityException(authToken, code)).toBe(true)
+            expect(tokenProvider).toHaveBeenCalledTimes(1)
+
+            promise.resolve({ token: authToken })
+            await triggerEventLoop()
+
+            expect(bearer.handleSecurityException(authToken, code)).toBe(true)
+            expect(tokenProvider).toHaveBeenCalledTimes(2)
+
+            promise.resolve({ token: authToken })
+          })
+        })
+
+        describe('and different auth token', () => {
+          const otherAuthToken = auth.bearer('bearer another_bear')
+
+          it('should return true and not call the provider', () => {
+            const handled = bearer.handleSecurityException(otherAuthToken, code)
+
+            expect(handled).toBe(true)
+            expect(tokenProvider).not.toHaveBeenCalled()
+          })
+        })
+      })
+
+      it.each(BEARER_NOT_HANDLED_ERROR_CODES)('should not handle "%s"', (code: SecurityErrorCode) => {
+        const handled = bearer.handleSecurityException(authToken, code)
+
+        expect(handled).toBe(false)
+        expect(tokenProvider).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('.getToken()', () => {
+      let bearer: AuthTokenManager
+      let tokenProvider: jest.Mock<Promise<AuthTokenAndExpiration>>
+      let authToken: AuthToken
+
+      beforeEach(async () => {
+        authToken = auth.bearer('bearer my_bear')
+        tokenProvider = jest.fn(async () => ({ token: authToken }))
+        bearer = authTokenManagers.bearer({ tokenProvider })
+      })
+
+      it('should call tokenProvider once and return the provided token many times', async () => {
+        await expect(bearer.getToken()).resolves.toBe(authToken)
+
+        expect(tokenProvider).toHaveBeenCalledTimes(1)
+
+        await expect(bearer.getToken()).resolves.toBe(authToken)
+        await expect(bearer.getToken()).resolves.toBe(authToken)
+
+        expect(tokenProvider).toHaveBeenCalledTimes(1)
+      })
+
+      it.each(BEARER_HANDLED_ERROR_CODES)('should reflect the authToken refreshed by handleSecurityException(authToken, "%s")', async (code: SecurityErrorCode) => {
+        const newAuthToken = auth.bearer('bearer another_bear')
+        await expect(bearer.getToken()).resolves.toBe(authToken)
+
+        expect(tokenProvider).toHaveBeenCalledTimes(1)
+
+        tokenProvider.mockReturnValueOnce(Promise.resolve({ token: newAuthToken }))
+
+        bearer.handleSecurityException(authToken, code)
+        expect(tokenProvider).toHaveBeenCalledTimes(2)
+
+        await expect(bearer.getToken()).resolves.toBe(newAuthToken)
+        await expect(bearer.getToken()).resolves.toBe(newAuthToken)
 
         expect(tokenProvider).toHaveBeenCalledTimes(2)
       })

--- a/packages/core/test/auth-token-manager.test.ts
+++ b/packages/core/test/auth-token-manager.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { auth } from '../src'
+import AuthTokenManager, { SecurityErrorCode, authTokenManagers } from '../src/auth-token-manager'
+import { AuthToken } from '../src/types'
+
+describe('authTokenManagers', () => {
+  const SECURITY_ERROR_CODES = [
+    'Neo.ClientError.Security.TokenExpired',
+    'Neo.ClientError.Security.MadeUp',
+    'Neo.ClientError.Security.AuthorizationExpired',
+    'Neo.ClientError.Security.Unauthorized'
+  ]
+
+  describe('.basic()', () => {
+    const BASIC_HANDLED_ERROR_CODES = Object.freeze(['Neo.ClientError.Security.Unauthorized'])
+    const BASIC_NOT_HANDLED_ERROR_CODES = Object.freeze(SECURITY_ERROR_CODES.filter(code => !BASIC_HANDLED_ERROR_CODES.includes(code)))
+
+    it.each([
+      undefined,
+      null,
+      {},
+      { tokenProvider: null },
+      { tokenProvider: undefined },
+      { tokenProvider: false },
+      { tokenProvider: auth.basic('user', 'password') }
+    ])('should throw when instantiate with wrong parameters (params=%o)', (param) => {
+      // @ts-expect-error
+      expect(() => authTokenManagers.basic(param)).toThrowError(TypeError)
+    })
+
+    it('should create an AuthTokenManager instance', () => {
+      const basic: AuthTokenManager = authTokenManagers.basic({ tokenProvider: async () => auth.basic('user', 'password') })
+
+      expect(basic).toBeDefined()
+      expect(basic.getToken).toBeInstanceOf(Function)
+      expect(basic.handleSecurityException).toBeInstanceOf(Function)
+    })
+
+    describe('.handleSecurityException()', () => {
+      let basic: AuthTokenManager
+      let tokenProvider: jest.Mock<Promise<AuthToken>>
+
+      beforeEach(async () => {
+        tokenProvider = jest.fn(async () => auth.basic('user', 'password'))
+        basic = authTokenManagers.basic({ tokenProvider })
+        // init auth token
+        await basic.getToken()
+        tokenProvider.mockReset()
+      })
+
+      describe.each(BASIC_HANDLED_ERROR_CODES)('when error code equals to "%s"', (code: SecurityErrorCode) => {
+        describe('and same auth token', () => {
+          const authToken = auth.basic('user', 'password')
+
+          it('should call tokenProvider and return true', () => {
+            const handled = basic.handleSecurityException(authToken, code)
+
+            expect(handled).toBe(true)
+            expect(tokenProvider).toHaveBeenCalled()
+          })
+
+          it('should call tokenProvider only if there is not an ongoing call', async () => {
+            const promise = { resolve: (_: AuthToken) => { } }
+            tokenProvider.mockReturnValue(new Promise<AuthToken>((resolve) => { promise.resolve = resolve }))
+
+            expect(basic.handleSecurityException(authToken, code)).toBe(true)
+            expect(tokenProvider).toHaveBeenCalled()
+
+            await triggerEventLoop()
+
+            expect(basic.handleSecurityException(authToken, code)).toBe(true)
+            expect(tokenProvider).toHaveBeenCalledTimes(1)
+
+            promise.resolve(authToken)
+            await triggerEventLoop()
+
+            expect(basic.handleSecurityException(authToken, code)).toBe(true)
+            expect(tokenProvider).toHaveBeenCalledTimes(2)
+
+            promise.resolve(authToken)
+          })
+        })
+
+        describe('and different auth token', () => {
+          const authToken = auth.basic('other_user', 'other_password')
+
+          it('should return true and not call the provider', () => {
+            const handled = basic.handleSecurityException(authToken, code)
+
+            expect(handled).toBe(true)
+            expect(tokenProvider).not.toHaveBeenCalled()
+          })
+        })
+      })
+
+      it.each(BASIC_NOT_HANDLED_ERROR_CODES)('should not handle "%s"', (code: SecurityErrorCode) => {
+        const handled = basic.handleSecurityException(auth.basic('user', 'password'), code)
+
+        expect(handled).toBe(false)
+        expect(tokenProvider).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('.getToken()', () => {
+      let basic: AuthTokenManager
+      let tokenProvider: jest.Mock<Promise<AuthToken>>
+      let authToken: AuthToken
+
+      beforeEach(async () => {
+        authToken = auth.basic('user', 'password')
+        tokenProvider = jest.fn(async () => authToken)
+        basic = authTokenManagers.basic({ tokenProvider })
+      })
+
+      it('should call tokenProvider once and return the provided token many times', async () => {
+        await expect(basic.getToken()).resolves.toBe(authToken)
+
+        expect(tokenProvider).toHaveBeenCalledTimes(1)
+
+        await expect(basic.getToken()).resolves.toBe(authToken)
+        await expect(basic.getToken()).resolves.toBe(authToken)
+
+        expect(tokenProvider).toHaveBeenCalledTimes(1)
+      })
+
+      it.each(BASIC_HANDLED_ERROR_CODES)('should reflect the authToken refreshed by handleSecurityException(authToken, "%s")', async (code: SecurityErrorCode) => {
+        const newAuthToken = auth.basic('other_user', 'other_password')
+        await expect(basic.getToken()).resolves.toBe(authToken)
+
+        expect(tokenProvider).toHaveBeenCalledTimes(1)
+
+        tokenProvider.mockReturnValueOnce(Promise.resolve(newAuthToken))
+
+        basic.handleSecurityException(authToken, code)
+        expect(tokenProvider).toHaveBeenCalledTimes(2)
+
+        await expect(basic.getToken()).resolves.toBe(newAuthToken)
+        await expect(basic.getToken()).resolves.toBe(newAuthToken)
+
+        expect(tokenProvider).toHaveBeenCalledTimes(2)
+      })
+    })
+  })
+})
+
+async function triggerEventLoop (): Promise<unknown> {
+  return await new Promise(resolve => setTimeout(resolve, 0))
+}

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/authentication-provider.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/authentication-provider.js
@@ -56,12 +56,10 @@ export default class AuthenticationProvider {
   handleError ({ connection, code }) {
     if (
       connection &&
-      [
-        'Neo.ClientError.Security.Unauthorized',
-        'Neo.ClientError.Security.TokenExpired'
-      ].includes(code)
+      code.startsWith('Neo.ClientError.Security.')
     ) {
-      this._authTokenManager.onTokenExpired(connection.authToken)
+      return this._authTokenManager.handleSecurityException(connection.authToken, code)
     }
+    return false
   }
 }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/authentication-provider.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/authentication-provider.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { expirationBasedAuthTokenManager } from '../../core/index.ts'
+import { staticAuthTokenManager } from '../../core/index.ts'
 import { object } from '../lang/index.js'
 
 /**
@@ -25,9 +25,7 @@ import { object } from '../lang/index.js'
  */
 export default class AuthenticationProvider {
   constructor ({ authTokenManager, userAgent, boltAgent }) {
-    this._authTokenManager = authTokenManager || expirationBasedAuthTokenManager({
-      tokenProvider: () => {}
-    })
+    this._authTokenManager = authTokenManager || staticAuthTokenManager({})
     this._userAgent = userAgent
     this._boltAgent = boltAgent
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-direct.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-direct.js
@@ -50,8 +50,8 @@ export default class DirectConnectionProvider extends PooledConnectionProvider {
   async acquireConnection ({ accessMode, database, bookmarks, auth, forceReAuth } = {}) {
     const databaseSpecificErrorHandler = ConnectionErrorHandler.create({
       errorCode: SERVICE_UNAVAILABLE,
-      handleAuthorizationExpired: (error, address, conn) =>
-        this._handleAuthorizationExpired(error, address, conn, database)
+      handleSecurityError: (error, address, conn) =>
+        this._handleSecurityError(error, address, conn, database)
     })
 
     const connection = await this._connectionPool.acquire({ auth, forceReAuth }, this._address)
@@ -68,12 +68,12 @@ export default class DirectConnectionProvider extends PooledConnectionProvider {
     return new DelegateConnection(connection, databaseSpecificErrorHandler)
   }
 
-  _handleAuthorizationExpired (error, address, connection, database) {
+  _handleSecurityError (error, address, connection, database) {
     this._log.warn(
       `Direct driver ${this._id} will close connection to ${address} for database '${database}' because of an error ${error.code} '${error.message}'`
     )
 
-    return super._handleAuthorizationExpired(error, address, connection)
+    return super._handleSecurityError(error, address, connection)
   }
 
   async _hasProtocolVersion (versionPredicate) {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
@@ -223,7 +223,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     conn._updateCurrentObserver()
   }
 
-  _handleAuthorizationExpired (error, address, connection) {
+  _handleSecurityError (error, address, connection) {
     const handled = this._authenticationProvider.handleError({ connection, code: error.code })
 
     if (handled) {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
@@ -19,7 +19,7 @@
 
 import { createChannelConnection, ConnectionErrorHandler } from '../connection/index.js'
 import Pool, { PoolConfig } from '../pool/index.js'
-import { error, ConnectionProvider, ServerInfo, newError, isStaticAuthTokenManger } from '../../core/index.ts'
+import { error, ConnectionProvider, ServerInfo, newError } from '../../core/index.ts'
 import AuthenticationProvider from './authentication-provider.js'
 import { object } from '../lang/index.js'
 
@@ -41,7 +41,6 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     this._id = id
     this._config = config
     this._log = log
-    this._authTokenManager = authTokenManager
     this._authenticationProvider = new AuthenticationProvider({ authTokenManager, userAgent, boltAgent })
     this._userAgent = userAgent
     this._boltAgent = boltAgent
@@ -225,7 +224,11 @@ export default class PooledConnectionProvider extends ConnectionProvider {
   }
 
   _handleAuthorizationExpired (error, address, connection) {
-    this._authenticationProvider.handleError({ connection, code: error.code })
+    const handled = this._authenticationProvider.handleError({ connection, code: error.code })
+
+    if (handled) {
+      error.retriable = true
+    }
 
     if (error.code === 'Neo.ClientError.Security.AuthorizationExpired') {
       this._connectionPool.apply(address, (conn) => { conn.authToken = null })
@@ -233,10 +236,6 @@ export default class PooledConnectionProvider extends ConnectionProvider {
 
     if (connection) {
       connection.close().catch(() => undefined)
-    }
-
-    if (error.code === 'Neo.ClientError.Security.TokenExpired' && !isStaticAuthTokenManger(this._authTokenManager)) {
-      error.retriable = true
     }
 
     return error

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -116,12 +116,12 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     return error
   }
 
-  _handleAuthorizationExpired (error, address, connection, database) {
+  _handleSecurityError (error, address, connection, database) {
     this._log.warn(
       `Routing driver ${this._id} will close connections to ${address} for database '${database}' because of an error ${error.code} '${error.message}'`
     )
 
-    return super._handleAuthorizationExpired(error, address, connection, database)
+    return super._handleSecurityError(error, address, connection, database)
   }
 
   _handleWriteFailure (error, address, database) {
@@ -150,7 +150,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
       (error, address) => this._handleUnavailability(error, address, context.database),
       (error, address) => this._handleWriteFailure(error, address, context.database),
       (error, address, conn) =>
-        this._handleAuthorizationExpired(error, address, conn, context.database)
+        this._handleSecurityError(error, address, conn, context.database)
     )
 
     const routingTable = await this._freshRoutingTable({
@@ -584,7 +584,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
 
       const databaseSpecificErrorHandler = ConnectionErrorHandler.create({
         errorCode: SESSION_EXPIRED,
-        handleAuthorizationExpired: (error, address, conn) => this._handleAuthorizationExpired(error, address, conn)
+        handleSecurityError: (error, address, conn) => this._handleSecurityError(error, address, conn)
       })
 
       const delegateConnection = !connection._sticky

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-error-handler.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-error-handler.js
@@ -26,25 +26,25 @@ export default class ConnectionErrorHandler {
     errorCode,
     handleUnavailability,
     handleWriteFailure,
-    handleAuthorizationExpired
+    handleSecurityError
   ) {
     this._errorCode = errorCode
     this._handleUnavailability = handleUnavailability || noOpHandler
     this._handleWriteFailure = handleWriteFailure || noOpHandler
-    this._handleAuthorizationExpired = handleAuthorizationExpired || noOpHandler
+    this._handleSecurityError = handleSecurityError || noOpHandler
   }
 
   static create ({
     errorCode,
     handleUnavailability,
     handleWriteFailure,
-    handleAuthorizationExpired
+    handleSecurityError
   }) {
     return new ConnectionErrorHandler(
       errorCode,
       handleUnavailability,
       handleWriteFailure,
-      handleAuthorizationExpired
+      handleSecurityError
     )
   }
 
@@ -63,8 +63,8 @@ export default class ConnectionErrorHandler {
    * @return {Neo4jError} new error that should be propagated to the user.
    */
   handleAndTransformError (error, address, connection) {
-    if (isAutorizationExpiredError(error)) {
-      return this._handleAuthorizationExpired(error, address, connection)
+    if (isSecurityError(error)) {
+      return this._handleSecurityError(error, address, connection)
     }
     if (isAvailabilityError(error)) {
       return this._handleUnavailability(error, address, connection)
@@ -76,11 +76,10 @@ export default class ConnectionErrorHandler {
   }
 }
 
-function isAutorizationExpiredError (error) {
-  return error && (
-    error.code === 'Neo.ClientError.Security.AuthorizationExpired' ||
-      error.code === 'Neo.ClientError.Security.TokenExpired'
-  )
+function isSecurityError (error) {
+  return error != null &&
+    error.code != null &&
+    error.code.startsWith('Neo.ClientError.Security.')
 }
 
 function isAvailabilityError (error) {

--- a/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
@@ -21,7 +21,7 @@ import auth from './auth.ts'
 import { AuthToken } from './types.ts'
 import { util } from './internal/index.ts'
 
-type SecurityErrorCode = `Neo.ClientError.Security.${string}`
+export type SecurityErrorCode = `Neo.ClientError.Security.${string}`
 
 /**
  * Interface for the piece of software responsible for keeping track of current active {@link AuthToken} across the driver.

--- a/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
@@ -120,7 +120,7 @@ class AuthTokenManagers {
    * **Warning**: `tokenProvider` must only ever return auth information belonging to the same identity.
    * Switching identities using the `AuthTokenManager` is undefined behavior.
    *
-   * @param param0 - The params
+   * @param {object} param0 - The params
    * @param {function(): Promise<AuthToken>} param0.tokenProvider - Retrieves a new valid auth token.
    * Must only ever return auth information belonging to the same identity.
    * @returns {AuthTokenManager} The basic auth data manager.
@@ -139,8 +139,16 @@ class AuthTokenManagers {
 
 /**
  * Holds the common {@link AuthTokenManagers} used in the Driver
+ *
+ * @experimental Exposed as preview feature.
  */
-export const authTokenManagers: AuthTokenManagers = Object.freeze(new AuthTokenManagers())
+const authTokenManagers: AuthTokenManagers = new AuthTokenManagers()
+
+Object.freeze(authTokenManagers)
+
+export {
+  authTokenManagers
+}
 
 export type {
   AuthTokenManagers

--- a/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
@@ -113,6 +113,28 @@ class AuthTokenManagers {
       'Neo.ClientError.Security.TokenExpired'
     ])
   }
+
+  /**
+   * Creates a {@link AuthTokenManager} for handle {@link AuthToken} and password rotation.
+   *
+   * **Warning**: `tokenProvider` must only ever return auth information belonging to the same identity.
+   * Switching identities using the `AuthTokenManager` is undefined behavior.
+   *
+   * @param param0 - The params
+   * @param {function(): Promise<AuthToken>} param0.tokenProvider - Retrieves a new valid auth token.
+   * Must only ever return auth information belonging to the same identity.
+   * @returns {AuthTokenManager} The basic auth data manager.
+   * @experimental Exposed as preview feature.
+   */
+  basic ({ tokenProvider }: { tokenProvider: () => Promise<AuthToken> }): AuthTokenManager {
+    if (typeof tokenProvider !== 'function') {
+      throw new TypeError(`tokenProvider should be function, but got: ${typeof tokenProvider}`)
+    }
+
+    return new ExpirationBasedAuthTokenManager(async () => {
+      return { token: await tokenProvider() }
+    }, ['Neo.ClientError.Security.Unauthorized'])
+  }
 }
 
 /**

--- a/packages/neo4j-driver-deno/lib/core/index.ts
+++ b/packages/neo4j-driver-deno/lib/core/index.ts
@@ -87,7 +87,7 @@ import Session, { TransactionConfig } from './session.ts'
 import Driver, * as driver from './driver.ts'
 import auth from './auth.ts'
 import BookmarkManager, { BookmarkManagerConfig, bookmarkManager } from './bookmark-manager.ts'
-import AuthTokenManager, { expirationBasedAuthTokenManager, staticAuthTokenManager, isStaticAuthTokenManger, AuthTokenAndExpiration } from './auth-token-manager.ts'
+import AuthTokenManager, { expirationBasedAuthTokenManager, staticAuthTokenManager, AuthTokenAndExpiration } from './auth-token-manager.ts'
 import { SessionConfig, QueryConfig, RoutingControl, routing } from './driver.ts'
 import { Config } from './types.ts'
 import * as types from './types.ts'
@@ -235,7 +235,6 @@ export {
   bookmarkManager,
   expirationBasedAuthTokenManager,
   staticAuthTokenManager,
-  isStaticAuthTokenManger,
   routing,
   resultTransformers,
   notificationCategory,

--- a/packages/neo4j-driver-deno/lib/core/index.ts
+++ b/packages/neo4j-driver-deno/lib/core/index.ts
@@ -87,7 +87,7 @@ import Session, { TransactionConfig } from './session.ts'
 import Driver, * as driver from './driver.ts'
 import auth from './auth.ts'
 import BookmarkManager, { BookmarkManagerConfig, bookmarkManager } from './bookmark-manager.ts'
-import AuthTokenManager, { expirationBasedAuthTokenManager, staticAuthTokenManager, AuthTokenAndExpiration } from './auth-token-manager.ts'
+import AuthTokenManager, { authTokenManagers, AuthTokenManagers, staticAuthTokenManager, AuthTokenAndExpiration } from './auth-token-manager.ts'
 import { SessionConfig, QueryConfig, RoutingControl, routing } from './driver.ts'
 import { Config } from './types.ts'
 import * as types from './types.ts'
@@ -108,6 +108,7 @@ const error = {
  * @private
  */
 const forExport = {
+  authTokenManagers,
   newError,
   Neo4jError,
   isRetriableError,
@@ -165,7 +166,6 @@ const forExport = {
   json,
   auth,
   bookmarkManager,
-  expirationBasedAuthTokenManager,
   routing,
   resultTransformers,
   notificationCategory,
@@ -175,6 +175,7 @@ const forExport = {
 }
 
 export {
+  authTokenManagers,
   newError,
   Neo4jError,
   isRetriableError,
@@ -233,7 +234,6 @@ export {
   json,
   auth,
   bookmarkManager,
-  expirationBasedAuthTokenManager,
   staticAuthTokenManager,
   routing,
   resultTransformers,
@@ -253,6 +253,7 @@ export type {
   BookmarkManager,
   BookmarkManagerConfig,
   AuthTokenManager,
+  AuthTokenManagers,
   AuthTokenAndExpiration,
   Config,
   SessionConfig,

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -21,6 +21,8 @@ import { logging } from './logging.ts'
 
 import {
   auth,
+  AuthTokenManagers,
+  authTokenManagers,
   BookmarkManager,
   bookmarkManager,
   BookmarkManagerConfig,
@@ -63,7 +65,6 @@ import {
   NotificationFilterDisabledCategory,
   notificationFilterDisabledCategory,
   AuthTokenManager,
-  expirationBasedAuthTokenManager,
   AuthTokenAndExpiration,
   staticAuthTokenManager,
   NotificationFilterMinimumSeverityLevel,
@@ -362,6 +363,7 @@ const graph = {
  * @private
  */
 const forExport = {
+  authTokenManagers,
   driver,
   hasReachableServer,
   int,
@@ -424,11 +426,11 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel,
-  expirationBasedAuthTokenManager
+  notificationFilterMinimumSeverityLevel
 }
 
 export {
+  authTokenManagers,
   driver,
   hasReachableServer,
   int,
@@ -491,13 +493,13 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel,
-  expirationBasedAuthTokenManager
+  notificationFilterMinimumSeverityLevel
 }
 export type {
   QueryResult,
   AuthToken,
   AuthTokenManager,
+  AuthTokenManagers,
   AuthTokenAndExpiration,
   Config,
   EncryptionLevel,

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -126,11 +126,11 @@ function isAuthTokenManager (value: unknown): value is AuthTokenManager {
   if (typeof value === 'object' &&
     value != null &&
     'getToken' in value &&
-    'onTokenExpired' in value) {
+    'handleSecurityException' in value) {
     const manager = value as AuthTokenManager
 
     return typeof manager.getToken === 'function' &&
-      typeof manager.onTokenExpired === 'function'
+      typeof manager.handleSecurityException === 'function'
   }
 
   return false

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -125,11 +125,11 @@ function isAuthTokenManager (value: unknown): value is AuthTokenManager {
   if (typeof value === 'object' &&
     value != null &&
     'getToken' in value &&
-    'onTokenExpired' in value) {
+    'handleSecurityException' in value) {
     const manager = value as AuthTokenManager
 
     return typeof manager.getToken === 'function' &&
-      typeof manager.onTokenExpired === 'function'
+      typeof manager.handleSecurityException === 'function'
   }
 
   return false

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -21,6 +21,8 @@ import { logging } from './logging'
 
 import {
   auth,
+  AuthTokenManagers,
+  authTokenManagers,
   BookmarkManager,
   bookmarkManager,
   BookmarkManagerConfig,
@@ -63,7 +65,6 @@ import {
   NotificationFilterDisabledCategory,
   notificationFilterDisabledCategory,
   AuthTokenManager,
-  expirationBasedAuthTokenManager,
   AuthTokenAndExpiration,
   staticAuthTokenManager,
   NotificationFilterMinimumSeverityLevel,
@@ -361,6 +362,7 @@ const graph = {
  * @private
  */
 const forExport = {
+  authTokenManagers,
   driver,
   hasReachableServer,
   int,
@@ -423,11 +425,11 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel,
-  expirationBasedAuthTokenManager
+  notificationFilterMinimumSeverityLevel
 }
 
 export {
+  authTokenManagers,
   driver,
   hasReachableServer,
   int,
@@ -490,13 +492,13 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel,
-  expirationBasedAuthTokenManager
+  notificationFilterMinimumSeverityLevel
 }
 export type {
   QueryResult,
   AuthToken,
   AuthTokenManager,
+  AuthTokenManagers,
   AuthTokenAndExpiration,
   Config,
   EncryptionLevel,

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -20,6 +20,7 @@ import { Driver, READ, WRITE } from './driver'
 import VERSION from './version'
 
 import {
+  authTokenManagers,
   Neo4jError,
   isRetryableError,
   error,
@@ -74,7 +75,6 @@ import {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  expirationBasedAuthTokenManager,
   staticAuthTokenManager
 } from 'neo4j-driver-core'
 import {
@@ -332,6 +332,7 @@ const graph = {
  * @private
  */
 const forExport = {
+  authTokenManagers,
   driver,
   hasReachableServer,
   int,
@@ -395,11 +396,11 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel,
-  expirationBasedAuthTokenManager
+  notificationFilterMinimumSeverityLevel
 }
 
 export {
+  authTokenManagers,
   driver,
   hasReachableServer,
   int,
@@ -463,7 +464,6 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel,
-  expirationBasedAuthTokenManager
+  notificationFilterMinimumSeverityLevel
 }
 export default forExport

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -99,9 +99,9 @@ function isAuthTokenManager (value) {
   return typeof value === 'object' &&
     value != null &&
     'getToken' in value &&
-    'onTokenExpired' in value &&
+    'handleSecurityException' in value &&
     typeof value.getToken === 'function' &&
-    typeof value.onTokenExpired === 'function'
+    typeof value.handleSecurityException === 'function'
 }
 
 function createAuthManager (authTokenOrManager) {

--- a/packages/neo4j-driver/test/types/index.test.ts
+++ b/packages/neo4j-driver/test/types/index.test.ts
@@ -45,7 +45,7 @@ import {
   NotificationFilterMinimumSeverityLevel,
   NotificationFilterDisabledCategory,
   notificationFilterDisabledCategory,
-  expirationBasedAuthTokenManager
+  authTokenManagers
 } from '../../types/index'
 
 import Driver from '../../types/driver'
@@ -88,7 +88,7 @@ const driver4: Driver = driver(
   }
 )
 
-const driver5: Driver = driver('bolt://localhost:7687', expirationBasedAuthTokenManager({
+const driver5: Driver = driver('bolt://localhost:7687', authTokenManagers.bearer({
   tokenProvider: async () => {
     return {
       token: auth.basic('neo4j', 'password')

--- a/packages/neo4j-driver/test/types/index.test.ts
+++ b/packages/neo4j-driver/test/types/index.test.ts
@@ -91,8 +91,14 @@ const driver4: Driver = driver(
 const driver5: Driver = driver('bolt://localhost:7687', authTokenManagers.bearer({
   tokenProvider: async () => {
     return {
-      token: auth.basic('neo4j', 'password')
+      token: auth.bearer('bearer token')
     }
+  }
+}))
+
+const driver6: Driver = driver('bolt://localhost:7687', authTokenManagers.basic({
+  tokenProvider: async () => {
+    return auth.basic('neo4j', 'password')
   }
 }))
 

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -18,6 +18,8 @@
  */
 
 import {
+  authTokenManagers,
+  AuthTokenManagers,
   Neo4jError,
   isRetriableError,
   error,
@@ -87,7 +89,6 @@ import {
   notificationFilterMinimumSeverityLevel,
   AuthTokenManager,
   AuthTokenAndExpiration,
-  expirationBasedAuthTokenManager,
   types as coreTypes
 } from 'neo4j-driver-core'
 import {
@@ -211,6 +212,7 @@ declare const graph: {
 */
 
 declare const forExport: {
+  authTokenManagers: typeof authTokenManagers
   driver: typeof driver
   hasReachableServer: typeof hasReachableServer
   int: typeof int
@@ -282,11 +284,11 @@ declare const forExport: {
   notificationSeverityLevel: typeof notificationSeverityLevel
   notificationFilterDisabledCategory: typeof notificationFilterDisabledCategory
   notificationFilterMinimumSeverityLevel: typeof notificationFilterMinimumSeverityLevel
-  expirationBasedAuthTokenManager: typeof expirationBasedAuthTokenManager
   logging: typeof logging
 }
 
 export {
+  authTokenManagers,
   driver,
   hasReachableServer,
   int,
@@ -358,11 +360,11 @@ export {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  expirationBasedAuthTokenManager,
   logging
 }
 
 export type {
+  AuthTokenManagers,
   BookmarkManager,
   BookmarkManagerConfig,
   SessionConfig,

--- a/packages/testkit-backend/deno/controller.ts
+++ b/packages/testkit-backend/deno/controller.ts
@@ -37,6 +37,8 @@ function newWire(context: Context, reply: Reply): Wire {
               msg: e.message,
               // @ts-ignore Code Neo4jError does have code
               code: e.code,
+              // @ts-ignore Code Neo4jError does retryable
+              retryable: e.retriable,
             },
           });
         }

--- a/packages/testkit-backend/src/context.js
+++ b/packages/testkit-backend/src/context.js
@@ -15,7 +15,8 @@ export default class Context {
     this._authTokenManagers = {}
     this._authTokenManagerGetAuthRequests = {}
     this._authTokenManagerOnAuthExpiredRequests = {}
-    this._expirationBasedAuthTokenProviderRequests = {}
+    this._bearerAuthTokenProviderRequests = {}
+    this._basicAuthTokenProviderRequests = {}
     this._binder = binder
     this._environmentLogLevel = environmentLogLevel
   }
@@ -201,16 +202,28 @@ export default class Context {
     delete this._authTokenManagerOnAuthExpiredRequests[id]
   }
 
-  addExpirationBasedAuthTokenProviderRequest (resolve, reject) {
-    return this._add(this._expirationBasedAuthTokenProviderRequests, { resolve, reject })
+  addBearerAuthTokenProviderRequest (resolve, reject) {
+    return this._add(this._bearerAuthTokenProviderRequests, { resolve, reject })
   }
 
-  getExpirationBasedAuthTokenProviderRequest (id) {
-    return this._expirationBasedAuthTokenProviderRequests[id]
+  getBearerAuthTokenProviderRequest (id) {
+    return this._bearerAuthTokenProviderRequests[id]
   }
 
-  removeExpirationBasedAuthTokenProviderRequest (id) {
-    delete this._expirationBasedAuthTokenProviderRequests[id]
+  removeBearerAuthTokenProviderRequest (id) {
+    delete this._bearerAuthTokenProviderRequests[id]
+  }
+
+  addBasicAuthTokenProviderRequest (resolve, reject) {
+    return this._add(this._basicAuthTokenProviderRequests, { resolve, reject })
+  }
+
+  getBasicAuthTokenProviderRequest (id) {
+    return this._basicAuthTokenProviderRequests[id]
+  }
+
+  removeBasicAuthTokenProviderRequest (id) {
+    delete this._basicAuthTokenProviderRequests[id]
   }
 
   _add (map, object) {

--- a/packages/testkit-backend/src/controller/local.js
+++ b/packages/testkit-backend/src/controller/local.js
@@ -70,7 +70,8 @@ export default class LocalController extends Controller {
         this._writeResponse(contextId, newResponse('DriverError', {
           id,
           msg: e.message,
-          code: e.code
+          code: e.code,
+          retryable: e.retriable
         }))
       }
       return

--- a/packages/testkit-backend/src/feature/common.js
+++ b/packages/testkit-backend/src/feature/common.js
@@ -27,6 +27,7 @@ const features = [
   'Feature:API:Driver.ExecuteQuery',
   'Feature:API:Driver:NotificationsConfig',
   'Feature:API:Driver:GetServerInfo',
+  'Feature:API:Driver.SupportsSessionAuth',
   'Feature:API:Driver.VerifyAuthentication',
   'Feature:API:Driver.VerifyConnectivity',
   'Feature:API:Session:NotificationsConfig',

--- a/packages/testkit-backend/src/feature/common.js
+++ b/packages/testkit-backend/src/feature/common.js
@@ -6,6 +6,7 @@ const features = [
   'Feature:Auth:Bearer',
   'Feature:Auth:Managed',
   'Feature:API:BookmarkManager',
+  'Feature:API:RetryableExceptions',
   'Feature:API:Session:AuthConfig',
   'Feature:API:SSLConfig',
   'Feature:API:SSLSchemes',

--- a/packages/testkit-backend/src/request-handlers-rx.js
+++ b/packages/testkit-backend/src/request-handlers-rx.js
@@ -28,7 +28,7 @@ export {
   NewAuthTokenManager,
   AuthTokenManagerClose,
   AuthTokenManagerGetAuthCompleted,
-  AuthTokenManagerOnAuthExpiredCompleted,
+  AuthTokenManagerHandleSecurityExceptionCompleted,
   NewBearerAuthTokenManager,
   BearerAuthTokenProviderCompleted,
   NewBasicAuthTokenManager,

--- a/packages/testkit-backend/src/request-handlers-rx.js
+++ b/packages/testkit-backend/src/request-handlers-rx.js
@@ -29,8 +29,10 @@ export {
   AuthTokenManagerClose,
   AuthTokenManagerGetAuthCompleted,
   AuthTokenManagerOnAuthExpiredCompleted,
-  NewExpirationBasedAuthTokenManager,
-  ExpirationBasedAuthTokenProviderCompleted,
+  NewBearerAuthTokenManager,
+  BearerAuthTokenProviderCompleted,
+  NewBasicAuthTokenManager,
+  BasicAuthTokenProviderCompleted,
   FakeTimeInstall,
   FakeTimeTick,
   FakeTimeUninstall

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -528,9 +528,16 @@ export function NewAuthTokenManager (_, context, _data, wire) {
         const id = context.addAuthTokenManagerGetAuthRequest(resolve, reject)
         wire.writeResponse(responses.AuthTokenManagerGetAuthRequest({ id, authTokenManagerId }))
       }),
-      onTokenExpired: (auth) => {
-        const id = context.addAuthTokenManagerOnAuthExpiredRequest()
-        wire.writeResponse(responses.AuthTokenManagerOnAuthExpiredRequest({ id, authTokenManagerId, auth }))
+      handleSecurityException: (auth, code) => {
+        if ([
+          'Neo.ClientError.Security.Unauthorized',
+          'Neo.ClientError.Security.TokenExpired'
+        ].includes(code)) {
+          const id = context.addAuthTokenManagerOnAuthExpiredRequest()
+          wire.writeResponse(responses.AuthTokenManagerOnAuthExpiredRequest({ id, authTokenManagerId, auth }))
+          return true
+        }
+        return false
       }
     }
   })

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -562,7 +562,7 @@ export function AuthTokenManagerOnAuthExpiredCompleted (_, context, { requestId 
 
 export function NewExpirationBasedAuthTokenManager ({ neo4j }, context, _, wire) {
   const id = context.addAuthTokenManager((expirationBasedAuthTokenManagerId) => {
-    return neo4j.expirationBasedAuthTokenManager({
+    return neo4j.authTokenManagers.bearer({
       tokenProvider: () => new Promise((resolve, reject) => {
         const id = context.addExpirationBasedAuthTokenProviderRequest(resolve, reject)
         wire.writeResponse(responses.ExpirationBasedAuthTokenProviderRequest({ id, expirationBasedAuthTokenManagerId }))

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -560,28 +560,47 @@ export function AuthTokenManagerOnAuthExpiredCompleted (_, context, { requestId 
   context.removeAuthTokenManagerOnAuthExpiredRequest(requestId)
 }
 
-export function NewExpirationBasedAuthTokenManager ({ neo4j }, context, _, wire) {
-  const id = context.addAuthTokenManager((expirationBasedAuthTokenManagerId) => {
+export function NewBearerAuthTokenManager ({ neo4j }, context, _, wire) {
+  const id = context.addAuthTokenManager((bearerAuthTokenManagerId) => {
     return neo4j.authTokenManagers.bearer({
       tokenProvider: () => new Promise((resolve, reject) => {
-        const id = context.addExpirationBasedAuthTokenProviderRequest(resolve, reject)
-        wire.writeResponse(responses.ExpirationBasedAuthTokenProviderRequest({ id, expirationBasedAuthTokenManagerId }))
+        const id = context.addBearerAuthTokenProviderRequest(resolve, reject)
+        wire.writeResponse(responses.BearerAuthTokenProviderRequest({ id, bearerAuthTokenManagerId }))
       })
     })
   })
 
-  wire.writeResponse(responses.ExpirationBasedAuthTokenManager({ id }))
+  wire.writeResponse(responses.BearerAuthTokenManager({ id }))
 }
 
-export function ExpirationBasedAuthTokenProviderCompleted (_, context, { requestId, auth }) {
-  const request = context.getExpirationBasedAuthTokenProviderRequest(requestId)
+export function BearerAuthTokenProviderCompleted (_, context, { requestId, auth }) {
+  const request = context.getBearerAuthTokenProviderRequest(requestId)
   request.resolve({
     expiration: auth.data.expiresInMs != null
       ? new Date(new Date().getTime() + auth.data.expiresInMs)
       : undefined,
     token: context.binder.parseAuthToken(auth.data.auth.data)
   })
-  context.removeExpirationBasedAuthTokenProviderRequest(requestId)
+  context.removeBearerAuthTokenProviderRequest(requestId)
+}
+
+export function NewBasicAuthTokenManager ({ neo4j }, context, _, wire) {
+  const id = context.addAuthTokenManager((basicAuthTokenManagerId) => {
+    return neo4j.authTokenManagers.basic({
+      tokenProvider: () => new Promise((resolve, reject) => {
+        const id = context.addBasicAuthTokenProviderRequest(resolve, reject)
+        wire.writeResponse(responses.BasicAuthTokenProviderRequest({ id, basicAuthTokenManagerId }))
+      })
+    })
+  })
+
+  wire.writeResponse(responses.BasicAuthTokenManager({ id }))
+}
+
+export function BasicAuthTokenProviderCompleted (_, context, { requestId, auth }) {
+  const request = context.getBasicAuthTokenProviderRequest(requestId)
+  request.resolve(context.binder.parseAuthToken(auth.data))
+  context.removeBasicAuthTokenProviderRequest(requestId)
 }
 
 export function GetRoutingTable (_, context, { driverId, database }, wire) {

--- a/packages/testkit-backend/src/responses.js
+++ b/packages/testkit-backend/src/responses.js
@@ -115,8 +115,8 @@ export function AuthorizationToken (data) {
   return response('AuthorizationToken', data)
 }
 
-export function AuthTokenManagerOnAuthExpiredRequest ({ id, authTokenManagerId, auth }) {
-  return response('AuthTokenManagerOnAuthExpiredRequest', { id, authTokenManagerId, auth: AuthorizationToken(auth) })
+export function AuthTokenManagerHandleSecurityExceptionRequest ({ id, authTokenManagerId, auth, code }) {
+  return response('AuthTokenManagerHandleSecurityExceptionRequest', { id, authTokenManagerId, auth: AuthorizationToken(auth), error_code: code })
 }
 
 export function BearerAuthTokenManager ({ id }) {

--- a/packages/testkit-backend/src/responses.js
+++ b/packages/testkit-backend/src/responses.js
@@ -119,12 +119,20 @@ export function AuthTokenManagerOnAuthExpiredRequest ({ id, authTokenManagerId, 
   return response('AuthTokenManagerOnAuthExpiredRequest', { id, authTokenManagerId, auth: AuthorizationToken(auth) })
 }
 
-export function ExpirationBasedAuthTokenManager ({ id }) {
-  return response('ExpirationBasedAuthTokenManager', { id })
+export function BearerAuthTokenManager ({ id }) {
+  return response('BearerAuthTokenManager', { id })
 }
 
-export function ExpirationBasedAuthTokenProviderRequest ({ id, expirationBasedAuthTokenManagerId }) {
-  return response('ExpirationBasedAuthTokenProviderRequest', { id, expirationBasedAuthTokenManagerId })
+export function BearerAuthTokenProviderRequest ({ id, bearerAuthTokenManagerId }) {
+  return response('BearerAuthTokenProviderRequest', { id, bearerAuthTokenManagerId })
+}
+
+export function BasicAuthTokenManager ({ id }) {
+  return response('BasicAuthTokenManager', { id })
+}
+
+export function BasicAuthTokenProviderRequest ({ id, basicAuthTokenManagerId }) {
+  return response('BasicAuthTokenProviderRequest', { id, basicAuthTokenManagerId })
 }
 
 export function DriverIsAuthenticated ({ id, authenticated }) {

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -1,4 +1,4 @@
-import skip, { ifEquals, ifEndsWith, endsWith, ifStartsWith, startsWith, not } from './skip.js'
+import skip, { ifEquals, ifEndsWith, endsWith, ifStartsWith, startsWith, not, or } from './skip.js'
 
 const skippedTests = [
   skip(
@@ -184,6 +184,20 @@ const skippedTests = [
     ifEquals(
       'stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_handshake'
     )
+  ),
+  skip(
+    'Backend does not support async AuthTokenManager.handleSecurityException',
+    ifStartsWith('stub.authorization.test_auth_token_manager.TestAuthTokenManager')
+      .and(
+        or(
+          endsWith('test_error_on_pull_using_session_run'),
+          endsWith('test_error_on_begin_using_tx_run'),
+          endsWith('test_error_on_run_using_tx_run'),
+          endsWith('test_error_on_pull_using_tx_run'),
+          endsWith('test_error_on_commit_using_tx_run'),
+          endsWith('test_error_on_rollback_using_tx_run')
+        )
+      )
   )
 ]
 


### PR DESCRIPTION
**⚠️ This API is released as preview.**

Currently, the `AuthTokenManager` is designed to handle token expiration only. The AuthTokenManager interface only has methods to receive notifications on security errors related to token expiration: `AuthTokenManager.onTokenExpired`. The provided implementation `neo4j.expirationBasedAuthTokenManager` is built to support only token expiration. However, we also want to cater for password rotation scenarios.

### Factory Method Changes

#### Expiration based and bearer tokens

The method `neo4j.expirationBasedAuthTokenManager` was renamed and moved to `neo4j.authTokenManagers.bearer`. 

```typescript
import neo4j, { AuthToken } from 'neo4j-driver'

/**
 * Method called whenever the driver needs to refresh the token.
 *
 * The refresh will happen if the driver is notified by the server
 * about a token expiration or if the `Date.now() > tokenData.expiry`
 *
 * Important, the driver will block all the connections creation until
 * this function resolves the new auth token.
 */
async function fetchAuthTokenFromMyProvider () {
   const bearer: string = await myProvider.getBearerToken()
   const token: AuthToken = neo4j.auth.bearer(bearer)
   const expiration: Date = myProvider.getExpiryDate()  
   return {
      token,
      // if expiration is not provided, 
      // the driver will only fetch a new token when a failure happens
      expiration 
   }
}

const driver = neo4j.driver(
    'neo4j://localhost:7687', 
    neo4j.authTokenManagers.bearer({ 
        tokenProvider: fetchAuthTokenFromMyProvider 
    })
)
```

#### Password rotation and basic auth

`neo4j.authTokenManagers.basic` was added to handle password rotation with `AuthTokenManager`.

 ```typescript
import neo4j, { AuthToken } from 'neo4j-driver'

/**
 * Method called whenever the driver needs to refresh the token.
 *
 * Important, the driver will block all the connections creation until
 * this function resolves the new auth token.
 */
async function fetchMyUserAndPassword () {
   const { user, password } = await myProvider.getUserAndPassword()
   return neo4j.auth.basic(user, password)  
}

const driver = neo4j.driver(
    'neo4j://localhost:7687', 
    neo4j.authTokenManagers.basic({ 
        tokenProvider: fetchMyUserAndPassword 
    })
)
```

### Development checklist

* [x] Update AuthTokenManager interface 
* [x] Change `expirationBasedAuthTokenManager` factory name to `authTokenManagers.bearer`
* [x] Add `authTokenManagers.basic` factory
* [x] Adapt `testkit-backend` 

**⚠️ This API is released as preview.**