### PR TITLE
Release Re-Auth and AuthTokenManager

### DIFF
--- a/packages/core/src/auth-token-manager.ts
+++ b/packages/core/src/auth-token-manager.ts
@@ -26,7 +26,7 @@ export type SecurityErrorCode = `Neo.ClientError.Security.${string}`
 /**
  * Interface for the piece of software responsible for keeping track of current active {@link AuthToken} across the driver.
  * @interface
- * @since 5.8
+ * @since 5.14
  */
 export default class AuthTokenManager {
   /**
@@ -56,7 +56,7 @@ export default class AuthTokenManager {
 /**
  * Interface which defines an {@link AuthToken} with an expiration data time associated
  * @interface
- * @since 5.8
+ * @since 5.14
  */
 export class AuthTokenAndExpiration {
   public readonly token: AuthToken

--- a/packages/core/src/auth-token-manager.ts
+++ b/packages/core/src/auth-token-manager.ts
@@ -26,7 +26,6 @@ export type SecurityErrorCode = `Neo.ClientError.Security.${string}`
 /**
  * Interface for the piece of software responsible for keeping track of current active {@link AuthToken} across the driver.
  * @interface
- * @experimental Exposed as preview feature.
  * @since 5.8
  */
 export default class AuthTokenManager {
@@ -57,7 +56,6 @@ export default class AuthTokenManager {
 /**
  * Interface which defines an {@link AuthToken} with an expiration data time associated
  * @interface
- * @experimental Exposed as preview feature.
  * @since 5.8
  */
 export class AuthTokenAndExpiration {
@@ -102,7 +100,6 @@ class AuthTokenManagers {
    * @param {function(): Promise<AuthTokenAndExpiration>} param0.tokenProvider - Retrieves a new valid auth token.
    * Must only ever return auth information belonging to the same identity.
    * @returns {AuthTokenManager} The temporal auth data manager.
-   * @experimental Exposed as preview feature.
    */
   bearer ({ tokenProvider }: { tokenProvider: () => Promise<AuthTokenAndExpiration> }): AuthTokenManager {
     if (typeof tokenProvider !== 'function') {
@@ -124,7 +121,6 @@ class AuthTokenManagers {
    * @param {function(): Promise<AuthToken>} param0.tokenProvider - Retrieves a new valid auth token.
    * Must only ever return auth information belonging to the same identity.
    * @returns {AuthTokenManager} The basic auth data manager.
-   * @experimental Exposed as preview feature.
    */
   basic ({ tokenProvider }: { tokenProvider: () => Promise<AuthToken> }): AuthTokenManager {
     if (typeof tokenProvider !== 'function') {
@@ -138,9 +134,7 @@ class AuthTokenManagers {
 }
 
 /**
- * Holds the common {@link AuthTokenManagers} used in the Driver
- *
- * @experimental Exposed as preview feature.
+ * Holds the common {@link AuthTokenManagers} used in the Driver.
  */
 const authTokenManagers: AuthTokenManagers = new AuthTokenManagers()
 

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -207,7 +207,6 @@ class SessionConfig {
      * which supports Bolt 5.1 and onwards.
      *
      * @type {AuthToken|undefined}
-     * @experimental Exposed as preview feature.
      * @see {@link driver}
      */
     this.auth = undefined

--- a/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
@@ -26,7 +26,7 @@ export type SecurityErrorCode = `Neo.ClientError.Security.${string}`
 /**
  * Interface for the piece of software responsible for keeping track of current active {@link AuthToken} across the driver.
  * @interface
- * @since 5.8
+ * @since 5.14
  */
 export default class AuthTokenManager {
   /**
@@ -56,7 +56,7 @@ export default class AuthTokenManager {
 /**
  * Interface which defines an {@link AuthToken} with an expiration data time associated
  * @interface
- * @since 5.8
+ * @since 5.14
  */
 export class AuthTokenAndExpiration {
   public readonly token: AuthToken

--- a/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth-token-manager.ts
@@ -26,7 +26,6 @@ export type SecurityErrorCode = `Neo.ClientError.Security.${string}`
 /**
  * Interface for the piece of software responsible for keeping track of current active {@link AuthToken} across the driver.
  * @interface
- * @experimental Exposed as preview feature.
  * @since 5.8
  */
 export default class AuthTokenManager {
@@ -57,7 +56,6 @@ export default class AuthTokenManager {
 /**
  * Interface which defines an {@link AuthToken} with an expiration data time associated
  * @interface
- * @experimental Exposed as preview feature.
  * @since 5.8
  */
 export class AuthTokenAndExpiration {
@@ -102,7 +100,6 @@ class AuthTokenManagers {
    * @param {function(): Promise<AuthTokenAndExpiration>} param0.tokenProvider - Retrieves a new valid auth token.
    * Must only ever return auth information belonging to the same identity.
    * @returns {AuthTokenManager} The temporal auth data manager.
-   * @experimental Exposed as preview feature.
    */
   bearer ({ tokenProvider }: { tokenProvider: () => Promise<AuthTokenAndExpiration> }): AuthTokenManager {
     if (typeof tokenProvider !== 'function') {
@@ -124,7 +121,6 @@ class AuthTokenManagers {
    * @param {function(): Promise<AuthToken>} param0.tokenProvider - Retrieves a new valid auth token.
    * Must only ever return auth information belonging to the same identity.
    * @returns {AuthTokenManager} The basic auth data manager.
-   * @experimental Exposed as preview feature.
    */
   basic ({ tokenProvider }: { tokenProvider: () => Promise<AuthToken> }): AuthTokenManager {
     if (typeof tokenProvider !== 'function') {
@@ -138,9 +134,7 @@ class AuthTokenManagers {
 }
 
 /**
- * Holds the common {@link AuthTokenManagers} used in the Driver
- *
- * @experimental Exposed as preview feature.
+ * Holds the common {@link AuthTokenManagers} used in the Driver.
  */
 const authTokenManagers: AuthTokenManagers = new AuthTokenManagers()
 

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -207,7 +207,6 @@ class SessionConfig {
      * which supports Bolt 5.1 and onwards.
      *
      * @type {AuthToken|undefined}
-     * @experimental Exposed as preview feature.
      * @see {@link driver}
      */
     this.auth = undefined

--- a/packages/neo4j-driver/src/result-rx.js
+++ b/packages/neo4j-driver/src/result-rx.js
@@ -110,7 +110,7 @@ export default class RxResult {
   /**
    * Pauses the automatic streaming of records.
    *
-   * This method provides a way of controll the flow of records
+   * This method provides a way of control the flow of records
    *
    * @experimental
    */


### PR DESCRIPTION
Removes the @experimental tags form the APIs.
The API is consider stable.