### PR TITLE
Hide protocol object behind the Connection

### DIFF
--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -82,7 +82,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
    */
   _createConnection ({ auth }, address, release) {
     return this._createChannelConnection(address).then(connection => {
-      connection._release = () => {
+      connection.release = () => {
         return release(address, connection)
       }
       this._openConnections[connection.id] = connection
@@ -160,7 +160,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
         await connection.resetAndFlush()
       }
     } finally {
-      await connection._release()
+      await connection.release()
     }
     return serverInfo
   }
@@ -191,7 +191,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
       }
       throw error
     } finally {
-      await Promise.all(connectionsToRelease.map(conn => conn._release()))
+      await Promise.all(connectionsToRelease.map(conn => conn.release()))
     }
   }
 
@@ -201,7 +201,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     connection._sticky = connectionWithSameCredentials && !connection.supportsReAuth
 
     if (shouldCreateStickyConnection || connection._sticky) {
-      await connection._release()
+      await connection.release()
       throw newError('Driver is connected to a database that does not support user switch.')
     }
   }

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -156,6 +156,26 @@ export default class ChannelConnection extends Connection {
     }
   }
 
+  beginTransaction (config) {
+    return this._protocol.beginTransaction(config)
+  }
+
+  run (query, parameters, config) {
+    return this._protocol.run(query, parameters, config)
+  }
+
+  commitTransaction (config) {
+    return this._protocol.commitTransaction(config)
+  }
+
+  rollbackTransaction (config) {
+    return this._protocol.rollbackTransaction(config)
+  }
+
+  getProtocolVersion () {
+    return this._protocol.version
+  }
+
   get authToken () {
     return this._authToken
   }

--- a/packages/bolt-connection/src/connection/connection-delegate.js
+++ b/packages/bolt-connection/src/connection/connection-delegate.js
@@ -35,6 +35,26 @@ export default class DelegateConnection extends Connection {
     this._delegate = delegate
   }
 
+  beginTransaction (config) {
+    return this._delegate.beginTransaction(config)
+  }
+
+  run (query, param, config) {
+    return this._delegate.run(query, param, config)
+  }
+
+  commitTransaction (config) {
+    return this._delegate.commitTransaction(config)
+  }
+
+  rollbackTransaction (config) {
+    return this._delegate.rollbackTransaction(config)
+  }
+
+  getProtocolVersion () {
+    return this._delegate.getProtocolVersion()
+  }
+
   get id () {
     return this._delegate.id
   }
@@ -103,11 +123,11 @@ export default class DelegateConnection extends Connection {
     return this._delegate.close()
   }
 
-  _release () {
+  release () {
     if (this._originalErrorHandler) {
       this._delegate._errorHandler = this._originalErrorHandler
     }
 
-    return this._delegate._release()
+    return this._delegate.release()
   }
 }

--- a/packages/bolt-connection/src/connection/connection.js
+++ b/packages/bolt-connection/src/connection/connection.js
@@ -54,13 +54,6 @@ export default class Connection extends CoreConnection {
   }
 
   /**
-   * @returns {boolean} whether this connection is in a working condition
-   */
-  isOpen () {
-    throw new Error('not implemented')
-  }
-
-  /**
    * @returns {BoltProtocol} the underlying bolt protocol assigned to this connection
    */
   protocol () {
@@ -108,18 +101,6 @@ export default class Connection extends CoreConnection {
    * @param {boolean} flush `true` if flush should happen after the message is written to the buffer.
    */
   write (message, observer, flush) {
-    throw new Error('not implemented')
-  }
-
-  /**
-   * Send a RESET-message to the database. Message is immediately flushed to the network.
-   * @return {Promise<void>} promise resolved when SUCCESS-message response arrives, or failed when other response messages arrives.
-   */
-  resetAndFlush () {
-    throw new Error('not implemented')
-  }
-
-  hasOngoingObservableRequests () {
     throw new Error('not implemented')
   }
 

--- a/packages/bolt-connection/src/connection/connection.js
+++ b/packages/bolt-connection/src/connection/connection.js
@@ -18,12 +18,14 @@
  */
 // eslint-disable-next-line no-unused-vars
 import { ResultStreamObserver, BoltProtocol } from '../bolt'
+import { Connection as CoreConnection } from 'neo4j-driver-core'
 
-export default class Connection {
+export default class Connection extends CoreConnection {
   /**
    * @param {ConnectionErrorHandler} errorHandler the error handler
    */
   constructor (errorHandler) {
+    super()
     this._errorHandler = errorHandler
   }
 

--- a/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
@@ -289,7 +289,7 @@ describe('constructor', () => {
 
         const connection = await create({}, server0, release)
 
-        const released = connection._release()
+        const released = connection.release()
 
         expect(released).toBe(releaseResult)
         expect(release).toHaveBeenCalledWith(server0, connection)
@@ -546,7 +546,7 @@ describe('user-switching', () => {
 
         expect(error).toEqual(newError('Driver is connected to a database that does not support user switch.'))
         expect(poolAcquire).toHaveBeenCalledWith({ auth: acquireAuth }, address)
-        expect(connection._release).toHaveBeenCalled()
+        expect(connection.release).toHaveBeenCalled()
         expect(connection._sticky).toEqual(isStickyConn)
       })
     })
@@ -599,7 +599,7 @@ describe('.verifyConnectivityAndGetServerInfo()', () => {
 
       await connectionProvider.verifyConnectivityAndGetServerInfo()
 
-      expect(seenConnections[0]._release).toHaveBeenCalledTimes(1)
+      expect(seenConnections[0].release).toHaveBeenCalledTimes(1)
     })
 
     it('should resetAndFlush and then release the connection', async () => {
@@ -607,7 +607,7 @@ describe('.verifyConnectivityAndGetServerInfo()', () => {
 
       await connectionProvider.verifyConnectivityAndGetServerInfo()
 
-      expect(seenConnections[0]._release.mock.invocationCallOrder[0])
+      expect(seenConnections[0].release.mock.invocationCallOrder[0])
         .toBeGreaterThan(resetAndFlush.mock.invocationCallOrder[0])
     })
 
@@ -636,7 +636,7 @@ describe('.verifyConnectivityAndGetServerInfo()', () => {
           await connectionProvider.verifyConnectivityAndGetServerInfo()
         } catch (e) {
         } finally {
-          expect(seenConnections[0]._release).toHaveBeenCalledTimes(1)
+          expect(seenConnections[0].release).toHaveBeenCalledTimes(1)
         }
       })
 
@@ -692,7 +692,7 @@ describe('.verifyConnectivityAndGetServerInfo()', () => {
         }
         connection.resetAndFlush = resetAndFlush
         if (releaseMock) {
-          connection._release = releaseMock
+          connection.release = releaseMock
         }
         seenConnections.push(connection)
         return connection
@@ -782,7 +782,7 @@ class FakeConnection extends Connection {
     super(null)
 
     this._address = address
-    this._release = jest.fn(() => release(address, this))
+    this.release = jest.fn(() => release(address, this))
     this._server = server
     this._authToken = auth
     this._closed = false

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -2834,8 +2834,8 @@ describe.each([
 
         expect(connections.length).toBe(1)
         expect(connections[0].resetAndFlush).toHaveBeenCalled()
-        expect(connections[0]._release).toHaveBeenCalled()
-        expect(connections[0]._release.mock.invocationCallOrder[0])
+        expect(connections[0].release).toHaveBeenCalled()
+        expect(connections[0].release.mock.invocationCallOrder[0])
           .toBeGreaterThan(connections[0].resetAndFlush.mock.invocationCallOrder[0])
       })
 
@@ -2856,7 +2856,7 @@ describe.each([
 
         // extra checks
         expect(connections.length).toBe(1)
-        expect(connections[0]._release).toHaveBeenCalled()
+        expect(connections[0].release).toHaveBeenCalled()
       })
 
       it('should not acquire, resetAndFlush and release connections for sever with the other access mode', async () => {
@@ -2900,7 +2900,7 @@ describe.each([
 
               expect(connections.length).toBe(1)
               expect(connections[0].resetAndFlush).toHaveBeenCalled()
-              expect(connections[0]._release).toHaveBeenCalled()
+              expect(connections[0].release).toHaveBeenCalled()
             }
           }
         })
@@ -2956,8 +2956,8 @@ describe.each([
 
               expect(connections.length).toBe(1)
               expect(connections[0].resetAndFlush).toHaveBeenCalled()
-              expect(connections[0]._release).toHaveBeenCalled()
-              expect(connections[0]._release.mock.invocationCallOrder[0])
+              expect(connections[0].release).toHaveBeenCalled()
+              expect(connections[0].release.mock.invocationCallOrder[0])
                 .toBeGreaterThan(connections[0].resetAndFlush.mock.invocationCallOrder[0])
             }
           }
@@ -2979,7 +2979,7 @@ describe.each([
 
               expect(connections.length).toBe(1)
               expect(connections[0].resetAndFlush).toHaveBeenCalled()
-              expect(connections[0]._release).toHaveBeenCalled()
+              expect(connections[0].release).toHaveBeenCalled()
             }
           }
         })
@@ -3054,7 +3054,7 @@ describe.each([
               connection.resetAndFlush = resetAndFlush
             }
             if (releaseMock) {
-              connection._release = releaseMock
+              connection.release = releaseMock
             }
             seenConnectionsPerAddress.get(address).push(connection)
             return connection
@@ -3193,7 +3193,7 @@ describe.each([
 
           const connection = await create({}, server0, release)
 
-          const released = connection._release()
+          const released = connection.release()
 
           expect(released).toBe(releaseResult)
           expect(release).toHaveBeenCalledWith(server0, connection)
@@ -3460,7 +3460,7 @@ describe.each([
 
           expect(error).toEqual(newError('Driver is connected to a database that does not support user switch.'))
           expect(poolAcquire).toHaveBeenCalledWith({ auth }, server3)
-          expect(connection._release).toHaveBeenCalled()
+          expect(connection.release).toHaveBeenCalled()
           expect(connection._sticky).toEqual(isStickyConn)
         })
 
@@ -3502,7 +3502,7 @@ describe.each([
 
           expect(error).toEqual(newError('Driver is connected to a database that does not support user switch.'))
           expect(poolAcquire).toHaveBeenCalledWith({ auth }, server1)
-          expect(connection._release).toHaveBeenCalled()
+          expect(connection.release).toHaveBeenCalled()
           expect(connection._sticky).toEqual(isStickyConn)
         })
 
@@ -3546,7 +3546,7 @@ describe.each([
 
           expect(error).toEqual(newError('Driver is connected to a database that does not support user switch.'))
           expect(poolAcquire).toHaveBeenCalledWith({ auth }, server0)
-          expect(connection._release).toHaveBeenCalled()
+          expect(connection.release).toHaveBeenCalled()
           expect(connection._sticky).toEqual(isStickyConn)
         })
 
@@ -3575,7 +3575,7 @@ describe.each([
 
           expect(error).toEqual(newError('Driver is connected to a database that does not support user switch.'))
           expect(poolAcquire).toHaveBeenCalledWith({ auth }, server0)
-          expect(connection._release).toHaveBeenCalled()
+          expect(connection.release).toHaveBeenCalled()
           expect(connection._sticky).toEqual(isStickyConn)
         })
       })
@@ -3903,7 +3903,7 @@ class FakeConnection extends Connection {
     this._version = version
     this._protocolVersion = protocolVersion
     this.release = release
-    this._release = jest.fn(() => release(address, this))
+    this.release = jest.fn(() => release(address, this))
     this.resetAndFlush = jest.fn(() => Promise.resolve())
     this._server = server
     this._authToken = authToken

--- a/packages/bolt-connection/test/connection/connection-delegate.test.js
+++ b/packages/bolt-connection/test/connection/connection-delegate.test.js
@@ -16,20 +16,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import DelegateConnection from '../../../bolt-connection/lib/connection/connection-delegate'
-import Connection from '../../../bolt-connection/lib/connection/connection'
-import { BoltProtocol } from '../../../bolt-connection/lib/bolt'
-import ConnectionErrorHandler from '../../../bolt-connection/lib/connection/connection-error-handler'
-import { internal } from 'neo4j-driver-core'
+
+import Connection from '../../src/connection/connection'
+import DelegateConnection from '../../src/connection/connection-delegate'
+import { Connection as CoreConnection, internal } from 'neo4j-driver-core'
+import ConnectionErrorHandler from '../../src/connection/connection-error-handler'
+import { BoltProtocol } from '../../src/bolt'
+import utils from '../test-utils'
 
 const {
   serverAddress: { ServerAddress: BoltAddress }
 } = internal
 
-describe('#unit DelegateConnection', () => {
+describe('DelegateConnection', () => {
+  beforeEach(() => {
+    expect.extend(utils.matchers)
+  })
+
+  const NON_DELEGATE_METHODS = [
+    'constructor',
+    // the delegate replaces the error handler of the original connection
+    // and not delegate the requests to the previous connection until released
+    'handleAndTransformError'
+  ]
+
   it('should delegate get id', () => {
     const delegate = new Connection(null)
-    const spy = spyOnProperty(delegate, 'id', 'get').and.returnValue(5)
+    const spy = jest.spyOn(delegate, 'id', 'get').mockReturnValue(5)
     const connection = new DelegateConnection(delegate, null)
 
     expect(connection.id).toBe(5)
@@ -38,7 +51,7 @@ describe('#unit DelegateConnection', () => {
 
   it('should delegate get databaseId', () => {
     const delegate = new Connection(null)
-    const spy = spyOnProperty(delegate, 'databaseId', 'get').and.returnValue(
+    const spy = jest.spyOn(delegate, 'databaseId', 'get').mockReturnValue(
       '123-456'
     )
     const connection = new DelegateConnection(delegate, null)
@@ -49,7 +62,7 @@ describe('#unit DelegateConnection', () => {
 
   it('should delegate set databaseId', () => {
     const delegate = new Connection(null)
-    const spy = spyOnProperty(delegate, 'databaseId', 'set')
+    const spy = jest.spyOn(delegate, 'databaseId', 'set').mockImplementation(() => {})
     const connection = new DelegateConnection(delegate, null)
 
     connection.databaseId = '345-678'
@@ -63,7 +76,7 @@ describe('#unit DelegateConnection', () => {
       version: 'Neo4j/3.5.6'
     }
     const delegate = new Connection(null)
-    const spy = spyOnProperty(delegate, 'server', 'get').and.returnValue(server)
+    const spy = jest.spyOn(delegate, 'server', 'get').mockReturnValue(server)
     const connection = new DelegateConnection(delegate, null)
 
     expect(connection.server).toBe(server)
@@ -73,7 +86,7 @@ describe('#unit DelegateConnection', () => {
   it('should delegate get address', () => {
     const address = BoltAddress.fromUrl('bolt://127.0.0.1:8080')
     const delegate = new Connection(null)
-    const spy = spyOnProperty(delegate, 'address', 'get').and.returnValue(
+    const spy = jest.spyOn(delegate, 'address', 'get').mockReturnValue(
       address
     )
     const connection = new DelegateConnection(delegate, null)
@@ -85,7 +98,7 @@ describe('#unit DelegateConnection', () => {
   it('should delegate get version', () => {
     const version = 'Neo4j/3.5.6'
     const delegate = new Connection(null)
-    const spy = spyOnProperty(delegate, 'version', 'get').and.returnValue(
+    const spy = jest.spyOn(delegate, 'version', 'get').mockReturnValue(
       version
     )
     const connection = new DelegateConnection(delegate, null)
@@ -96,7 +109,7 @@ describe('#unit DelegateConnection', () => {
 
   it('should delegate set version', () => {
     const delegate = new Connection(null)
-    const spy = spyOnProperty(delegate, 'version', 'set')
+    const spy = jest.spyOn(delegate, 'version', 'set').mockImplementation(() => {})
     const connection = new DelegateConnection(delegate, null)
 
     connection.version = 'Neo4j/3.4.9'
@@ -106,7 +119,7 @@ describe('#unit DelegateConnection', () => {
 
   it('should delegate isOpen', () => {
     const delegate = new Connection(null)
-    const spy = spyOn(delegate, 'isOpen').and.returnValue(true)
+    const spy = jest.spyOn(delegate, 'isOpen').mockReturnValue(true)
     const connection = new DelegateConnection(delegate, null)
 
     expect(connection.isOpen()).toBeTruthy()
@@ -116,7 +129,7 @@ describe('#unit DelegateConnection', () => {
   it('should delegate protocol', () => {
     const protocol = new BoltProtocol()
     const delegate = new Connection(null)
-    const spy = spyOn(delegate, 'protocol').and.returnValue(protocol)
+    const spy = jest.spyOn(delegate, 'protocol').mockReturnValue(protocol)
     const connection = new DelegateConnection(delegate, null)
 
     expect(connection.protocol()).toBe(protocol)
@@ -125,7 +138,7 @@ describe('#unit DelegateConnection', () => {
 
   it('should delegate connect', () => {
     const delegate = new Connection(null)
-    const spy = spyOn(delegate, 'connect')
+    const spy = jest.spyOn(delegate, 'connect').mockImplementation(() => {})
     const connection = new DelegateConnection(delegate, null)
 
     connection.connect('neo4j/js-driver', 'mydriver/0.0.0 some system info', {})
@@ -135,7 +148,7 @@ describe('#unit DelegateConnection', () => {
 
   it('should delegate write', () => {
     const delegate = new Connection(null)
-    const spy = spyOn(delegate, 'write')
+    const spy = jest.spyOn(delegate, 'write').mockImplementation(() => {})
     const connection = new DelegateConnection(delegate, null)
 
     connection.write({}, null, true)
@@ -145,7 +158,7 @@ describe('#unit DelegateConnection', () => {
 
   it('should delegate resetAndFlush', () => {
     const delegate = new Connection(null)
-    const spy = spyOn(delegate, 'resetAndFlush')
+    const spy = jest.spyOn(delegate, 'resetAndFlush').mockImplementation(() => {})
     const connection = new DelegateConnection(delegate, null)
 
     connection.resetAndFlush()
@@ -155,7 +168,7 @@ describe('#unit DelegateConnection', () => {
 
   it('should delegate close', async () => {
     const delegate = new Connection(null)
-    const spy = spyOn(delegate, 'close').and.returnValue(Promise.resolve())
+    const spy = jest.spyOn(delegate, 'close').mockReturnValue(Promise.resolve())
     const connection = new DelegateConnection(delegate, null)
 
     await connection.close()
@@ -163,13 +176,13 @@ describe('#unit DelegateConnection', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  it('should delegate _release', () => {
+  it('should delegate release', () => {
     const delegate = new Connection(null)
-    delegate._release = () => {}
-    const spy = spyOn(delegate, '_release')
+    delegate.release = () => {}
+    const spy = jest.spyOn(delegate, 'release').mockImplementation(() => {})
     const connection = new DelegateConnection(delegate, null)
 
-    connection._release()
+    connection.release()
 
     expect(spy).toHaveBeenCalledTimes(1)
   })
@@ -177,7 +190,7 @@ describe('#unit DelegateConnection', () => {
   it('should override errorHandler on create and restore on release', () => {
     const errorHandlerOriginal = new ConnectionErrorHandler('code1')
     const delegate = new Connection(errorHandlerOriginal)
-    delegate._release = () => {}
+    delegate.release = () => {}
 
     expect(delegate._errorHandler).toBe(errorHandlerOriginal)
 
@@ -186,8 +199,31 @@ describe('#unit DelegateConnection', () => {
 
     expect(delegate._errorHandler).toBe(errorHandlerNew)
 
-    connection._release()
+    connection.release()
 
     expect(delegate._errorHandler).toBe(errorHandlerOriginal)
   })
+
+  it.each(getDelegatedMethods())('should delegate %s calls with exact args number and return value', (delegatedMethod) => {
+    const result = 'the result'
+    const method = CoreConnection.prototype[delegatedMethod] || Connection.prototype[delegatedMethod]
+    const argsNumber = method.length // function.length returns the number of arguments expected by the function
+    const args = [...Array(argsNumber).keys()]
+
+    const connection = {
+      [delegatedMethod]: jest.fn(() => result)
+    }
+
+    const delegatedConnection = new DelegateConnection(connection)
+
+    expect(delegatedConnection[delegatedMethod](...args)).toBe(result)
+    expect(connection[delegatedMethod]).toHaveBeenCalledTimes(1)
+    expect(connection[delegatedMethod]).toBeCalledWith(...args)
+    expect(connection[delegatedMethod]).toBeCalledWithThis(connection)
+  })
+
+  function getDelegatedMethods () {
+    const allMethods = new Set([...Object.keys(Connection.prototype), ...Object.keys(CoreConnection.prototype)])
+    return [...allMethods].filter(method => !NON_DELEGATE_METHODS.includes(method))
+  }
 })

--- a/packages/bolt-connection/test/fake-connection.js
+++ b/packages/bolt-connection/test/fake-connection.js
@@ -95,7 +95,7 @@ export default class FakeConnection extends Connection {
     return Promise.resolve()
   }
 
-  _release () {
+  release () {
     this.releaseInvoked++
     return Promise.resolve()
   }

--- a/packages/bolt-connection/test/test-utils.js
+++ b/packages/bolt-connection/test/test-utils.js
@@ -53,6 +53,7 @@ const matchers = {
     } else {
       result.message = `Expected '${actual}' to be an element of '[${expected}]', but it wasn't`
     }
+    return result
   },
   toBeMessage: function (actual, expected) {
     if (expected === undefined) {
@@ -84,6 +85,12 @@ const matchers = {
       result.message = () => `Expected message '[${failures}]', but it didn't`
     }
     return result
+  },
+  toBeCalledWithThis: function (theMockedFunction, thisArg) {
+    return {
+      pass: theMockedFunction.mock.contexts.filter(ctx => ctx === thisArg).length > 0,
+      message: () => `Expected to be called with this equals to '${json.stringify(thisArg)}', but it wasn't.`
+    }
   }
 }
 

--- a/packages/core/src/connection-provider.ts
+++ b/packages/core/src/connection-provider.ts
@@ -24,6 +24,18 @@ import { ServerInfo } from './result-summary'
 import { AuthToken } from './types'
 
 /**
+ * Interface define a releasable resource shape
+ *
+ * @private
+ * @interface
+ */
+class Releasable {
+  release (): Promise<void> {
+    throw new Error('Not implemented')
+  }
+}
+
+/**
  * Interface define a common way to acquire a connection
  *
  * @private
@@ -53,7 +65,7 @@ class ConnectionProvider {
     impersonatedUser?: string
     onDatabaseNameResolved?: (databaseName?: string) => void
     auth?: AuthToken
-  }): Promise<Connection> {
+  }): Promise<Connection & Releasable> {
     throw Error('Not implemented')
   }
 
@@ -150,3 +162,6 @@ class ConnectionProvider {
 }
 
 export default ConnectionProvider
+export {
+  Releasable
+}

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -18,121 +18,91 @@
  */
 /* eslint-disable @typescript-eslint/promise-function-async */
 
-import { ServerAddress } from './internal/server-address'
+import { Bookmarks } from './internal/bookmarks'
+import { AccessMode } from './internal/constants'
+import { ResultStreamObserver } from './internal/observers'
+import { TxConfig } from './internal/tx-config'
+import NotificationFilter from './notification-filter'
+
+interface HasBeforeErrorAndAfterComplete {
+  beforeError?: (error: Error) => void
+  afterComplete?: (metadata: unknown) => void
+}
+
+interface BeginTransactionConfig extends HasBeforeErrorAndAfterComplete {
+  bookmarks: Bookmarks
+  txConfig: TxConfig
+  mode?: AccessMode
+  database?: string
+  impersonatedUser?: string
+  notificationFilter?: NotificationFilter
+}
+
+interface CommitTransactionConfig extends HasBeforeErrorAndAfterComplete {
+
+}
+
+interface RollbackConnectionConfig extends HasBeforeErrorAndAfterComplete {
+
+}
+
+interface RunQueryConfig extends BeginTransactionConfig {
+  fetchSize: number
+  highRecordWatermark: number
+  lowRecordWatermark: number
+  reactive: boolean
+}
 
 /**
- * Interface which defines the raw connection with the database
+ * Interface which defines a connection for the core driver object.
+ *
+ *
+ * This connection exposes only methods used by the code module.
+ * Methods with connection implementation details can be defined and used
+ * by the implementation layer.
+ *
  * @private
+ * @interface
  */
 class Connection {
-  get id (): string {
-    return ''
+  beginTransaction (config: BeginTransactionConfig): ResultStreamObserver {
+    throw new Error('Not implemented')
   }
 
-  get databaseId (): string {
-    return ''
+  run (query: string, parameters?: Record<string, unknown>, config?: RunQueryConfig): ResultStreamObserver {
+    throw new Error('Not implemented')
   }
 
-  get server (): any {
-    return {}
+  commitTransaction (config: CommitTransactionConfig): ResultStreamObserver {
+    throw new Error('Not implemented')
   }
 
-  /**
-   * @property {object} authToken The auth registered in the connection
-   */
-  get authToken (): any {
-    return {}
+  rollbackTransaction (config: RollbackConnectionConfig): ResultStreamObserver {
+    throw new Error('Not implemented')
   }
 
-  /**
-   * @property {ServerAddress} the server address this connection is opened against
-   */
-  get address (): ServerAddress | undefined {
-    return undefined
-  }
-
-  /**
-   * @property {ServerVersion} the version of the server this connection is connected to
-   */
-  get version (): any {
-    return undefined
-  }
-
-  /**
-   * @property {boolean} supportsReAuth Indicates the connection supports re-auth
-   */
-  get supportsReAuth (): boolean {
-    return false
-  }
-
-  /**
-   * @returns {boolean} whether this connection is in a working condition
-   */
-  isOpen (): boolean {
-    return false
-  }
-
-  /**
-   * @todo be removed and internalize the methods
-   * @returns {any} the underlying bolt protocol assigned to this connection
-   */
-  protocol (): any {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Connect to the target address, negotiate Bolt protocol and send initialization message.
-   * @param {string} userAgent the user agent for this driver.
-   * @param {string} boltAgent the bolt agent for this driver.
-   * @param {Object} authToken the object containing auth information.
-   * @param {Object} waitReAuth whether to connect method should wait until re-Authorised
-   * @return {Promise<Connection>} promise resolved with the current connection if connection is successful. Rejected promise otherwise.
-   */
-  connect (userAgent: string, boltAgent: string, authToken: any, waitReAuth: false): Promise<Connection> {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Write a message to the network channel.
-   * @param {RequestMessage} message the message to write.
-   * @param {ResultStreamObserver} observer the response observer.
-   * @param {boolean} flush `true` if flush should happen after the message is written to the buffer.
-   */
-  write (message: any, observer: any, flush: boolean): void {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Send a RESET-message to the database. Message is immediately flushed to the network.
-   * @return {Promise<void>} promise resolved when SUCCESS-message response arrives, or failed when other response messages arrives.
-   */
   resetAndFlush (): Promise<void> {
-    throw Error('Not implemented')
+    throw new Error('Not implemented')
   }
 
-  /**
-   * Checks if there is an ongoing request being handled
-   * @return {boolean} `true` if there is an ongoing request being handled
-   */
+  isOpen (): boolean {
+    throw new Error('Not implemented')
+  }
+
+  getProtocolVersion (): number {
+    throw new Error('Not implemented')
+  }
+
   hasOngoingObservableRequests (): boolean {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Call close on the channel.
-   * @returns {Promise<void>} - A promise that will be resolved when the connection is closed.
-   *
-   */
-  close (): Promise<void> {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Called to release the connection
-   */
-  _release (): Promise<void> {
-    return Promise.resolve()
+    throw new Error('Not implemented')
   }
 }
 
 export default Connection
+
+export type {
+  BeginTransactionConfig,
+  CommitTransactionConfig,
+  RollbackConnectionConfig,
+  RunQueryConfig
+}

--- a/packages/core/src/internal/connection-holder.ts
+++ b/packages/core/src/internal/connection-holder.ts
@@ -25,6 +25,7 @@ import { ACCESS_MODE_WRITE, AccessMode } from './constants'
 import { Bookmarks } from './bookmarks'
 import ConnectionProvider, { Releasable } from '../connection-provider'
 import { AuthToken } from '../types'
+import { Logger } from './logger'
 
 /**
  * @private
@@ -87,6 +88,7 @@ class ConnectionHolder implements ConnectionHolderInterface {
   private readonly _getConnectionAcquistionBookmarks: () => Promise<Bookmarks>
   private readonly _onDatabaseNameResolved?: (databaseName?: string) => void
   private readonly _auth?: AuthToken
+  private readonly _log: Logger
   private _closed: boolean
 
   /**
@@ -102,14 +104,15 @@ class ConnectionHolder implements ConnectionHolderInterface {
    * @property {AuthToken} params.auth - the target auth for the to-be-acquired connection
    */
   constructor ({
-    mode = ACCESS_MODE_WRITE,
+    mode,
     database = '',
     bookmarks,
     connectionProvider,
     impersonatedUser,
     onDatabaseNameResolved,
     getConnectionAcquistionBookmarks,
-    auth
+    auth,
+    log
   }: {
     mode?: AccessMode
     database?: string
@@ -119,8 +122,9 @@ class ConnectionHolder implements ConnectionHolderInterface {
     onDatabaseNameResolved?: (databaseName?: string) => void
     getConnectionAcquistionBookmarks?: () => Promise<Bookmarks>
     auth?: AuthToken
-  } = {}) {
-    this._mode = mode
+    log: Logger
+  }) {
+    this._mode = mode ?? ACCESS_MODE_WRITE
     this._closed = false
     this._database = database != null ? assertString(database, 'database') : ''
     this._bookmarks = bookmarks ?? Bookmarks.empty()
@@ -130,6 +134,8 @@ class ConnectionHolder implements ConnectionHolderInterface {
     this._connectionPromise = Promise.resolve(null)
     this._onDatabaseNameResolved = onDatabaseNameResolved
     this._auth = auth
+    this._log = log
+    this._logError = this._logError.bind(this)
     this._getConnectionAcquistionBookmarks = getConnectionAcquistionBookmarks ?? (() => Promise.resolve(Bookmarks.empty()))
   }
 
@@ -209,6 +215,10 @@ class ConnectionHolder implements ConnectionHolderInterface {
     return this._releaseConnection(hasTx)
   }
 
+  log (): Logger {
+    return this._log
+  }
+
   /**
    * Return the current pooled connection instance to the connection pool.
    * We don't pool Session instances, to avoid users using the Session after they've called close.
@@ -231,9 +241,18 @@ class ConnectionHolder implements ConnectionHolderInterface {
           return Promise.resolve(null)
         }
       })
-      .catch(ignoreError)
+      .catch(this._logError)
 
     return this._connectionPromise
+  }
+
+  _logError (error: Error): null {
+    if (this._log.isWarnEnabled()) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      this._log.warn(`ConnectionHolder got an error while releasing the connection. Error ${error}. Stacktrace: ${error.stack}`)
+    }
+
+    return null
   }
 }
 
@@ -245,7 +264,7 @@ export default class ReadOnlyConnectionHolder extends ConnectionHolder {
   private readonly _connectionHolder: ConnectionHolder
 
   /**
-   * Contructor
+   * Constructor
    * @param {ConnectionHolder} connectionHolder the connection holder which will treat the requests
    */
   constructor (connectionHolder: ConnectionHolder) {
@@ -255,7 +274,8 @@ export default class ReadOnlyConnectionHolder extends ConnectionHolder {
       bookmarks: connectionHolder.bookmarks(),
       // @ts-expect-error
       getConnectionAcquistionBookmarks: connectionHolder._getConnectionAcquistionBookmarks,
-      connectionProvider: connectionHolder.connectionProvider()
+      connectionProvider: connectionHolder.connectionProvider(),
+      log: connectionHolder.log()
     })
     this._connectionHolder = connectionHolder
   }
@@ -298,6 +318,13 @@ export default class ReadOnlyConnectionHolder extends ConnectionHolder {
 }
 
 class EmptyConnectionHolder extends ConnectionHolder {
+  constructor () {
+    super({
+      // Empty logger
+      log: Logger.create({})
+    })
+  }
+
   mode (): undefined {
     return undefined
   }

--- a/packages/core/src/internal/constants.ts
+++ b/packages/core/src/internal/constants.ts
@@ -38,6 +38,8 @@ const BOLT_PROTOCOL_V5_1: number = 5.1
 const BOLT_PROTOCOL_V5_2: number = 5.2
 const BOLT_PROTOCOL_V5_3: number = 5.3
 
+export type AccessMode = typeof ACCESS_MODE_READ | typeof ACCESS_MODE_WRITE
+
 export {
   FETCH_ALL,
   ACCESS_MODE_READ,

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -513,7 +513,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
           connectionHolder
             .releaseConnection()
             .then(() =>
-              connection?.protocol()?.version
+              connection?.getProtocolVersion()
             ),
         // onRejected:
         _ => undefined

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -75,7 +75,7 @@ class Session {
   private readonly _results: Result[]
   private readonly _bookmarkManager?: BookmarkManager
   private readonly _notificationFilter?: NotificationFilter
-  private readonly _log?: Logger
+  private readonly _log: Logger
   /**
    * @constructor
    * @protected
@@ -132,7 +132,8 @@ class Session {
       connectionProvider,
       impersonatedUser,
       onDatabaseNameResolved: this._onDatabaseNameResolved,
-      getConnectionAcquistionBookmarks: this._getConnectionAcquistionBookmarks
+      getConnectionAcquistionBookmarks: this._getConnectionAcquistionBookmarks,
+      log
     })
     this._writeConnectionHolder = new ConnectionHolder({
       mode: ACCESS_MODE_WRITE,
@@ -142,7 +143,8 @@ class Session {
       connectionProvider,
       impersonatedUser,
       onDatabaseNameResolved: this._onDatabaseNameResolved,
-      getConnectionAcquistionBookmarks: this._getConnectionAcquistionBookmarks
+      getConnectionAcquistionBookmarks: this._getConnectionAcquistionBookmarks,
+      log
     })
     this._open = true
     this._hasTx = false

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -187,7 +187,7 @@ class Session {
     const result = this._run(validatedQuery, params, async connection => {
       const bookmarks = await this._bookmarks()
       this._assertSessionIsOpen()
-      return (connection as Connection).protocol().run(validatedQuery, params, {
+      return (connection as Connection).run(validatedQuery, params, {
         bookmarks,
         txConfig: autoCommitTxConfig,
         mode: this._mode,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -19,7 +19,7 @@
 
 /* eslint-disable @typescript-eslint/promise-function-async */
 
-import { FailedObserver } from './internal/observers'
+import { FailedObserver, ResultStreamObserver } from './internal/observers'
 import { validateQueryAndParameters } from './internal/util'
 import { FETCH_ALL, ACCESS_MODE_READ, ACCESS_MODE_WRITE } from './internal/constants'
 import { newError } from './error'
@@ -40,7 +40,7 @@ import { RecordShape } from './record'
 import NotificationFilter from './notification-filter'
 import { Logger } from './internal/logger'
 
-type ConnectionConsumer = (connection: Connection | null) => any | undefined | Promise<any> | Promise<undefined>
+type ConnectionConsumer<T> = (connection: Connection) => Promise<T> | T
 type TransactionWork<T> = (tx: Transaction) => Promise<T> | T
 type ManagedTransactionWork<T> = (tx: ManagedTransaction) => Promise<T> | T
 
@@ -189,7 +189,7 @@ class Session {
     const result = this._run(validatedQuery, params, async connection => {
       const bookmarks = await this._bookmarks()
       this._assertSessionIsOpen()
-      return (connection as Connection).run(validatedQuery, params, {
+      return connection.run(validatedQuery, params, {
         bookmarks,
         txConfig: autoCommitTxConfig,
         mode: this._mode,
@@ -207,57 +207,61 @@ class Session {
     return result
   }
 
-  _run (
+  _run <T extends ResultStreamObserver = ResultStreamObserver>(
     query: Query,
     parameters: any,
-    customRunner: ConnectionConsumer
+    customRunner: ConnectionConsumer<T>
   ): Result {
-    const connectionHolder = this._connectionHolderWithMode(this._mode)
-
-    let observerPromise
-    if (!this._open) {
-      observerPromise = Promise.resolve(
-        new FailedObserver({
-          error: newError('Cannot run query in a closed session.')
-        })
-      )
-    } else if (!this._hasTx && connectionHolder.initializeConnection()) {
-      observerPromise = connectionHolder
-        .getConnection()
-        .then(connection => customRunner(connection))
-        .catch(error => Promise.resolve(new FailedObserver({ error })))
-    } else {
-      observerPromise = Promise.resolve(
-        new FailedObserver({
-          error: newError(
-            'Queries cannot be run directly on a ' +
-              'session with an open transaction; either run from within the ' +
-              'transaction or use a different session.'
-          )
-        })
-      )
-    }
+    const { connectionHolder, resultPromise } = this._acquireAndConsumeConnection(customRunner)
+    const observerPromise = resultPromise.catch(error => Promise.resolve(new FailedObserver({ error })))
     const watermarks = { high: this._highRecordWatermark, low: this._lowRecordWatermark }
     return new Result(observerPromise, query, parameters, connectionHolder, watermarks)
   }
 
-  _acquireConnection (connectionConsumer: ConnectionConsumer): Promise<Connection> {
-    let promise
+  /**
+   * This method is used by Rediscovery on the neo4j-driver-bolt-protocol package.
+   *
+   * @private
+   * @param {function()} connectionConsumer The method which will use the connection
+   * @returns {Promise<T>} A connection promise
+   */
+  _acquireConnection<T> (connectionConsumer: ConnectionConsumer<T>): Promise<T> {
+    const { connectionHolder, resultPromise } = this._acquireAndConsumeConnection(connectionConsumer)
+
+    return resultPromise.then(async (result: T) => {
+      await connectionHolder.releaseConnection()
+      return result
+    })
+  }
+
+  /**
+   * Acquires a {@link Connection}, consume it and return a promise of the result along with
+   * the {@link ConnectionHolder} used in the process.
+   *
+   * @private
+   * @param connectionConsumer
+   * @returns {object} The connection holder and connection promise.
+   */
+
+  private _acquireAndConsumeConnection<T>(connectionConsumer: ConnectionConsumer<T>): {
+    connectionHolder: ConnectionHolder
+    resultPromise: Promise<T>
+  } {
+    let resultPromise: Promise<T>
     const connectionHolder = this._connectionHolderWithMode(this._mode)
     if (!this._open) {
-      promise = Promise.reject(
+      resultPromise = Promise.reject(
         newError('Cannot run query in a closed session.')
       )
     } else if (!this._hasTx && connectionHolder.initializeConnection()) {
-      promise = connectionHolder
+      resultPromise = connectionHolder
         .getConnection()
-        .then(connection => connectionConsumer(connection))
-        .then(async result => {
-          await connectionHolder.releaseConnection()
-          return result
-        })
+        // Connection won't be null at this point since the initialize method
+        // return
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        .then(connection => connectionConsumer(connection!))
     } else {
-      promise = Promise.reject(
+      resultPromise = Promise.reject(
         newError(
           'Queries cannot be run directly on a ' +
             'session with an open transaction; either run from within the ' +
@@ -266,7 +270,7 @@ class Session {
       )
     }
 
-    return promise
+    return { connectionHolder, resultPromise }
   }
 
   /**

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -139,7 +139,7 @@ class Transaction {
         this._onConnection()
         if (connection != null) {
           this._bookmarks = await getBookmarks()
-          return connection.protocol().beginTransaction({
+          return connection.beginTransaction({
             bookmarks: this._bookmarks,
             txConfig,
             mode: this._connectionHolder.mode(),
@@ -150,13 +150,13 @@ class Transaction {
               if (events != null) {
                 events.onError(error)
               }
-              return this._onError(error)
+              this._onError(error).catch(() => {})
             },
             afterComplete: (metadata: any) => {
               if (events != null) {
                 events.onComplete(metadata)
               }
-              return this._onComplete(metadata)
+              this._onComplete(metadata)
             }
           })
         } else {
@@ -364,7 +364,7 @@ const _states = {
       }
     },
     run: (
-      query: Query,
+      query: string,
       parameters: any,
       {
         connectionHolder,
@@ -388,7 +388,7 @@ const _states = {
           .then(conn => {
             onConnection()
             if (conn != null) {
-              return conn.protocol().run(query, parameters, {
+              return conn.run(query, parameters, {
                 bookmarks: Bookmarks.empty(),
                 txConfig: TxConfig.empty(),
                 beforeError: onError,
@@ -643,12 +643,12 @@ function finishTransaction (
         return Promise.all(pendingResults.map(result => result.summary())).then(results => {
           if (connection != null) {
             if (commit) {
-              return connection.protocol().commitTransaction({
+              return connection.commitTransaction({
                 beforeError: onError,
                 afterComplete: onComplete
               })
             } else {
-              return connection.protocol().rollbackTransaction({
+              return connection.rollbackTransaction({
                 beforeError: onError,
                 afterComplete: onComplete
               })

--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -467,9 +467,9 @@ describe('Result', () => {
           'should enrich summary with the protocol version onCompleted',
           async version => {
             const connectionMock = new FakeConnection()
-            // converting to accept number as undefined
+            // converting to accept undefined as number
             // this test is considering the situation where protocol version
-            // is undefined, which it should not happen in normal driver
+            // is undefined, which should not happen during normal driver
             // operation.
             connectionMock.protocolVersion = version as unknown as number
 
@@ -681,9 +681,9 @@ describe('Result', () => {
           'should enrich summary with the protocol version on completed',
           async version => {
             const connectionMock = new FakeConnection()
-            // converting to accept number as undefined
+            // converting to accept undefined as number
             // this test is considering the situation where protocol version
-            // is undefined, which it should not happen in normal driver
+            // is undefined, which should not happen during normal driver
             // operation.
             connectionMock.protocolVersion = version as unknown as number
 

--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -27,6 +27,7 @@ import {
 import ResultStreamObserverMock from './utils/result-stream-observer.mock'
 import Result from '../src/result'
 import FakeConnection from './utils/connection.fake'
+import { Logger } from '../src/internal/logger'
 
 interface AB {
   a: number
@@ -154,7 +155,7 @@ describe('Result', () => {
       ])('when query=%s and parameters=%s', (query, params, expected) => {
         let connectionHolderMock: connectionHolder.ConnectionHolder
         beforeEach(() => {
-          connectionHolderMock = new connectionHolder.ConnectionHolder({})
+          connectionHolderMock = new connectionHolder.ConnectionHolder({ log: Logger.create({}) })
           result = new Result(
             Promise.resolve(streamObserverMock),
             query,
@@ -406,7 +407,7 @@ describe('Result', () => {
         let connectionHolderMock: connectionHolder.ConnectionHolder
 
         beforeEach(() => {
-          connectionHolderMock = new connectionHolder.ConnectionHolder({})
+          connectionHolderMock = new connectionHolder.ConnectionHolder({ log: Logger.create({}) })
           result = new Result(
             Promise.resolve(streamObserverMock),
             'query',
@@ -632,7 +633,7 @@ describe('Result', () => {
         let connectionHolderMock: connectionHolder.ConnectionHolder
 
         beforeEach(() => {
-          connectionHolderMock = new connectionHolder.ConnectionHolder({})
+          connectionHolderMock = new connectionHolder.ConnectionHolder({ log: Logger.create({}) })
           result = new Result(
             Promise.resolve(streamObserverMock),
             'query',

--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -466,14 +466,15 @@ describe('Result', () => {
         it.each([123, undefined])(
           'should enrich summary with the protocol version onCompleted',
           async version => {
-            const connectionMock = {
-              protocol: () => {
-                return { version }
-              }
-            }
+            const connectionMock = new FakeConnection()
+            // converting to accept number as undefined
+            // this test is considering the situation where protocol version
+            // is undefined, which it should not happen in normal driver
+            // operation.
+            connectionMock.protocolVersion = version as unknown as number
 
             connectionHolderMock.getConnection = async (): Promise<Connection> => {
-              return asConnection(connectionMock)
+              return connectionMock
             }
             const metadata = {
               resultConsumedAfter: 20,
@@ -679,14 +680,15 @@ describe('Result', () => {
         it.each([123, undefined])(
           'should enrich summary with the protocol version on completed',
           async version => {
-            const connectionMock = {
-              protocol: () => {
-                return { version }
-              }
-            }
+            const connectionMock = new FakeConnection()
+            // converting to accept number as undefined
+            // this test is considering the situation where protocol version
+            // is undefined, which it should not happen in normal driver
+            // operation.
+            connectionMock.protocolVersion = version as unknown as number
 
             connectionHolderMock.getConnection = async (): Promise<Connection> => {
-              return await Promise.resolve(asConnection(connectionMock))
+              return await Promise.resolve(connectionMock)
             }
             const metadata = {
               resultConsumedAfter: 20,
@@ -1718,8 +1720,4 @@ function simulateStream (
     return true
   }
   */
-}
-
-function asConnection (value: any): Connection {
-  return value
 }

--- a/packages/core/test/transaction.test.ts
+++ b/packages/core/test/transaction.test.ts
@@ -21,6 +21,7 @@ import { ConnectionProvider, newError, NotificationFilter, Transaction, Transact
 import { BeginTransactionConfig } from '../src/connection'
 import { Bookmarks } from '../src/internal/bookmarks'
 import { ConnectionHolder } from '../src/internal/connection-holder'
+import { Logger } from '../src/internal/logger'
 import { TxConfig } from '../src/internal/tx-config'
 import FakeConnection from './utils/connection.fake'
 import { validNotificationFilters } from './utils/notification-filters.fixtures'
@@ -511,7 +512,7 @@ function newTransactionPromise ({
   }
   connectionProvider.close = async () => await Promise.resolve()
 
-  const connectionHolder = new ConnectionHolder({ connectionProvider })
+  const connectionHolder = new ConnectionHolder({ connectionProvider, log: Logger.create({}) })
   connectionHolder.initializeConnection()
 
   const transaction = new TransactionPromise({
@@ -547,7 +548,7 @@ function newRegularTransaction ({
   connectionProvider.acquireConnection = async () => await Promise.resolve(connection)
   connectionProvider.close = async () => await Promise.resolve()
 
-  const connectionHolder = new ConnectionHolder({ connectionProvider })
+  const connectionHolder = new ConnectionHolder({ connectionProvider, log: Logger.create({}) })
   connectionHolder.initializeConnection()
 
   const transaction = new Transaction({

--- a/packages/core/test/transaction.test.ts
+++ b/packages/core/test/transaction.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { ConnectionProvider, newError, NotificationFilter, Transaction, TransactionPromise } from '../src'
+import { BeginTransactionConfig } from '../src/connection'
 import { Bookmarks } from '../src/internal/bookmarks'
 import { ConnectionHolder } from '../src/internal/connection-holder'
 import { TxConfig } from '../src/internal/tx-config'
@@ -137,15 +138,12 @@ testTx('TransactionPromise', newTransactionPromise, () => {
 
         function setupTx (): [TransactionPromise] {
           const connection = newFakeConnection()
-          const protocol = connection.protocol()
+          const originalBegin = connection.beginTransaction.bind(connection)
 
-          connection.protocol = () => {
-            return {
-              ...protocol,
-              beginTransaction: (params: { afterComplete: (meta: any) => void }) => {
-                ctx(() => params.afterComplete({}))
-              }
-            }
+          connection.beginTransaction = (config: BeginTransactionConfig) => {
+            const stream = originalBegin(config)
+            ctx(() => config.afterComplete?.call(null, {}))
+            return stream
           }
 
           const tx = newTransactionPromise({
@@ -251,16 +249,14 @@ testTx('TransactionPromise', newTransactionPromise, () => {
 
         function setupTx (): [TransactionPromise, Error] {
           const connection = newFakeConnection()
-          const protocol = connection.protocol()
           const expectedError = newError('begin error')
 
-          connection.protocol = () => {
-            return {
-              ...protocol,
-              beginTransaction: (params: { beforeError: (error: Error) => void }) => {
-                ctx(() => params.beforeError(expectedError))
-              }
-            }
+          const originalBegin = connection.beginTransaction.bind(connection)
+
+          connection.beginTransaction = (config: BeginTransactionConfig) => {
+            const stream = originalBegin(config)
+            ctx(() => config.beforeError?.call(null, expectedError))
+            return stream
           }
 
           const tx = newTransactionPromise({

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
@@ -82,7 +82,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
    */
   _createConnection ({ auth }, address, release) {
     return this._createChannelConnection(address).then(connection => {
-      connection._release = () => {
+      connection.release = () => {
         return release(address, connection)
       }
       this._openConnections[connection.id] = connection
@@ -160,7 +160,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
         await connection.resetAndFlush()
       }
     } finally {
-      await connection._release()
+      await connection.release()
     }
     return serverInfo
   }
@@ -191,7 +191,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
       }
       throw error
     } finally {
-      await Promise.all(connectionsToRelease.map(conn => conn._release()))
+      await Promise.all(connectionsToRelease.map(conn => conn.release()))
     }
   }
 
@@ -201,7 +201,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     connection._sticky = connectionWithSameCredentials && !connection.supportsReAuth
 
     if (shouldCreateStickyConnection || connection._sticky) {
-      await connection._release()
+      await connection.release()
       throw newError('Driver is connected to a database that does not support user switch.')
     }
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
@@ -156,6 +156,26 @@ export default class ChannelConnection extends Connection {
     }
   }
 
+  beginTransaction (config) {
+    return this._protocol.beginTransaction(config)
+  }
+
+  run (query, parameters, config) {
+    return this._protocol.run(query, parameters, config)
+  }
+
+  commitTransaction (config) {
+    return this._protocol.commitTransaction(config)
+  }
+
+  rollbackTransaction (config) {
+    return this._protocol.rollbackTransaction(config)
+  }
+
+  getProtocolVersion () {
+    return this._protocol.version
+  }
+
   get authToken () {
     return this._authToken
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-delegate.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-delegate.js
@@ -35,6 +35,26 @@ export default class DelegateConnection extends Connection {
     this._delegate = delegate
   }
 
+  beginTransaction (config) {
+    return this._delegate.beginTransaction(config)
+  }
+
+  run (query, param, config) {
+    return this._delegate.run(query, param, config)
+  }
+
+  commitTransaction (config) {
+    return this._delegate.commitTransaction(config)
+  }
+
+  rollbackTransaction (config) {
+    return this._delegate.rollbackTransaction(config)
+  }
+
+  getProtocolVersion () {
+    return this._delegate.getProtocolVersion()
+  }
+
   get id () {
     return this._delegate.id
   }
@@ -103,11 +123,11 @@ export default class DelegateConnection extends Connection {
     return this._delegate.close()
   }
 
-  _release () {
+  release () {
     if (this._originalErrorHandler) {
       this._delegate._errorHandler = this._originalErrorHandler
     }
 
-    return this._delegate._release()
+    return this._delegate.release()
   }
 }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection.js
@@ -54,13 +54,6 @@ export default class Connection extends CoreConnection {
   }
 
   /**
-   * @returns {boolean} whether this connection is in a working condition
-   */
-  isOpen () {
-    throw new Error('not implemented')
-  }
-
-  /**
    * @returns {BoltProtocol} the underlying bolt protocol assigned to this connection
    */
   protocol () {
@@ -108,18 +101,6 @@ export default class Connection extends CoreConnection {
    * @param {boolean} flush `true` if flush should happen after the message is written to the buffer.
    */
   write (message, observer, flush) {
-    throw new Error('not implemented')
-  }
-
-  /**
-   * Send a RESET-message to the database. Message is immediately flushed to the network.
-   * @return {Promise<void>} promise resolved when SUCCESS-message response arrives, or failed when other response messages arrives.
-   */
-  resetAndFlush () {
-    throw new Error('not implemented')
-  }
-
-  hasOngoingObservableRequests () {
     throw new Error('not implemented')
   }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection.js
@@ -18,12 +18,14 @@
  */
 // eslint-disable-next-line no-unused-vars
 import { ResultStreamObserver, BoltProtocol } from '../bolt/index.js'
+import { Connection as CoreConnection } from '../../core/index.ts'
 
-export default class Connection {
+export default class Connection extends CoreConnection {
   /**
    * @param {ConnectionErrorHandler} errorHandler the error handler
    */
   constructor (errorHandler) {
+    super()
     this._errorHandler = errorHandler
   }
 

--- a/packages/neo4j-driver-deno/lib/core/connection-provider.ts
+++ b/packages/neo4j-driver-deno/lib/core/connection-provider.ts
@@ -24,6 +24,18 @@ import { ServerInfo } from './result-summary.ts'
 import { AuthToken } from './types.ts'
 
 /**
+ * Interface define a releasable resource shape
+ * 
+ * @private
+ * @interface
+ */
+class Releasable {
+  release(): Promise<void> {
+    throw new Error('Not implemented')
+  }
+}
+
+/**
  * Interface define a common way to acquire a connection
  *
  * @private
@@ -53,7 +65,7 @@ class ConnectionProvider {
     impersonatedUser?: string
     onDatabaseNameResolved?: (databaseName?: string) => void
     auth?: AuthToken
-  }): Promise<Connection> {
+  }): Promise<Connection & Releasable> {
     throw Error('Not implemented')
   }
 
@@ -150,3 +162,6 @@ class ConnectionProvider {
 }
 
 export default ConnectionProvider
+export {
+  Releasable
+}

--- a/packages/neo4j-driver-deno/lib/core/connection-provider.ts
+++ b/packages/neo4j-driver-deno/lib/core/connection-provider.ts
@@ -25,12 +25,12 @@ import { AuthToken } from './types.ts'
 
 /**
  * Interface define a releasable resource shape
- * 
+ *
  * @private
  * @interface
  */
 class Releasable {
-  release(): Promise<void> {
+  release (): Promise<void> {
     throw new Error('Not implemented')
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/connection.ts
+++ b/packages/neo4j-driver-deno/lib/core/connection.ts
@@ -18,121 +18,94 @@
  */
 /* eslint-disable @typescript-eslint/promise-function-async */
 
-import { ServerAddress } from './internal/server-address.ts'
+import { Bookmarks } from './internal/bookmarks.ts'
+import { AccessMode } from './internal/constants.ts'
+import { ResultStreamObserver } from './internal/observers.ts'
+import { TxConfig } from './internal/tx-config.ts'
+import NotificationFilter from './notification-filter.ts'
+
+
+interface HasBeforeErrorAndAfterComplete {
+  beforeError?: (error: Error) => void 
+  afterComplete?: (metadata: unknown) => void
+}
+
+interface BeginTransactionConfig extends HasBeforeErrorAndAfterComplete {
+  bookmarks: Bookmarks,
+  txConfig: TxConfig,
+  mode?: AccessMode
+  database?: string
+  impersonatedUser?: string 
+  notificationFilter?: NotificationFilter
+}
+
+interface CommitTransactionConfig extends HasBeforeErrorAndAfterComplete {
+
+}
+
+interface RollbackConnectionConfig extends HasBeforeErrorAndAfterComplete {
+
+}
+
+interface RunQueryConfig extends BeginTransactionConfig {
+  fetchSize: number
+  highRecordWatermark: number
+  lowRecordWatermark: number
+  reactive: boolean
+}
+
 
 /**
- * Interface which defines the raw connection with the database
+ * Interface which defines a connection for the core driver object.
+ * 
+ * 
+ * This connection exposes only methods used by the code module. 
+ * Methods with connection implementation details can be defined and used
+ * by the implementation layer.
+ * 
  * @private
+ * @interface
  */
 class Connection {
-  get id (): string {
-    return ''
+  beginTransaction(config: BeginTransactionConfig): ResultStreamObserver {
+    throw new Error('Not implemented')
   }
 
-  get databaseId (): string {
-    return ''
+  run(query: string, parameters?: Record<string, unknown>, config?: RunQueryConfig): ResultStreamObserver {
+    throw new Error('Not implemented')
   }
 
-  get server (): any {
-    return {}
+  commitTransaction(config: CommitTransactionConfig): ResultStreamObserver {
+    throw new Error('Not implemented')
   }
 
-  /**
-   * @property {object} authToken The auth registered in the connection
-   */
-  get authToken (): any {
-    return {}
+  rollbackTransaction(config: RollbackConnectionConfig): ResultStreamObserver {
+    throw new Error('Not implemented')
   }
 
-  /**
-   * @property {ServerAddress} the server address this connection is opened against
-   */
-  get address (): ServerAddress | undefined {
-    return undefined
+  resetAndFlush(): Promise<void> {
+    throw new Error('Not implemented')
   }
 
-  /**
-   * @property {ServerVersion} the version of the server this connection is connected to
-   */
-  get version (): any {
-    return undefined
+  isOpen(): boolean {
+    throw new Error('Not implemented')
   }
 
-  /**
-   * @property {boolean} supportsReAuth Indicates the connection supports re-auth
-   */
-  get supportsReAuth (): boolean {
-    return false
+  getProtocolVersion(): number {
+    throw new Error('Not implemented')
+  }
+  
+  hasOngoingObservableRequests(): boolean {
+    throw new Error('Not implemented')
   }
 
-  /**
-   * @returns {boolean} whether this connection is in a working condition
-   */
-  isOpen (): boolean {
-    return false
-  }
-
-  /**
-   * @todo be removed and internalize the methods
-   * @returns {any} the underlying bolt protocol assigned to this connection
-   */
-  protocol (): any {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Connect to the target address, negotiate Bolt protocol and send initialization message.
-   * @param {string} userAgent the user agent for this driver.
-   * @param {string} boltAgent the bolt agent for this driver.
-   * @param {Object} authToken the object containing auth information.
-   * @param {Object} waitReAuth whether to connect method should wait until re-Authorised
-   * @return {Promise<Connection>} promise resolved with the current connection if connection is successful. Rejected promise otherwise.
-   */
-  connect (userAgent: string, boltAgent: string, authToken: any, waitReAuth: false): Promise<Connection> {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Write a message to the network channel.
-   * @param {RequestMessage} message the message to write.
-   * @param {ResultStreamObserver} observer the response observer.
-   * @param {boolean} flush `true` if flush should happen after the message is written to the buffer.
-   */
-  write (message: any, observer: any, flush: boolean): void {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Send a RESET-message to the database. Message is immediately flushed to the network.
-   * @return {Promise<void>} promise resolved when SUCCESS-message response arrives, or failed when other response messages arrives.
-   */
-  resetAndFlush (): Promise<void> {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Checks if there is an ongoing request being handled
-   * @return {boolean} `true` if there is an ongoing request being handled
-   */
-  hasOngoingObservableRequests (): boolean {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Call close on the channel.
-   * @returns {Promise<void>} - A promise that will be resolved when the connection is closed.
-   *
-   */
-  close (): Promise<void> {
-    throw Error('Not implemented')
-  }
-
-  /**
-   * Called to release the connection
-   */
-  _release (): Promise<void> {
-    return Promise.resolve()
-  }
 }
 
 export default Connection
+
+export type {
+  BeginTransactionConfig,
+  CommitTransactionConfig,
+  RollbackConnectionConfig,
+  RunQueryConfig
+}

--- a/packages/neo4j-driver-deno/lib/core/connection.ts
+++ b/packages/neo4j-driver-deno/lib/core/connection.ts
@@ -24,18 +24,17 @@ import { ResultStreamObserver } from './internal/observers.ts'
 import { TxConfig } from './internal/tx-config.ts'
 import NotificationFilter from './notification-filter.ts'
 
-
 interface HasBeforeErrorAndAfterComplete {
-  beforeError?: (error: Error) => void 
+  beforeError?: (error: Error) => void
   afterComplete?: (metadata: unknown) => void
 }
 
 interface BeginTransactionConfig extends HasBeforeErrorAndAfterComplete {
-  bookmarks: Bookmarks,
-  txConfig: TxConfig,
+  bookmarks: Bookmarks
+  txConfig: TxConfig
   mode?: AccessMode
   database?: string
-  impersonatedUser?: string 
+  impersonatedUser?: string
   notificationFilter?: NotificationFilter
 }
 
@@ -54,51 +53,49 @@ interface RunQueryConfig extends BeginTransactionConfig {
   reactive: boolean
 }
 
-
 /**
  * Interface which defines a connection for the core driver object.
- * 
- * 
- * This connection exposes only methods used by the code module. 
+ *
+ *
+ * This connection exposes only methods used by the code module.
  * Methods with connection implementation details can be defined and used
  * by the implementation layer.
- * 
+ *
  * @private
  * @interface
  */
 class Connection {
-  beginTransaction(config: BeginTransactionConfig): ResultStreamObserver {
+  beginTransaction (config: BeginTransactionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
-  run(query: string, parameters?: Record<string, unknown>, config?: RunQueryConfig): ResultStreamObserver {
+  run (query: string, parameters?: Record<string, unknown>, config?: RunQueryConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
-  commitTransaction(config: CommitTransactionConfig): ResultStreamObserver {
+  commitTransaction (config: CommitTransactionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
-  rollbackTransaction(config: RollbackConnectionConfig): ResultStreamObserver {
+  rollbackTransaction (config: RollbackConnectionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
-  resetAndFlush(): Promise<void> {
+  resetAndFlush (): Promise<void> {
     throw new Error('Not implemented')
   }
 
-  isOpen(): boolean {
+  isOpen (): boolean {
     throw new Error('Not implemented')
   }
 
-  getProtocolVersion(): number {
-    throw new Error('Not implemented')
-  }
-  
-  hasOngoingObservableRequests(): boolean {
+  getProtocolVersion (): number {
     throw new Error('Not implemented')
   }
 
+  hasOngoingObservableRequests (): boolean {
+    throw new Error('Not implemented')
+  }
 }
 
 export default Connection

--- a/packages/neo4j-driver-deno/lib/core/internal/connection-holder.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/connection-holder.ts
@@ -21,9 +21,9 @@
 import { newError } from '../error.ts'
 import { assertString } from './util.ts'
 import Connection from '../connection.ts'
-import { ACCESS_MODE_WRITE } from './constants.ts'
+import { ACCESS_MODE_WRITE, AccessMode } from './constants.ts'
 import { Bookmarks } from './bookmarks.ts'
-import ConnectionProvider from '../connection-provider.ts'
+import ConnectionProvider, { Releasable } from '../connection-provider.ts'
 import { AuthToken } from '../types.ts'
 
 /**
@@ -77,12 +77,12 @@ interface ConnectionHolderInterface {
  * @private
  */
 class ConnectionHolder implements ConnectionHolderInterface {
-  private readonly _mode: string
+  private readonly _mode: AccessMode
   private _database?: string
   private readonly _bookmarks: Bookmarks
   private readonly _connectionProvider?: ConnectionProvider
   private _referenceCount: number
-  private _connectionPromise: Promise<Connection | null>
+  private _connectionPromise: Promise<Connection & Releasable | null>
   private readonly _impersonatedUser?: string
   private readonly _getConnectionAcquistionBookmarks: () => Promise<Bookmarks>
   private readonly _onDatabaseNameResolved?: (databaseName?: string) => void
@@ -111,7 +111,7 @@ class ConnectionHolder implements ConnectionHolderInterface {
     getConnectionAcquistionBookmarks,
     auth
   }: {
-    mode?: string
+    mode?: AccessMode
     database?: string
     bookmarks?: Bookmarks
     connectionProvider?: ConnectionProvider
@@ -133,7 +133,7 @@ class ConnectionHolder implements ConnectionHolderInterface {
     this._getConnectionAcquistionBookmarks = getConnectionAcquistionBookmarks ?? (() => Promise.resolve(Bookmarks.empty()))
   }
 
-  mode (): string | undefined {
+  mode (): AccessMode | undefined {
     return this._mode
   }
 
@@ -168,7 +168,7 @@ class ConnectionHolder implements ConnectionHolderInterface {
     return true
   }
 
-  private async _createConnectionPromise (connectionProvider: ConnectionProvider): Promise<Connection | null> {
+  private async _createConnectionPromise (connectionProvider: ConnectionProvider): Promise<Connection & Releasable | null> {
     return await connectionProvider.acquireConnection({
       accessMode: this._mode,
       database: this._database,
@@ -218,15 +218,15 @@ class ConnectionHolder implements ConnectionHolderInterface {
    */
   private _releaseConnection (hasTx?: boolean): Promise<Connection | null> {
     this._connectionPromise = this._connectionPromise
-      .then((connection?: Connection | null) => {
+      .then((connection?: Connection & Releasable | null) => {
         if (connection != null) {
           if (connection.isOpen() && (connection.hasOngoingObservableRequests() || hasTx === true)) {
             return connection
               .resetAndFlush()
               .catch(ignoreError)
-              .then(() => connection._release().then(() => null))
+              .then(() => connection.release().then(() => null))
           }
-          return connection._release().then(() => null)
+          return connection.release().then(() => null)
         } else {
           return Promise.resolve(null)
         }

--- a/packages/neo4j-driver-deno/lib/core/internal/constants.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/constants.ts
@@ -38,6 +38,8 @@ const BOLT_PROTOCOL_V5_1: number = 5.1
 const BOLT_PROTOCOL_V5_2: number = 5.2
 const BOLT_PROTOCOL_V5_3: number = 5.3
 
+export type AccessMode = typeof ACCESS_MODE_READ | typeof ACCESS_MODE_WRITE
+
 export {
   FETCH_ALL,
   ACCESS_MODE_READ,

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -513,7 +513,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
           connectionHolder
             .releaseConnection()
             .then(() =>
-              connection?.protocol()?.version
+              connection?.getProtocolVersion()
             ),
         // onRejected:
         _ => undefined

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -75,7 +75,7 @@ class Session {
   private readonly _results: Result[]
   private readonly _bookmarkManager?: BookmarkManager
   private readonly _notificationFilter?: NotificationFilter
-  private readonly _log?: Logger
+  private readonly _log: Logger
   /**
    * @constructor
    * @protected
@@ -132,7 +132,8 @@ class Session {
       connectionProvider,
       impersonatedUser,
       onDatabaseNameResolved: this._onDatabaseNameResolved,
-      getConnectionAcquistionBookmarks: this._getConnectionAcquistionBookmarks
+      getConnectionAcquistionBookmarks: this._getConnectionAcquistionBookmarks,
+      log
     })
     this._writeConnectionHolder = new ConnectionHolder({
       mode: ACCESS_MODE_WRITE,
@@ -142,7 +143,8 @@ class Session {
       connectionProvider,
       impersonatedUser,
       onDatabaseNameResolved: this._onDatabaseNameResolved,
-      getConnectionAcquistionBookmarks: this._getConnectionAcquistionBookmarks
+      getConnectionAcquistionBookmarks: this._getConnectionAcquistionBookmarks,
+      log
     })
     this._open = true
     this._hasTx = false

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -19,7 +19,7 @@
 
 /* eslint-disable @typescript-eslint/promise-function-async */
 
-import { FailedObserver } from './internal/observers.ts'
+import { FailedObserver, ResultStreamObserver } from './internal/observers.ts'
 import { validateQueryAndParameters } from './internal/util.ts'
 import { FETCH_ALL, ACCESS_MODE_READ, ACCESS_MODE_WRITE } from './internal/constants.ts'
 import { newError } from './error.ts'
@@ -40,7 +40,7 @@ import { RecordShape } from './record.ts'
 import NotificationFilter from './notification-filter.ts'
 import { Logger } from './internal/logger.ts'
 
-type ConnectionConsumer = (connection: Connection | null) => any | undefined | Promise<any> | Promise<undefined>
+type ConnectionConsumer<T> = (connection: Connection) => Promise<T> | T
 type TransactionWork<T> = (tx: Transaction) => Promise<T> | T
 type ManagedTransactionWork<T> = (tx: ManagedTransaction) => Promise<T> | T
 
@@ -189,7 +189,7 @@ class Session {
     const result = this._run(validatedQuery, params, async connection => {
       const bookmarks = await this._bookmarks()
       this._assertSessionIsOpen()
-      return (connection as Connection).run(validatedQuery, params, {
+      return connection.run(validatedQuery, params, {
         bookmarks,
         txConfig: autoCommitTxConfig,
         mode: this._mode,
@@ -207,57 +207,62 @@ class Session {
     return result
   }
 
-  _run (
+  _run <T extends ResultStreamObserver = ResultStreamObserver>(
     query: Query,
     parameters: any,
-    customRunner: ConnectionConsumer
+    customRunner: ConnectionConsumer<T>
   ): Result {
-    const connectionHolder = this._connectionHolderWithMode(this._mode)
-
-    let observerPromise
-    if (!this._open) {
-      observerPromise = Promise.resolve(
-        new FailedObserver({
-          error: newError('Cannot run query in a closed session.')
-        })
-      )
-    } else if (!this._hasTx && connectionHolder.initializeConnection()) {
-      observerPromise = connectionHolder
-        .getConnection()
-        .then(connection => customRunner(connection))
-        .catch(error => Promise.resolve(new FailedObserver({ error })))
-    } else {
-      observerPromise = Promise.resolve(
-        new FailedObserver({
-          error: newError(
-            'Queries cannot be run directly on a ' +
-              'session with an open transaction; either run from within the ' +
-              'transaction or use a different session.'
-          )
-        })
-      )
-    }
+    const { connectionHolder, resultPromise } = this._acquireAndConsumeConnection(customRunner)
+    const observerPromise  = resultPromise.catch(error => Promise.resolve(new FailedObserver({ error })))
     const watermarks = { high: this._highRecordWatermark, low: this._lowRecordWatermark }
     return new Result(observerPromise, query, parameters, connectionHolder, watermarks)
   }
 
-  _acquireConnection (connectionConsumer: ConnectionConsumer): Promise<Connection> {
-    let promise
+  /**
+   * This method is used by Rediscovery on the neo4j-driver-bolt-protocol package.
+   * 
+   * @private
+   * @param {function()} connectionConsumer The method which will use the connection
+   * @returns {Promise<T>} A connection promise
+   */
+  _acquireConnection<T> (connectionConsumer: ConnectionConsumer<T>): Promise<T> {
+    const { connectionHolder, resultPromise } = this._acquireAndConsumeConnection(connectionConsumer)
+
+    return resultPromise.then(async (result: T) => {
+      await connectionHolder.releaseConnection()
+      return result
+    })
+  }
+
+  /**
+   * Acquires a {@link Connection}, consume it and return a promise of the result along with 
+   * the {@link ConnectionHolder} used in the process.
+   *  
+   * @private
+   * @param connectionConsumer 
+   * @returns {object} The connection holder and connection promise.
+   */
+
+  private _acquireAndConsumeConnection<T>(connectionConsumer: ConnectionConsumer<T>): { 
+    connectionHolder: ConnectionHolder, 
+    resultPromise: Promise<T> 
+  } {
+
+    let resultPromise: Promise<T>
     const connectionHolder = this._connectionHolderWithMode(this._mode)
     if (!this._open) {
-      promise = Promise.reject(
+      resultPromise = Promise.reject(
         newError('Cannot run query in a closed session.')
       )
     } else if (!this._hasTx && connectionHolder.initializeConnection()) {
-      promise = connectionHolder
+      resultPromise = connectionHolder
         .getConnection()
-        .then(connection => connectionConsumer(connection))
-        .then(async result => {
-          await connectionHolder.releaseConnection()
-          return result
-        })
+        // Connection won't be null at this point since the initialize method
+        // return 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        .then(connection => connectionConsumer(connection!))
     } else {
-      promise = Promise.reject(
+      resultPromise = Promise.reject(
         newError(
           'Queries cannot be run directly on a ' +
             'session with an open transaction; either run from within the ' +
@@ -266,7 +271,7 @@ class Session {
       )
     }
 
-    return promise
+    return { connectionHolder, resultPromise }
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -213,14 +213,14 @@ class Session {
     customRunner: ConnectionConsumer<T>
   ): Result {
     const { connectionHolder, resultPromise } = this._acquireAndConsumeConnection(customRunner)
-    const observerPromise  = resultPromise.catch(error => Promise.resolve(new FailedObserver({ error })))
+    const observerPromise = resultPromise.catch(error => Promise.resolve(new FailedObserver({ error })))
     const watermarks = { high: this._highRecordWatermark, low: this._lowRecordWatermark }
     return new Result(observerPromise, query, parameters, connectionHolder, watermarks)
   }
 
   /**
    * This method is used by Rediscovery on the neo4j-driver-bolt-protocol package.
-   * 
+   *
    * @private
    * @param {function()} connectionConsumer The method which will use the connection
    * @returns {Promise<T>} A connection promise
@@ -235,19 +235,18 @@ class Session {
   }
 
   /**
-   * Acquires a {@link Connection}, consume it and return a promise of the result along with 
+   * Acquires a {@link Connection}, consume it and return a promise of the result along with
    * the {@link ConnectionHolder} used in the process.
-   *  
+   *
    * @private
-   * @param connectionConsumer 
+   * @param connectionConsumer
    * @returns {object} The connection holder and connection promise.
    */
 
-  private _acquireAndConsumeConnection<T>(connectionConsumer: ConnectionConsumer<T>): { 
-    connectionHolder: ConnectionHolder, 
-    resultPromise: Promise<T> 
+  private _acquireAndConsumeConnection<T>(connectionConsumer: ConnectionConsumer<T>): {
+    connectionHolder: ConnectionHolder
+    resultPromise: Promise<T>
   } {
-
     let resultPromise: Promise<T>
     const connectionHolder = this._connectionHolderWithMode(this._mode)
     if (!this._open) {
@@ -258,7 +257,7 @@ class Session {
       resultPromise = connectionHolder
         .getConnection()
         // Connection won't be null at this point since the initialize method
-        // return 
+        // return
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         .then(connection => connectionConsumer(connection!))
     } else {

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -187,7 +187,7 @@ class Session {
     const result = this._run(validatedQuery, params, async connection => {
       const bookmarks = await this._bookmarks()
       this._assertSessionIsOpen()
-      return (connection as Connection).protocol().run(validatedQuery, params, {
+      return (connection as Connection).run(validatedQuery, params, {
         bookmarks,
         txConfig: autoCommitTxConfig,
         mode: this._mode,

--- a/packages/neo4j-driver-deno/lib/core/transaction.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction.ts
@@ -139,7 +139,7 @@ class Transaction {
         this._onConnection()
         if (connection != null) {
           this._bookmarks = await getBookmarks()
-          return connection.protocol().beginTransaction({
+          return connection.beginTransaction({
             bookmarks: this._bookmarks,
             txConfig,
             mode: this._connectionHolder.mode(),
@@ -150,13 +150,13 @@ class Transaction {
               if (events != null) {
                 events.onError(error)
               }
-              return this._onError(error)
+              this._onError(error).catch(() => {})
             },
             afterComplete: (metadata: any) => {
               if (events != null) {
                 events.onComplete(metadata)
               }
-              return this._onComplete(metadata)
+              this._onComplete(metadata)
             }
           })
         } else {
@@ -364,7 +364,7 @@ const _states = {
       }
     },
     run: (
-      query: Query,
+      query: string,
       parameters: any,
       {
         connectionHolder,
@@ -388,7 +388,7 @@ const _states = {
           .then(conn => {
             onConnection()
             if (conn != null) {
-              return conn.protocol().run(query, parameters, {
+              return conn.run(query, parameters, {
                 bookmarks: Bookmarks.empty(),
                 txConfig: TxConfig.empty(),
                 beforeError: onError,
@@ -643,12 +643,12 @@ function finishTransaction (
         return Promise.all(pendingResults.map(result => result.summary())).then(results => {
           if (connection != null) {
             if (commit) {
-              return connection.protocol().commitTransaction({
+              return connection.commitTransaction({
                 beforeError: onError,
                 afterComplete: onComplete
               })
             } else {
-              return connection.protocol().rollbackTransaction({
+              return connection.rollbackTransaction({
                 beforeError: onError,
                 afterComplete: onComplete
               })

--- a/packages/neo4j-driver/test/internal/connection-holder-readonly.test.js
+++ b/packages/neo4j-driver/test/internal/connection-holder-readonly.test.js
@@ -299,7 +299,7 @@ describe('#unit ReadOnlyConnectionHolder wrapping ConnectionHolder', () => {
 })
 
 function newConnectionHolder (params, connectionHolderInit = () => {}) {
-  const connectionHolder = new ConnectionHolder(params)
+  const connectionHolder = new ConnectionHolder(params || {})
   connectionHolderInit(connectionHolder)
   return new ReadOnlyConnectionHolder(connectionHolder)
 }

--- a/packages/neo4j-driver/test/internal/connection-holder.test.js
+++ b/packages/neo4j-driver/test/internal/connection-holder.test.js
@@ -23,7 +23,8 @@ import FakeConnection from './fake-connection'
 import { internal } from 'neo4j-driver-core'
 
 const {
-  connectionHolder: { ConnectionHolder, EMPTY_CONNECTION_HOLDER }
+  connectionHolder: { ConnectionHolder, EMPTY_CONNECTION_HOLDER },
+  logger: { Logger }
 } = internal
 
 describe('#unit EmptyConnectionHolder', () => {
@@ -254,7 +255,7 @@ describe('#unit ConnectionHolder', () => {
       expect(connectionProvider.mode()).toBe(mode)
     }
 
-    verifyMode(new ConnectionHolder(), WRITE)
+    verifyMode(new ConnectionHolder({}), WRITE)
     verifyMode(new ConnectionHolder({ mode: WRITE }), WRITE)
     verifyMode(new ConnectionHolder({ mode: READ }), READ)
   })
@@ -266,7 +267,7 @@ describe('#unit ConnectionHolder', () => {
 
     const connectionProvider = newSingleConnectionProvider(new FakeConnection())
 
-    verifyDefault(new ConnectionHolder())
+    verifyDefault(new ConnectionHolder({}))
     verifyDefault(new ConnectionHolder({ mode: READ, connectionProvider }))
     verifyDefault(new ConnectionHolder({ mode: WRITE, connectionProvider }))
     verifyDefault(
@@ -318,6 +319,78 @@ describe('#unit ConnectionHolder', () => {
 
         it('should call connection.release()', () => {
           expect(connection.releaseInvoked).toBe(1)
+        })
+      })
+
+      describe('and connection is open but release fails', () => {
+        describe('when warn logging is enabled', () => {
+          let connection
+          let releaseError
+          let log
+          let warnSpy
+
+          beforeEach(async () => {
+            log = new Logger('warn', () => {})
+            warnSpy = spyOn(log, 'warn').and.callThrough()
+
+            releaseError = new Error('something wrong is not right')
+            connection = new FakeConnection()
+            const originalRelease = connection.release.bind(connection)
+            connection.release = () => {
+              originalRelease()
+              return Promise.reject(releaseError)
+            }
+            const connectionProvider = newSingleConnectionProvider(connection)
+            const connectionHolder = new ConnectionHolder({
+              mode: READ,
+              connectionProvider,
+              log
+            })
+
+            connectionHolder.initializeConnection()
+
+            await connectionHolder.releaseConnection()
+          })
+
+          it('should log error as warning()', () => {
+            expect(warnSpy).toHaveBeenCalledWith(jasmine.stringMatching(
+              `ConnectionHolder got an error while releasing the connection. Error ${releaseError}. Stacktrace:`
+            ))
+          })
+        })
+
+        describe('when warn logging is not  enabled', () => {
+          let connection
+          let releaseError
+          let log
+          let warnSpy
+
+          beforeEach(async () => {
+            log = new Logger('error', () => {})
+            warnSpy = spyOn(log, 'warn').and.callThrough()
+
+            releaseError = new Error('something wrong is not right')
+            connection = new FakeConnection()
+            const originalRelease = connection.release.bind(connection)
+            connection.release = () => {
+              originalRelease()
+              return Promise.reject(releaseError)
+            }
+            const connectionProvider = newSingleConnectionProvider(connection)
+            const connectionHolder = new ConnectionHolder({
+              mode: READ,
+              connectionProvider,
+              log
+            })
+
+            connectionHolder.initializeConnection()
+
+            await connectionHolder.releaseConnection()
+          })
+
+          it('should not log error', () => {
+            expect(warnSpy).not.toHaveBeenCalled()
+          })
         })
       })
 

--- a/packages/neo4j-driver/test/internal/connection-holder.test.js
+++ b/packages/neo4j-driver/test/internal/connection-holder.test.js
@@ -316,7 +316,7 @@ describe('#unit ConnectionHolder', () => {
           expect(connection.resetInvoked).toBe(1)
         })
 
-        it('should call connection._release()', () => {
+        it('should call connection.release()', () => {
           expect(connection.releaseInvoked).toBe(1)
         })
       })
@@ -343,7 +343,7 @@ describe('#unit ConnectionHolder', () => {
           expect(connection.resetInvoked).toBe(0)
         })
 
-        it('should call connection._release()', () => {
+        it('should call connection.release()', () => {
           expect(connection.releaseInvoked).toBe(1)
         })
       })
@@ -369,7 +369,7 @@ describe('#unit ConnectionHolder', () => {
           expect(connection.resetInvoked).toBe(0)
         })
 
-        it('should call connection._release()', () => {
+        it('should call connection.release()', () => {
           expect(connection.releaseInvoked).toBe(1)
         })
       })
@@ -398,7 +398,7 @@ describe('#unit ConnectionHolder', () => {
           expect(connection.resetInvoked).toBe(1)
         })
 
-        it('should call connection._release()', () => {
+        it('should call connection.release()', () => {
           expect(connection.releaseInvoked).toBe(1)
         })
       })
@@ -424,7 +424,7 @@ describe('#unit ConnectionHolder', () => {
           expect(connection.resetInvoked).toBe(0)
         })
 
-        it('should call connection._release()', () => {
+        it('should call connection.release()', () => {
           expect(connection.releaseInvoked).toBe(1)
         })
       })

--- a/packages/neo4j-driver/test/internal/fake-connection.js
+++ b/packages/neo4j-driver/test/internal/fake-connection.js
@@ -110,7 +110,7 @@ export default class FakeConnection extends Connection {
     return Promise.resolve()
   }
 
-  _release () {
+  release () {
     this.releaseInvoked++
     return Promise.resolve()
   }


### PR DESCRIPTION
The connection in the driver is exposing the protocol object, which is not great. Improve this part of the code can be done by make the connection object have methods to do high level requests to the server.

List of calls the core driver does using the protocol, by passing the connection:

* `version`
* `run`
* `beginTransaction`
* `commitTransaction`
* `rollbackTransaction`

Methods is present in the `Connection` interface (used by core in **bold**):

* `id`
* `database`
* `server`
* `authToken`
* `address`
* `version`
* `supportsReAuth`
* **`isOpen`**
* **`protocol`**
* `connect`
* `write`
* **`resetAndFlush`**
* **`hasOngoingObservableRequests`**
* **`_release`**

So, `isOpen`, `resetAndFlush` and `hasOngoingObservableRequests`  are the methods which will stay in the connection along with the new methods. The method `release` will move the a `Releasable` interface, which will be composed with `Connection` when returning the connection from the provider.

The `Releasable` interface is also defined to enable the `ConnectionProvider` returns a connection which can be released back to the pool.

Internally, `bolt-connection` can keep exposing the internal of the connection outside the connection in a first moment. The full encapsulation of the `protocol` should be done in the next phase of refactoring.