### PR TITLE
Fix flaky tests on TransactionExecutor suite

### DIFF
--- a/packages/core/src/internal/transaction-executor.ts
+++ b/packages/core/src/internal/transaction-executor.ts
@@ -32,7 +32,7 @@ type TransactionWork<T, Tx = Transaction> = (tx: Tx) => T | Promise<T>
 type Resolve<T> = (value: T | PromiseLike<T>) => void
 type Reject = (value: any) => void
 type Timeout = ReturnType<typeof setTimeout>
-type SetTimeout = (...args: Parameters<typeof setTimeout>) => Timeout
+type SetTimeout = (callback: (...args: unknown[]) => void, ms: number | undefined, ...args: unknown[]) => Timeout
 type ClearTimeout = (timeoutId: Timeout) => void
 
 interface Dependencies {

--- a/packages/core/src/internal/transaction-executor.ts
+++ b/packages/core/src/internal/transaction-executor.ts
@@ -32,10 +32,20 @@ type TransactionWork<T, Tx = Transaction> = (tx: Tx) => T | Promise<T>
 type Resolve<T> = (value: T | PromiseLike<T>) => void
 type Reject = (value: any) => void
 type Timeout = ReturnType<typeof setTimeout>
+type SetTimeout = (...args: Parameters<typeof setTimeout>) => Timeout
+type ClearTimeout = (timeoutId: Timeout) => void
 
 interface Dependencies {
-  setTimeout: typeof setTimeout
-  clearTimeout: typeof clearTimeout
+  setTimeout: SetTimeout
+  clearTimeout: ClearTimeout
+}
+
+function setTimeoutWrapper (callback: (...args: unknown[]) => void, ms: number | undefined, ...args: unknown[]): Timeout {
+  return setTimeout(callback, ms, ...args)
+}
+
+function clearTimeoutWrapper (timeoutId: Timeout): void {
+  return clearTimeout(timeoutId)
 }
 
 export class TransactionExecutor {
@@ -44,8 +54,8 @@ export class TransactionExecutor {
   private readonly _multiplier: number
   private readonly _jitterFactor: number
   private _inFlightTimeoutIds: Timeout[]
-  private readonly _setTimeout: typeof setTimeout
-  private readonly _clearTimeout: typeof clearTimeout
+  private readonly _setTimeout: SetTimeout
+  private readonly _clearTimeout: ClearTimeout
   public pipelineBegin: boolean
 
   constructor (
@@ -54,8 +64,8 @@ export class TransactionExecutor {
     multiplier?: number,
     jitterFactor?: number,
     dependencies: Dependencies = {
-      setTimeout,
-      clearTimeout
+      setTimeout: setTimeoutWrapper,
+      clearTimeout: clearTimeoutWrapper
     }
   ) {
     this._maxRetryTimeMs = _valueOrDefault(

--- a/packages/neo4j-driver-deno/lib/core/internal/transaction-executor.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/transaction-executor.ts
@@ -32,7 +32,7 @@ type TransactionWork<T, Tx = Transaction> = (tx: Tx) => T | Promise<T>
 type Resolve<T> = (value: T | PromiseLike<T>) => void
 type Reject = (value: any) => void
 type Timeout = ReturnType<typeof setTimeout>
-type SetTimeout = (...args: Parameters<typeof setTimeout>) => Timeout
+type SetTimeout = (callback: (...args: unknown[]) => void, ms: number | undefined, ...args: unknown[]) => Timeout
 type ClearTimeout = (timeoutId: Timeout) => void
 
 interface Dependencies {
@@ -40,7 +40,7 @@ interface Dependencies {
   clearTimeout: ClearTimeout
 }
 
-function setTimeoutWrapper (callback: (...args:unknown[]) => void, ms: number | undefined, ...args: unknown[]): Timeout {
+function setTimeoutWrapper (callback: (...args: unknown[]) => void, ms: number | undefined, ...args: unknown[]): Timeout {
   return setTimeout(callback, ms, ...args)
 }
 

--- a/packages/neo4j-driver/test/internal/timers-util.js
+++ b/packages/neo4j-driver/test/internal/timers-util.js
@@ -18,7 +18,7 @@
 */
 
 /**
- * This is a liter mock which only creates mocked functions to work
+ * This is a lighter mock which only creates mocked functions to work
  * as timeouts.
  */
 class TimeoutsMock {
@@ -30,11 +30,12 @@ class TimeoutsMock {
   }
 
   setTimeout (code, delay) {
+    let timeoutId = this._timeoutIdCounter++
+    this.invocationDelays.push(delay)
     if (!this._paused) {
       code()
-      this.invocationDelays.push(delay)
     }
-    return this._timeoutIdCounter++
+    return timeoutId
   }
 
   clearTimeout (id) {

--- a/packages/neo4j-driver/test/internal/timers-util.js
+++ b/packages/neo4j-driver/test/internal/timers-util.js
@@ -15,47 +15,37 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+*/
+
+/**
+ * This is a liter mock which only creates mocked functions to work
+ * as timeouts.
  */
-class SetTimeoutMock {
+class TimeoutsMock {
   constructor () {
-    this._clearState()
+    this.clearState()
+    // bind it to be used as standalone functions
+    this.setTimeout = this.setTimeout.bind(this)
+    this.clearTimeout = this.clearTimeout.bind(this)
   }
 
-  install () {
-    this._originalSetTimeout = global.setTimeout
-    global.setTimeout = (code, delay) => {
-      if (!this._paused) {
-        code()
-        this.invocationDelays.push(delay)
-      }
-      return this._timeoutIdCounter++
+  setTimeout (code, delay) {
+    if (!this._paused) {
+      code()
+      this.invocationDelays.push(delay)
     }
+    return this._timeoutIdCounter++
+  }
 
-    this._originalClearTimeout = global.clearTimeout
-    global.clearTimeout = id => {
-      this.clearedTimeouts.push(id)
-    }
-
-    return this
+  clearTimeout (id) {
+    this.clearedTimeouts.push(id)
   }
 
   pause () {
     this._paused = true
   }
 
-  uninstall () {
-    global.setTimeout = this._originalSetTimeout
-    global.clearTimeout = this._originalClearTimeout
-    this._clearState()
-  }
-
-  setTimeoutOriginal (code, delay) {
-    return this._originalSetTimeout.call(null, code, delay)
-  }
-
-  _clearState () {
-    this._originalSetTimeout = null
-    this._originalClearTimeout = null
+  clearState () {
     this._paused = false
     this._timeoutIdCounter = 0
 
@@ -64,4 +54,6 @@ class SetTimeoutMock {
   }
 }
 
-export const setTimeoutMock = new SetTimeoutMock()
+export {
+  TimeoutsMock
+}

--- a/packages/neo4j-driver/test/internal/timers-util.js
+++ b/packages/neo4j-driver/test/internal/timers-util.js
@@ -30,9 +30,9 @@ class TimeoutsMock {
   }
 
   setTimeout (code, delay) {
-    let timeoutId = this._timeoutIdCounter++
+    const timeoutId = this._timeoutIdCounter++
     this.invocationDelays.push(delay)
-    if (!this._paused) {
+    if (!this._timeoutCallbacksDisabled) {
       code()
     }
     return timeoutId
@@ -42,12 +42,12 @@ class TimeoutsMock {
     this.clearedTimeouts.push(id)
   }
 
-  pause () {
-    this._paused = true
+  disableTimeoutCallbacks () {
+    this._timeoutCallbacksDisabled = true
   }
 
   clearState () {
-    this._paused = false
+    this._timeoutCallbacksDisabled = false
     this._timeoutIdCounter = 0
 
     this.invocationDelays = []

--- a/packages/neo4j-driver/test/internal/transaction-executor.test.js
+++ b/packages/neo4j-driver/test/internal/transaction-executor.test.js
@@ -477,7 +477,7 @@ function createTransactionExecutorWithFakeTimeout (...args) {
     args[4] = { ...dependencies, ...args[4] }
   } else {
     throw new TypeError(
-      `Expected  object or undefined as args[4] but got ${typeof args[4]}`)
+      `Expected object or undefined as args[4] but got ${typeof args[4]}`)
   }
 
   return {

--- a/packages/neo4j-driver/test/internal/transaction-executor.test.js
+++ b/packages/neo4j-driver/test/internal/transaction-executor.test.js
@@ -18,7 +18,7 @@
  */
 
 import { newError, error as err, internal } from 'neo4j-driver-core'
-import { setTimeoutMock } from './timers-util'
+import { TimeoutsMock } from './timers-util'
 import lolex from 'lolex'
 
 const {
@@ -89,36 +89,31 @@ describe('#unit TransactionExecutor', () => {
   }, 60000)
 
   it('should cancel in-flight timeouts when closed', async () => {
-    const fakeSetTimeout = setTimeoutMock.install()
-    try {
-      const executor = new TransactionExecutor()
-      // do not execute setTimeout callbacks
-      fakeSetTimeout.pause()
+    const { fakeSetTimeout, executor } = createTransactionExecutorWithFakeTimeout()
+    // do not execute setTimeout callbacks
+    fakeSetTimeout.pause()
 
-      executor.execute(transactionCreator([SERVICE_UNAVAILABLE]), () =>
-        Promise.resolve(42)
-      )
-      executor.execute(transactionCreator([TRANSIENT_ERROR_1]), () =>
-        Promise.resolve(4242)
-      )
-      executor.execute(transactionCreator([SESSION_EXPIRED]), () =>
-        Promise.resolve(424242)
-      )
+    executor.execute(transactionCreator([SERVICE_UNAVAILABLE]), () =>
+      Promise.resolve(42)
+    )
+    executor.execute(transactionCreator([TRANSIENT_ERROR_1]), () =>
+      Promise.resolve(4242)
+    )
+    executor.execute(transactionCreator([SESSION_EXPIRED]), () =>
+      Promise.resolve(424242)
+    )
 
-      await new Promise((resolve, reject) => {
-        fakeSetTimeout.setTimeoutOriginal(() => {
-          try {
-            executor.close()
-            expect(fakeSetTimeout.clearedTimeouts.length).toEqual(3)
-            resolve()
-          } catch (error) {
-            reject(error)
-          }
-        }, 1000)
-      })
-    } finally {
-      fakeSetTimeout.uninstall()
-    }
+    await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        try {
+          executor.close()
+          expect(fakeSetTimeout.clearedTimeouts.length).toEqual(3)
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
+      }, 1000)
+    })
   }, 60000)
 })
 
@@ -320,177 +315,176 @@ describe('#unit TransactionExecutor', () => {
     })
 
     async function testRetryWhenTransactionCreatorFails (errorCodes) {
-      const fakeSetTimeout = setTimeoutMock.install()
-      try {
-        const executor = new TransactionExecutor()
-        executor.pipelineBegin = pipelineBegin
-        const transactionCreator = throwingTransactionCreator(
-          errorCodes,
-          new FakeTransaction()
-        )
-        const usedTransactions = []
+      const { fakeSetTimeout, executor } = createTransactionExecutorWithFakeTimeout()
+      executor.pipelineBegin = pipelineBegin
+      const transactionCreator = throwingTransactionCreator(
+        errorCodes,
+        new FakeTransaction()
+      )
+      const usedTransactions = []
 
-        const result = await executor.execute(transactionCreator, tx => {
-          expect(tx).toBeDefined()
-          usedTransactions.push(tx)
-          return Promise.resolve(42)
-        })
+      const result = await executor.execute(transactionCreator, tx => {
+        expect(tx).toBeDefined()
+        usedTransactions.push(tx)
+        return Promise.resolve(42)
+      })
 
-        expect(usedTransactions.length).toEqual(1)
-        expect(result).toEqual(42)
-        verifyRetryDelays(fakeSetTimeout, errorCodes.length)
-      } finally {
-        fakeSetTimeout.uninstall()
-      }
+      expect(usedTransactions.length).toEqual(1)
+      expect(result).toEqual(42)
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length)
     }
 
     async function testRetryWhenTransactionBeginFails (errorCodes) {
-      const fakeSetTimeout = setTimeoutMock.install()
-      try {
-        const executor = new TransactionExecutor()
-        executor.pipelineBegin = pipelineBegin
-        const transactionCreator = throwingTransactionCreatorOnBegin(
-          errorCodes,
-          new FakeTransaction()
-        )
-        const usedTransactions = []
-        const beginTransactions = []
+      const { fakeSetTimeout, executor } = createTransactionExecutorWithFakeTimeout()
+      executor.pipelineBegin = pipelineBegin
+      const transactionCreator = throwingTransactionCreatorOnBegin(
+        errorCodes,
+        new FakeTransaction()
+      )
+      const usedTransactions = []
+      const beginTransactions = []
 
-        const result = await executor.execute(transactionCreator, async tx => {
-          expect(tx).toBeDefined()
-          beginTransactions.push(tx)
+      const result = await executor.execute(transactionCreator, async tx => {
+        expect(tx).toBeDefined()
+        beginTransactions.push(tx)
 
-          if (pipelineBegin) {
-            // forcing await for tx since pipeline doesn't wait for begin return
-            await tx
-          }
+        if (pipelineBegin) {
+          // forcing await for tx since pipeline doesn't wait for begin return
+          await tx
+        }
 
-          usedTransactions.push(tx)
-          return Promise.resolve(42)
-        })
+        usedTransactions.push(tx)
+        return Promise.resolve(42)
+      })
 
-        expect(beginTransactions.length).toEqual(pipelineBegin ? errorCodes.length + 1 : 1)
-        expect(usedTransactions.length).toEqual(1)
-        expect(result).toEqual(42)
-        verifyRetryDelays(fakeSetTimeout, errorCodes.length)
-      } finally {
-        fakeSetTimeout.uninstall()
-      }
+      expect(beginTransactions.length).toEqual(pipelineBegin ? errorCodes.length + 1 : 1)
+      expect(usedTransactions.length).toEqual(1)
+      expect(result).toEqual(42)
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length)
     }
 
     async function testRetryWhenTransactionWorkReturnsRejectedPromise (
       errorCodes
     ) {
-      const fakeSetTimeout = setTimeoutMock.install()
-      try {
-        const executor = new TransactionExecutor()
-        executor.pipelineBegin = pipelineBegin
-        const usedTransactions = []
-        const realWork = transactionWork(errorCodes, 42)
+      const { fakeSetTimeout, executor } = createTransactionExecutorWithFakeTimeout()
+      executor.pipelineBegin = pipelineBegin
+      const usedTransactions = []
+      const realWork = transactionWork(errorCodes, 42)
 
-        const result = await executor.execute(transactionCreator(), tx => {
-          expect(tx).toBeDefined()
-          usedTransactions.push(tx)
-          return realWork()
-        })
+      const result = await executor.execute(transactionCreator(), tx => {
+        expect(tx).toBeDefined()
+        usedTransactions.push(tx)
+        return realWork()
+      })
 
-        // work should have failed 'failures.length' times and succeeded 1 time
-        expect(usedTransactions.length).toEqual(errorCodes.length + 1)
-        expectAllTransactionsToBeClosed(usedTransactions)
-        expect(result).toEqual(42)
-        verifyRetryDelays(fakeSetTimeout, errorCodes.length)
-      } finally {
-        fakeSetTimeout.uninstall()
-      }
+      // work should have failed 'failures.length' times and succeeded 1 time
+      expect(usedTransactions.length).toEqual(errorCodes.length + 1)
+      expectAllTransactionsToBeClosed(usedTransactions)
+      expect(result).toEqual(42)
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length)
     }
 
     async function testRetryWhenTransactionCommitReturnsRejectedPromise (
       errorCodes
     ) {
-      const fakeSetTimeout = setTimeoutMock.install()
-      try {
-        const executor = new TransactionExecutor()
-        executor.pipelineBegin = pipelineBegin
-        const usedTransactions = []
-        const realWork = () => Promise.resolve(4242)
+      const { fakeSetTimeout, executor } = createTransactionExecutorWithFakeTimeout()
+      executor.pipelineBegin = pipelineBegin
+      const usedTransactions = []
+      const realWork = () => Promise.resolve(4242)
 
-        const result = await executor.execute(
-          transactionCreator(errorCodes),
-          tx => {
-            expect(tx).toBeDefined()
-            usedTransactions.push(tx)
-            return realWork()
-          }
-        )
+      const result = await executor.execute(
+        transactionCreator(errorCodes),
+        tx => {
+          expect(tx).toBeDefined()
+          usedTransactions.push(tx)
+          return realWork()
+        }
+      )
 
-        // work should have failed 'failures.length' times and succeeded 1 time
-        expect(usedTransactions.length).toEqual(errorCodes.length + 1)
-        expectAllTransactionsToBeClosed(usedTransactions)
-        expect(result).toEqual(4242)
-        verifyRetryDelays(fakeSetTimeout, errorCodes.length)
-      } finally {
-        fakeSetTimeout.uninstall()
-      }
+      // work should have failed 'failures.length' times and succeeded 1 time
+      expect(usedTransactions.length).toEqual(errorCodes.length + 1)
+      expectAllTransactionsToBeClosed(usedTransactions)
+      expect(result).toEqual(4242)
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length)
     }
 
     async function testRetryWhenTransactionWorkThrows (errorCodes) {
-      const fakeSetTimeout = setTimeoutMock.install()
-      try {
-        const executor = new TransactionExecutor()
-        executor.pipelineBegin = pipelineBegin
-        const usedTransactions = []
-        const realWork = throwingTransactionWork(errorCodes, 42)
+      const { fakeSetTimeout, executor } = createTransactionExecutorWithFakeTimeout()
+      executor.pipelineBegin = pipelineBegin
+      const usedTransactions = []
+      const realWork = throwingTransactionWork(errorCodes, 42)
 
-        const result = await executor.execute(transactionCreator(), async tx => {
-          expect(tx).toBeDefined()
-          usedTransactions.push(tx)
-          if (pipelineBegin) {
-            await tx
-          }
-          return realWork()
-        })
+      const result = await executor.execute(transactionCreator(), async tx => {
+        expect(tx).toBeDefined()
+        usedTransactions.push(tx)
+        if (pipelineBegin) {
+          await tx
+        }
+        return realWork()
+      })
 
-        // work should have failed 'failures.length' times and succeeded 1 time
-        expect(usedTransactions.length).toEqual(errorCodes.length + 1)
-        expectAllTransactionsToBeClosed(usedTransactions)
-        expect(result).toEqual(42)
-        verifyRetryDelays(fakeSetTimeout, errorCodes.length)
-      } finally {
-        fakeSetTimeout.uninstall()
-      }
+      // work should have failed 'failures.length' times and succeeded 1 time
+      expect(usedTransactions.length).toEqual(errorCodes.length + 1)
+      expectAllTransactionsToBeClosed(usedTransactions)
+      expect(result).toEqual(42)
+      verifyRetryDelays(fakeSetTimeout, errorCodes.length)
     }
 
     async function testRetryWhenTransactionWorkThrowsAndRollbackFails (
       txWorkErrorCodes,
       rollbackErrorCodes
     ) {
-      const fakeSetTimeout = setTimeoutMock.install()
-      try {
-        const executor = new TransactionExecutor()
-        executor.pipelineBegin = pipelineBegin
-        const usedTransactions = []
-        const realWork = throwingTransactionWork(txWorkErrorCodes, 424242)
+      const { fakeSetTimeout, executor } = createTransactionExecutorWithFakeTimeout()
+      executor.pipelineBegin = pipelineBegin
+      const usedTransactions = []
+      const realWork = throwingTransactionWork(txWorkErrorCodes, 424242)
 
-        const result = await executor.execute(
-          transactionCreator([], rollbackErrorCodes),
-          tx => {
-            expect(tx).toBeDefined()
-            usedTransactions.push(tx)
-            return realWork()
-          }
-        )
+      const result = await executor.execute(
+        transactionCreator([], rollbackErrorCodes),
+        tx => {
+          expect(tx).toBeDefined()
+          usedTransactions.push(tx)
+          return realWork()
+        }
+      )
 
-        // work should have failed 'failures.length' times and succeeded 1 time
-        expect(usedTransactions.length).toEqual(txWorkErrorCodes.length + 1)
-        expectAllTransactionsToBeClosed(usedTransactions)
-        expect(result).toEqual(424242)
-        verifyRetryDelays(fakeSetTimeout, txWorkErrorCodes.length)
-      } finally {
-        fakeSetTimeout.uninstall()
-      }
+      // work should have failed 'failures.length' times and succeeded 1 time
+      expect(usedTransactions.length).toEqual(txWorkErrorCodes.length + 1)
+      expectAllTransactionsToBeClosed(usedTransactions)
+      expect(result).toEqual(424242)
+      verifyRetryDelays(fakeSetTimeout, txWorkErrorCodes.length)
     }
   })
 })
+
+function createTransactionExecutorWithFakeTimeout (...args) {
+  const fakeSetTimeout = new TimeoutsMock()
+  const dependencies = {
+    setTimeout: fakeSetTimeout.setTimeout,
+    clearTimeout: fakeSetTimeout.clearTimeout
+  }
+
+  // args should have at least 5 elements for place the dependencies
+  if (args.length < 5) {
+    args.length = 5
+  }
+
+  // dependencies not set, so we should set
+  if (args[4] === undefined) {
+    args[4] = dependencies
+  // dependencies are an object, so we should join both
+  } else if (typeof args[4] === 'object') {
+    args[4] = { ...dependencies, ...args[4] }
+  } else {
+    throw new TypeError(
+      `Expected  object or undefined as args[4] but got ${typeof args[4]}`)
+  }
+
+  return {
+    executor: new TransactionExecutor(...args),
+    fakeSetTimeout
+  }
+}
 
 async function testNoRetryOnUnknownError (
   errorCodes,

--- a/packages/neo4j-driver/test/internal/transaction-executor.test.js
+++ b/packages/neo4j-driver/test/internal/transaction-executor.test.js
@@ -91,7 +91,7 @@ describe('#unit TransactionExecutor', () => {
   it('should cancel in-flight timeouts when closed', async () => {
     const { fakeSetTimeout, executor } = createTransactionExecutorWithFakeTimeout()
     // do not execute setTimeout callbacks
-    fakeSetTimeout.pause()
+    fakeSetTimeout.disableTimeoutCallbacks()
 
     executor.execute(transactionCreator([SERVICE_UNAVAILABLE]), () =>
       Promise.resolve(42)
@@ -464,16 +464,7 @@ function createTransactionExecutorWithFakeTimeout (...args) {
     clearTimeout: fakeSetTimeout.clearTimeout
   }
 
-  // args should have at least 5 elements for place the dependencies
-  if (args.length < 5) {
-    args.length = 5
-  }
-
-  // dependencies not set, so we should set
-  if (args[4] === undefined) {
-    args[4] = dependencies
-  // dependencies are an object, so we should join both
-  } else if (typeof args[4] === 'object') {
+  if (typeof args[4] === 'object' || args[4] === undefined) {
     args[4] = { ...dependencies, ...args[4] }
   } else {
     throw new TypeError(


### PR DESCRIPTION
The TransactionExecutor tests were mocking the global setTimeout and clearTimeout. This mocks were conflicting with other calls to this api in the browser tests. So, the calls to the set/clear were not being the expected in some situations.

Replace the global mock for injecting the functions resolve this issue in a less intrusive way.