### PR TITLE
Fix docs definition from Session._setTxExecutorToPipelineBegin

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -591,6 +591,7 @@ class Session {
    * Configure the transaction executor to pipeline transaction begin.
    *
    * @private
+   * @returns {void}
    */
   private _setTxExecutorToPipelineBegin (pipelined: boolean): void {
     this._transactionExecutor.pipelineBegin = pipelined

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -591,6 +591,7 @@ class Session {
    * Configure the transaction executor to pipeline transaction begin.
    *
    * @private
+   * @returns {void}
    */
   private _setTxExecutorToPipelineBegin (pipelined: boolean): void {
     this._transactionExecutor.pipelineBegin = pipelined


### PR DESCRIPTION
The lack of return types breaks the esdocs.