### PR TITLE
Fix 32+ bits length numbers serialization in ResultSummary

### DIFF
--- a/packages/core/src/result-summary.ts
+++ b/packages/core/src/result-summary.ts
@@ -644,9 +644,9 @@ class ServerInfo {
 
 function intValue (value: NumberOrInteger): number {
   if (value instanceof Integer) {
-    return value.toInt()
+    return value.toNumber()
   } else if (typeof value === 'bigint') {
-    return int(value).toInt()
+    return int(value).toNumber()
   } else {
     return value
   }

--- a/packages/core/test/result-summary.test.ts
+++ b/packages/core/test/result-summary.test.ts
@@ -17,14 +17,20 @@
  * limitations under the License.
  */
 
+import { int } from '../src'
 import {
   ServerInfo,
   Notification,
   NotificationSeverityLevel,
   NotificationCategory,
   notificationSeverityLevel,
-  notificationCategory
+  notificationCategory,
+  ProfiledPlan,
+  QueryStatistics,
+  Stats
 } from '../src/result-summary'
+
+import fc from 'fast-check'
 
 describe('ServerInfo', () => {
   it.each([
@@ -155,6 +161,203 @@ describe('notificationCategory', () => {
   it.each(getValidCategories())('should have %s as key', (category) => {
     const keys = Object.keys(notificationCategory)
     expect(keys.includes(category)).toBe(true)
+  })
+})
+
+describe('ProfilePlan', () => {
+  describe.each([
+    'dbHits',
+    'rows',
+    'pageCacheMisses',
+    'pageCacheHits',
+    'pageCacheHitRatio',
+    'time'
+  ])('.%s', (field: keyof ProfiledPlan) => {
+    it('should handle return arbitrary integer as it is', () => {
+      return fc.assert(
+        fc.property(
+          fc.integer(),
+          value => {
+            const rawProfilePlan = {
+              [field]: value
+            }
+
+            const profilePlan = new ProfiledPlan(rawProfilePlan)
+
+            return profilePlan[field] === value
+          }
+        )
+      )
+    })
+
+    it('should handle Integer with maxSafeInteger', () => {
+      return fc.assert(
+        fc.property(
+          fc.maxSafeInteger().map(value => [int(value), value]),
+          ([value, expectedValue]) => {
+            const rawProfilePlan = {
+              [field]: value
+            }
+
+            const profilePlan = new ProfiledPlan(rawProfilePlan)
+
+            return profilePlan[field] === expectedValue
+          }
+        )
+      )
+    })
+
+    it('should handle Integer with arbitrary integer', () => {
+      return fc.assert(
+        fc.property(
+          fc.integer().map(value => [int(value), value]),
+          ([value, expectedValue]) => {
+            const rawProfilePlan = {
+              [field]: value
+            }
+
+            const profilePlan = new ProfiledPlan(rawProfilePlan)
+
+            return profilePlan[field] === expectedValue
+          }
+        )
+      )
+    })
+
+    it('should handle BigInt with maxSafeInteger', () => {
+      return fc.assert(
+        fc.property(
+          fc.maxSafeInteger().map(value => [BigInt(value), value]),
+          ([value, expectedValue]) => {
+            const rawProfilePlan = {
+              [field]: value
+            }
+
+            const profilePlan = new ProfiledPlan(rawProfilePlan)
+
+            return profilePlan[field] === expectedValue
+          }
+        )
+      )
+    })
+
+    it('should handle Integer with arbitrary integer', () => {
+      return fc.assert(
+        fc.property(
+          fc.integer().map(value => [BigInt(value), value]),
+          ([value, expectedValue]) => {
+            const rawProfilePlan = {
+              [field]: value
+            }
+
+            const profilePlan = new ProfiledPlan(rawProfilePlan)
+
+            return profilePlan[field] === expectedValue
+          }
+        )
+      )
+    })
+  })
+})
+
+describe('QueryStatistics', () => {
+  describe.each([
+    'nodesCreated',
+    'nodesDeleted',
+    'relationshipsCreated',
+    'relationshipsDeleted',
+    'propertiesSet',
+    'labelsAdded',
+    'labelsRemoved',
+    'indexesAdded',
+    'indexesRemoved',
+    'constraintsAdded',
+    'constraintsRemoved'
+  ])('.%s', (field: keyof Stats) => {
+    it('should handle return arbitrary integer as it is', () => {
+      return fc.assert(
+        fc.property(
+          fc.integer(),
+          value => {
+            const stats = {
+              [field]: value
+            }
+
+            const queryStatistics = new QueryStatistics(stats)
+
+            return queryStatistics.updates()[field] === value
+          }
+        )
+      )
+    })
+
+    it('should handle Integer with maxSafeInteger', () => {
+      return fc.assert(
+        fc.property(
+          fc.maxSafeInteger().map(value => [int(value), value]),
+          ([value, expectedValue]) => {
+            const stats = {
+              [field]: value
+            }
+
+            const queryStatistics = new QueryStatistics(stats)
+
+            return queryStatistics.updates()[field] === expectedValue
+          }
+        )
+      )
+    })
+
+    it('should handle Integer with arbitrary integer', () => {
+      return fc.assert(
+        fc.property(
+          fc.integer().map(value => [int(value), value]),
+          ([value, expectedValue]) => {
+            const stats = {
+              [field]: value
+            }
+
+            const queryStatistics = new QueryStatistics(stats)
+
+            return queryStatistics.updates()[field] === expectedValue
+          }
+        )
+      )
+    })
+
+    it('should handle BigInt with maxSafeInteger', () => {
+      return fc.assert(
+        fc.property(
+          fc.maxSafeInteger().map(value => [BigInt(value), value]),
+          ([value, expectedValue]) => {
+            const stats = {
+              [field]: value
+            }
+
+            const queryStatistics = new QueryStatistics(stats)
+
+            return queryStatistics.updates()[field] === expectedValue
+          }
+        )
+      )
+    })
+
+    it('should handle Integer with arbitrary integer', () => {
+      return fc.assert(
+        fc.property(
+          fc.integer().map(value => [BigInt(value), value]),
+          ([value, expectedValue]) => {
+            const stats = {
+              [field]: value
+            }
+
+            const queryStatistics = new QueryStatistics(stats)
+
+            return queryStatistics.updates()[field] === expectedValue
+          }
+        )
+      )
+    })
   })
 })
 

--- a/packages/core/test/result-summary.test.ts
+++ b/packages/core/test/result-summary.test.ts
@@ -273,7 +273,7 @@ describe('QueryStatistics', () => {
     'indexesRemoved',
     'constraintsAdded',
     'constraintsRemoved'
-  ])('.%s', (field: keyof Stats) => {
+  ])('.updates().%s', (field: keyof Stats) => {
     it('should handle return arbitrary integer as it is', () => {
       return fc.assert(
         fc.property(

--- a/packages/core/test/result-summary.test.ts
+++ b/packages/core/test/result-summary.test.ts
@@ -262,25 +262,25 @@ describe('ProfilePlan', () => {
 
 describe('QueryStatistics', () => {
   describe.each([
-    'nodesCreated',
-    'nodesDeleted',
-    'relationshipsCreated',
-    'relationshipsDeleted',
-    'propertiesSet',
-    'labelsAdded',
-    'labelsRemoved',
-    'indexesAdded',
-    'indexesRemoved',
-    'constraintsAdded',
-    'constraintsRemoved'
-  ])('.updates().%s', (field: keyof Stats) => {
+    ['nodesCreated', 'nodes-created'],
+    ['nodesDeleted', 'nodes-deleted'],
+    ['relationshipsCreated', 'relationships-created'],
+    ['relationshipsDeleted', 'relationships-deleted'],
+    ['propertiesSet', 'properties-set'],
+    ['labelsAdded', 'labels-added'],
+    ['labelsRemoved', 'labels-removed'],
+    ['indexesAdded', 'indexes-added'],
+    ['indexesRemoved', 'indexes-removed'],
+    ['constraintsAdded', 'constraints-added'],
+    ['constraintsRemoved', 'constraints-removed']
+  ])('.updates().%s', (field: keyof Stats, rawField: string) => {
     it('should handle return arbitrary integer as it is', () => {
       return fc.assert(
         fc.property(
           fc.integer(),
           value => {
             const stats = {
-              [field]: value
+              [rawField]: value
             }
 
             const queryStatistics = new QueryStatistics(stats)
@@ -297,7 +297,7 @@ describe('QueryStatistics', () => {
           fc.maxSafeInteger().map(value => [int(value), value]),
           ([value, expectedValue]) => {
             const stats = {
-              [field]: value
+              [rawField]: value
             }
 
             const queryStatistics = new QueryStatistics(stats)
@@ -314,7 +314,7 @@ describe('QueryStatistics', () => {
           fc.integer().map(value => [int(value), value]),
           ([value, expectedValue]) => {
             const stats = {
-              [field]: value
+              [rawField]: value
             }
 
             const queryStatistics = new QueryStatistics(stats)
@@ -331,7 +331,7 @@ describe('QueryStatistics', () => {
           fc.maxSafeInteger().map(value => [BigInt(value), value]),
           ([value, expectedValue]) => {
             const stats = {
-              [field]: value
+              [rawField]: value
             }
 
             const queryStatistics = new QueryStatistics(stats)
@@ -348,7 +348,7 @@ describe('QueryStatistics', () => {
           fc.integer().map(value => [BigInt(value), value]),
           ([value, expectedValue]) => {
             const stats = {
-              [field]: value
+              [rawField]: value
             }
 
             const queryStatistics = new QueryStatistics(stats)

--- a/packages/neo4j-driver-deno/lib/core/result-summary.ts
+++ b/packages/neo4j-driver-deno/lib/core/result-summary.ts
@@ -644,9 +644,9 @@ class ServerInfo {
 
 function intValue (value: NumberOrInteger): number {
   if (value instanceof Integer) {
-    return value.toInt()
+    return value.toNumber()
   } else if (typeof value === 'bigint') {
-    return int(value).toInt()
+    return int(value).toNumber()
   } else {
     return value
   }


### PR DESCRIPTION
The driver was only considering the low 32 bits when driver configured for using BigInt or Integer.