### PR TITLE
Bump Browserify-sign to 4.2.2 to solve critical issue with DSA

### DIFF
--- a/packages/neo4j-driver-lite/package-lock.json
+++ b/packages/neo4j-driver-lite/package-lock.json
@@ -13,6 +13,7 @@
 				"@rollup/plugin-node-resolve": "^13.3.0",
 				"@types/jest": "^29.5.3",
 				"browser-resolve": "^2.0.0",
+				"browserify-sign": "^4.2.2",
 				"esdoc": "^1.1.0",
 				"esdoc-importpath-plugin": "^1.0.2",
 				"esdoc-standard-plugin": "^1.0.0",
@@ -1634,6 +1635,24 @@
 				"safer-buffer": "~2.1.0"
 			}
 		},
+		"node_modules/asn1.js": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"node_modules/asn1.js/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
+		},
 		"node_modules/assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2007,6 +2026,12 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/bn.js": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+			"dev": true
+		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2035,6 +2060,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+			"dev": true
+		},
 		"node_modules/browser-resolve": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
@@ -2042,6 +2073,50 @@
 			"dev": true,
 			"dependencies": {
 				"resolve": "^1.17.0"
+			}
+		},
+		"node_modules/browserify-aes": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"dev": true,
+			"dependencies": {
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/browserify-rsa": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+			"integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^5.0.0",
+				"randombytes": "^2.0.1"
+			}
+		},
+		"node_modules/browserify-sign": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+			"integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^5.2.1",
+				"browserify-rsa": "^4.1.0",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"elliptic": "^6.5.4",
+				"inherits": "^2.0.4",
+				"parse-asn1": "^5.1.6",
+				"readable-stream": "^3.6.2",
+				"safe-buffer": "^5.2.1"
+			},
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/browserslist": {
@@ -2134,6 +2209,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
+		"node_modules/buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
 			"dev": true
 		},
 		"node_modules/buildcheck": {
@@ -2282,6 +2363,16 @@
 			],
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/cjs-module-lexer": {
@@ -2442,6 +2533,33 @@
 			},
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dev": true,
+			"dependencies": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"node_modules/create-hmac": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"dev": true,
+			"dependencies": {
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"node_modules/create-require": {
@@ -2697,6 +2815,27 @@
 			"version": "1.4.494",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.494.tgz",
 			"integrity": "sha512-KF7wtsFFDu4ws1ZsSOt4pdmO1yWVNWCFtijVYZPUeW4SV7/hy/AESjLn/+qIWgq7mHscNOKAwN5AIM1+YAy+Ww==",
+			"dev": true
+		},
+		"node_modules/elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"node_modules/elliptic/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -3115,6 +3254,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
+			"dependencies": {
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3473,6 +3622,41 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"node_modules/hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+			"dev": true,
+			"dependencies": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -5033,6 +5217,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dev": true,
+			"dependencies": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5083,6 +5278,18 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"dev": true
+		},
+		"node_modules/minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+			"dev": true
 		},
 		"node_modules/minimatch": {
 			"version": "3.0.4",
@@ -5291,6 +5498,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse-asn1": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+			"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+			"dev": true,
+			"dependencies": {
+				"asn1.js": "^5.2.0",
+				"browserify-aes": "^1.0.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5341,6 +5561,22 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
+		},
+		"node_modules/pbkdf2": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+			"integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+			"dev": true,
+			"dependencies": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
 		},
 		"node_modules/performance-now": {
 			"version": "2.1.0",
@@ -5506,6 +5742,15 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.6"
+			}
+		},
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"node_modules/react-is": {
@@ -5690,6 +5935,16 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dev": true,
+			"dependencies": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
 		"node_modules/rollup": {
 			"version": "2.79.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
@@ -5757,6 +6012,19 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			},
+			"bin": {
+				"sha.js": "bin.js"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -7963,6 +8231,26 @@
 				"safer-buffer": "~2.1.0"
 			}
 		},
+		"asn1.js": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
+			}
+		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -8273,6 +8561,12 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"bn.js": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+			"dev": true
+		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -8298,6 +8592,12 @@
 				"fill-range": "^7.0.1"
 			}
 		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+			"dev": true
+		},
 		"browser-resolve": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
@@ -8305,6 +8605,47 @@
 			"dev": true,
 			"requires": {
 				"resolve": "^1.17.0"
+			}
+		},
+		"browserify-aes": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"dev": true,
+			"requires": {
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"browserify-rsa": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+			"integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^5.0.0",
+				"randombytes": "^2.0.1"
+			}
+		},
+		"browserify-sign": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+			"integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^5.2.1",
+				"browserify-rsa": "^4.1.0",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"elliptic": "^6.5.4",
+				"inherits": "^2.0.4",
+				"parse-asn1": "^5.1.6",
+				"readable-stream": "^3.6.2",
+				"safe-buffer": "^5.2.1"
 			}
 		},
 		"browserslist": {
@@ -8357,6 +8698,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
 			"dev": true
 		},
 		"buildcheck": {
@@ -8455,6 +8802,16 @@
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
 			"integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
 			"dev": true
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"cjs-module-lexer": {
 			"version": "1.2.3",
@@ -8583,6 +8940,33 @@
 			"requires": {
 				"crc-32": "^1.2.0",
 				"readable-stream": "^3.4.0"
+			}
+		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"create-require": {
@@ -8790,6 +9174,29 @@
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.494.tgz",
 			"integrity": "sha512-KF7wtsFFDu4ws1ZsSOt4pdmO1yWVNWCFtijVYZPUeW4SV7/hy/AESjLn/+qIWgq7mHscNOKAwN5AIM1+YAy+Ww==",
 			"dev": true
+		},
+		"elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
+			}
 		},
 		"emittery": {
 			"version": "0.13.1",
@@ -9130,6 +9537,16 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
+			"requires": {
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -9405,6 +9822,38 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
+		},
+		"hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+			"dev": true,
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
 		},
 		"html-escaper": {
 			"version": "2.0.2",
@@ -10666,6 +11115,17 @@
 			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
 			"dev": true
 		},
+		"md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dev": true,
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -10703,6 +11163,18 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"dev": true
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
 			"dev": true
 		},
 		"minimatch": {
@@ -10869,6 +11341,19 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
+		"parse-asn1": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+			"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+			"dev": true,
+			"requires": {
+				"asn1.js": "^5.2.0",
+				"browserify-aes": "^1.0.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -10904,6 +11389,19 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
+		},
+		"pbkdf2": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+			"integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+			"dev": true,
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -11026,6 +11524,15 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true,
 			"optional": true
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
 		},
 		"react-is": {
 			"version": "18.2.0",
@@ -11175,6 +11682,16 @@
 			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
 			"dev": true
 		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dev": true,
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
 		"rollup": {
 			"version": "2.79.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
@@ -11217,6 +11734,16 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"shebang-command": {
 			"version": "2.0.0",

--- a/packages/neo4j-driver-lite/package.json
+++ b/packages/neo4j-driver-lite/package.json
@@ -45,6 +45,7 @@
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@types/jest": "^29.5.3",
     "browser-resolve": "^2.0.0",
+    "browserify-sign": "^4.2.2",
     "esdoc": "^1.1.0",
     "esdoc-importpath-plugin": "^1.0.2",
     "esdoc-standard-plugin": "^1.0.0",

--- a/packages/neo4j-driver/package-lock.json
+++ b/packages/neo4j-driver/package-lock.json
@@ -19,6 +19,7 @@
 				"@rollup/plugin-node-resolve": "^13.3.0",
 				"@types/jasmine": "^4.3.1",
 				"async": "^3.2.4",
+				"browserify-sign": "^4.2.2",
 				"esdoc": "^1.1.0",
 				"esdoc-importpath-plugin": "^1.0.2",
 				"esdoc-standard-plugin": "^1.0.0",
@@ -3275,9 +3276,9 @@
 			}
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
 			"dev": true
 		},
 		"node_modules/body-parser": {
@@ -3416,26 +3417,29 @@
 			}
 		},
 		"node_modules/browserify-sign": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-			"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+			"integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
 			"dev": true,
 			"dependencies": {
-				"bn.js": "^5.1.1",
-				"browserify-rsa": "^4.0.1",
+				"bn.js": "^5.2.1",
+				"browserify-rsa": "^4.1.0",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.3",
+				"elliptic": "^6.5.4",
 				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.5",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
+				"parse-asn1": "^5.1.6",
+				"readable-stream": "^3.6.2",
+				"safe-buffer": "^5.2.1"
+			},
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/browserify-sign/node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -16886,9 +16890,9 @@
 			}
 		},
 		"bn.js": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
 			"dev": true
 		},
 		"body-parser": {
@@ -17023,26 +17027,26 @@
 			}
 		},
 		"browserify-sign": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-			"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+			"integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^5.1.1",
-				"browserify-rsa": "^4.0.1",
+				"bn.js": "^5.2.1",
+				"browserify-rsa": "^4.1.0",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.3",
+				"elliptic": "^6.5.4",
 				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.5",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
+				"parse-asn1": "^5.1.6",
+				"readable-stream": "^3.6.2",
+				"safe-buffer": "^5.2.1"
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",

--- a/packages/neo4j-driver/package.json
+++ b/packages/neo4j-driver/package.json
@@ -41,6 +41,7 @@
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@types/jasmine": "^4.3.1",
     "async": "^3.2.4",
+    "browserify-sign": "^4.2.2",
     "esdoc": "^1.1.0",
     "esdoc-importpath-plugin": "^1.0.2",
     "esdoc-standard-plugin": "^1.0.0",


### PR DESCRIPTION
This issue should not affect the driver since the driver doesn't do DSA with user inputs.

More details about the issue in:
https://github.com/neo4j/neo4j-javascript-driver/security/dependabot/200