### PR TITLE
Introduce explicity resource management to Transaction

### DIFF
--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -291,6 +291,12 @@ class Transaction {
     }
   }
 
+  // eslint-disable-next-line
+  // @ts-ignore
+  [Symbol.asyncDispose] (): Promise<void> {
+    return this.close()
+  }
+
   _onErrorCallback (error: Error): Promise<Connection | null> {
     // error will be "acknowledged" by sending a RESET message
     // database will then forget about this transaction and cleanup all corresponding resources

--- a/packages/neo4j-driver-deno/lib/core/transaction.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction.ts
@@ -291,6 +291,12 @@ class Transaction {
     }
   }
 
+  // eslint-disable-next-line
+  // @ts-ignore
+  [Symbol.asyncDispose] (): Promise<void> {
+    return this.close()
+  }
+
   _onErrorCallback (error: Error): Promise<Connection | null> {
     // error will be "acknowledged" by sending a RESET message
     // database will then forget about this transaction and cleanup all corresponding resources


### PR DESCRIPTION
This is a TC39 [proposal](https://github.com/tc39/proposal-explicit-resource-management) which is already implemented in Typescript 5.2, core-js, babel and other polyfill tools.

This feature enables the user begin a transaction with the `await using` keywords and then do not have to close the resource afterwards, since this resources will be closed after leaving the block which were created at.

Transaction will be closed using with the same behaviour as `Transaction.close` calls. So, the transaction will be rollback if still open.

_Note: For better usage in cluster environments, you should use `executeRead` and `executeWrite` for handling retries._

Usage example:

```typescript
await using tx = session.beginTransaction()
await tx.run('CREATE (p:Person { name:$name }) RETURN p', { name }).summary()
await tx.commit()
```