### PR TITLE
Introduce driver level Hydration and Dehydration hooks

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -74,7 +74,9 @@ export default class BoltProtocol {
     { disableLosslessIntegers, useBigInt } = {},
     createResponseHandler = () => null,
     log,
-    onProtocolError
+    onProtocolError,
+    hydrationHooks,
+    dehydrationHooks
   ) {
     this._server = server || {}
     this._chunker = chunker
@@ -86,11 +88,13 @@ export default class BoltProtocol {
     this._fatalError = null
     this._lastMessageSignature = null
     this._config = { disableLosslessIntegers, useBigInt }
+    this._hydrationHooks = hydrationHooks
+    this._dehydrationHooks = dehydrationHooks
   }
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v2.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v2.js
@@ -37,7 +37,7 @@ export default class BoltProtocol extends BoltProtocolV1 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v3.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v3.js
@@ -48,7 +48,7 @@ export default class BoltProtocol extends BoltProtocolV2 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x0.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x0.js
@@ -46,7 +46,7 @@ export default class BoltProtocol extends BoltProtocolV3 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x1.js
@@ -49,6 +49,8 @@ export default class BoltProtocol extends BoltProtocolV4 {
     createResponseHandler = () => null,
     log,
     onProtocolError,
+    hydrationHooks,
+    dehydrationHooks,
     serversideRouting
   ) {
     super(
@@ -57,7 +59,9 @@ export default class BoltProtocol extends BoltProtocolV4 {
       packstreamConfig,
       createResponseHandler,
       log,
-      onProtocolError
+      onProtocolError,
+      hydrationHooks,
+      dehydrationHooks
     )
     this._serversideRouting = serversideRouting
   }
@@ -68,7 +72,7 @@ export default class BoltProtocol extends BoltProtocolV4 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x2.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x2.js
@@ -34,7 +34,7 @@ export default class BoltProtocol extends BoltProtocolV41 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x3.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x3.js
@@ -39,7 +39,7 @@ export default class BoltProtocol extends BoltProtocolV42 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }
@@ -126,6 +126,6 @@ export default class BoltProtocol extends BoltProtocolV42 {
     this._transformer = new Transformer(Object.values({
       ...transformersFactories,
       ...utcTransformersFactories
-    }).map(create => create(this._config, this._log)))
+    }).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
   }
 }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x4.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x4.js
@@ -39,7 +39,7 @@ export default class BoltProtocol extends BoltProtocolV43 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }
@@ -178,6 +178,6 @@ export default class BoltProtocol extends BoltProtocolV43 {
     this._transformer = new Transformer(Object.values({
       ...transformersFactories,
       ...utcTransformersFactories
-    }).map(create => create(this._config, this._log)))
+    }).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
   }
 }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.js
@@ -37,7 +37,7 @@ export default class BoltProtocol extends BoltProtocolV44 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x1.js
@@ -37,7 +37,7 @@ export default class BoltProtocol extends BoltProtocolV5x0 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x2.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x2.js
@@ -36,7 +36,7 @@ export default class BoltProtocol extends BoltProtocolV5x1 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x3.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x3.js
@@ -36,7 +36,7 @@ export default class BoltProtocol extends BoltProtocolV5x2 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x4.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x4.js
@@ -36,7 +36,7 @@ export default class BoltProtocol extends BoltProtocolV5x3 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/bolt-connection/src/bolt/create.js
+++ b/packages/bolt-connection/src/bolt/create.js
@@ -48,6 +48,8 @@ import ResponseHandler from './response-handler'
  * @param {boolean} config.disableLosslessIntegers Disable the lossless integers
  * @param {boolean} packstreamConfig.useBigInt if this connection should convert all received integers to native BigInt numbers.
  * @param {boolean} config.serversideRouting It's using server side routing
+ * @param {HydatrationHooks} config.hydrationHooks Hydatration hooks used to map types
+ * @param {DehydrationHooks} config.dehydrationHooks Hydatration hooks used to map types
  */
 export default function create ({
   version,
@@ -59,7 +61,9 @@ export default function create ({
   serversideRouting,
   server, // server info
   log,
-  observer
+  observer,
+  hydrationHooks,
+  dehydrationHooks
 } = {}) {
   const createResponseHandler = protocol => {
     const responseHandler = new ResponseHandler({
@@ -94,7 +98,9 @@ export default function create ({
     serversideRouting,
     createResponseHandler,
     observer.onProtocolError.bind(observer),
-    log
+    log,
+    hydrationHooks,
+    dehydrationHooks
   )
 }
 
@@ -106,7 +112,9 @@ function createProtocol (
   serversideRouting,
   createResponseHandler,
   onProtocolError,
-  log
+  log,
+  hydrationHooks,
+  dehydrationHooks
 ) {
   switch (version) {
     case 1:
@@ -116,7 +124,9 @@ function createProtocol (
         packingConfig,
         createResponseHandler,
         log,
-        onProtocolError
+        onProtocolError,
+        hydrationHooks,
+        dehydrationHooks
       )
     case 2:
       return new BoltProtocolV2(
@@ -125,7 +135,9 @@ function createProtocol (
         packingConfig,
         createResponseHandler,
         log,
-        onProtocolError
+        onProtocolError,
+        hydrationHooks,
+        dehydrationHooks
       )
     case 3:
       return new BoltProtocolV3(
@@ -134,7 +146,9 @@ function createProtocol (
         packingConfig,
         createResponseHandler,
         log,
-        onProtocolError
+        onProtocolError,
+        hydrationHooks,
+        dehydrationHooks
       )
     case 4.0:
       return new BoltProtocolV4x0(
@@ -143,7 +157,9 @@ function createProtocol (
         packingConfig,
         createResponseHandler,
         log,
-        onProtocolError
+        onProtocolError,
+        hydrationHooks,
+        dehydrationHooks
       )
     case 4.1:
       return new BoltProtocolV4x1(
@@ -153,6 +169,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 4.2:
@@ -163,6 +181,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 4.3:
@@ -173,6 +193,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 4.4:
@@ -183,6 +205,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 5.0:
@@ -193,6 +217,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 5.1:
@@ -203,6 +229,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 5.2:
@@ -213,6 +241,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 5.3:
@@ -222,6 +252,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting)
     case 5.4:
       return new BoltProtocolV5x4(server,
@@ -230,6 +262,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting)
     default:
       throw newError('Unknown Bolt protocol version: ' + version)

--- a/packages/bolt-connection/src/bolt/transformer.js
+++ b/packages/bolt-connection/src/bolt/transformer.js
@@ -18,7 +18,7 @@
  */
 
 import { structure } from '../packstream'
-import { internal } from 'neo4j-driver-core'
+import { internal, isDate, isDateTime, isDuration, isInt, isLocalDateTime, isLocalTime, isPoint, isTime } from 'neo4j-driver-core'
 
 const { objectUtil } = internal
 
@@ -30,9 +30,26 @@ export default class Transformer {
   /**
    * Constructor
    * @param {TypeTransformer[]} transformers The type transformers
+   * @param {HydatrationHooks} hydration The hydration hooks
+   * @param {DehydrationHooks} dehydrationHooks the DehydrationHooks
    */
-  constructor (transformers) {
+  constructor (transformers, hydration, dehydrationHooks) {
     this._transformers = transformers
+    hydration = hydration || {}
+    this._hydrators = [
+      [isDuration, hydration.Duration],
+      [isLocalTime, hydration.LocalTime],
+      [isLocalDateTime, hydration.LocalDateTime],
+      [isTime, hydration.Time],
+      [isDate, hydration.Date],
+      [isDateTime, hydration.DateTime],
+      [isInt, hydration.Integer],
+      [isPoint, hydration.Point]
+    ]
+      .map(([isTypeInstance, hydrate]) => ({ isTypeInstance, hydrate }))
+      .filter(({ hydrate }) => hydrate != null)
+
+    this._dehydrationHooks = dehydrationHooks || []
     this._transformersPerSignature = new Map(transformers.map(typeTransformer => [typeTransformer.signature, typeTransformer]))
     this.fromStructure = this.fromStructure.bind(this)
     this.toStructure = this.toStructure.bind(this)
@@ -47,14 +64,23 @@ export default class Transformer {
    */
   fromStructure (struct) {
     try {
-      if (struct instanceof structure.Structure && this._transformersPerSignature.has(struct.signature)) {
-        const { fromStructure } = this._transformersPerSignature.get(struct.signature)
-        return fromStructure(struct)
+      const value = this._fromStructure(struct)
+      const hydrator = this._hydrators.find(({ isTypeInstance }) => isTypeInstance(value))
+      if (hydrator != null) {
+        return hydrator.hydrate(value)
       }
-      return struct
+      return value
     } catch (error) {
       return objectUtil.createBrokenObject(error)
     }
+  }
+
+  _fromStructure (struct) {
+    if (struct instanceof structure.Structure && this._transformersPerSignature.has(struct.signature)) {
+      const { fromStructure } = this._transformersPerSignature.get(struct.signature)
+      return fromStructure(struct)
+    }
+    return struct
   }
 
   /**
@@ -63,9 +89,18 @@ export default class Transformer {
    * @returns {<T>|structure.Structure} The structure or the object, if any transformer was found
    */
   toStructure (type) {
-    const transformer = this._transformers.find(({ isTypeInstance }) => isTypeInstance(type))
+    const dehydratedType = this._dehydrateType(type)
+    const transformer = this._transformers.find(({ isTypeInstance }) => isTypeInstance(dehydratedType))
     if (transformer !== undefined) {
-      return transformer.toStructure(type)
+      return transformer.toStructure(dehydratedType)
+    }
+    return dehydratedType
+  }
+
+  _dehydrateType (type) {
+    const dehydation = this._dehydrationHooks.find(({ isTypeInstance }) => isTypeInstance(type))
+    if (dehydation !== undefined) {
+      return dehydation.dehydrate(type)
     }
     return type
   }

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -778,7 +778,7 @@ function _isFailFastError (error) {
 }
 
 function _isFailFastSecurityError (error) {
-  return error.code.startsWith('Neo.ClientError.Security.') &&
+  return error.code != null && error.code.startsWith('Neo.ClientError.Security.') &&
     ![
       AUTHORIZATION_EXPIRED_CODE
     ].includes(error.code)

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -75,7 +75,9 @@ export function createChannelConnection (
             onProtocolError: conn._handleProtocolError.bind(conn),
             onErrorApplyTransformation: error =>
               conn.handleAndTransformError(error, conn._address)
-          }
+          },
+          hydrationHooks: config.hydrationHooks,
+          dehydrationHooks: config.dehydrationHooks
         })
 
       const connection = new ChannelConnection(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,11 @@ import NotificationFilter, {
   notificationFilterMinimumSeverityLevel,
   NotificationFilterMinimumSeverityLevel
 } from './notification-filter'
+import {
+  HydatrationHooks,
+  DehytrationHook,
+  DehydrationHooks
+} from './mapping'
 import Result, { QueryResult, ResultObserver } from './result'
 import EagerResult from './result-eager'
 import ConnectionProvider from './connection-provider'
@@ -265,7 +270,10 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  HydatrationHooks,
+  DehytrationHook,
+  DehydrationHooks
 }
 
 export default forExport

--- a/packages/core/src/mapping.ts
+++ b/packages/core/src/mapping.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Integer from './integer'
+import { Point } from './spatial-types'
+import { DateTime, Duration, LocalDateTime, LocalTime, Time } from './temporal-types'
+
+/**
+ * Defines methods for hydrate and dehydrate objects
+ *
+ * @interface
+ */
+export class HydatrationHooks {
+  public readonly Duration?: <V extends unknown> (duration: Duration) => V
+  public readonly LocalTime?: <V extends unknown> (localTime: LocalTime) => V
+  public readonly LocalDateTime?: <V extends unknown> (localDateTime: LocalDateTime) => V
+  public readonly Time?: <V extends unknown> (time: Time) => V
+  public readonly Date?: <V extends unknown> (date: Date) => V
+  public readonly DateTime?: <V extends unknown> (dateTime: DateTime) => V
+  public readonly Integer?: <V extends unknown> (integer: Integer) => V
+  public readonly Point?: <V extends unknown> (point: Point) => V
+
+  constructor () {
+    throw new Error('This class should not be instantiated')
+  }
+}
+
+export class DehytrationHook<I = unknown, O = unknown> {
+  constructor () {
+    throw new Error('This class should not be instantiated')
+  }
+
+  public isTypeInstance (value: unknown): value is I {
+    throw new Error('Not Implemented')
+  }
+
+  public dehydrate (value: I): O {
+    throw new Error('Not Implemented')
+  }
+}
+
+export type DehydrationHooks = DehytrationHook[]
+// bytes |> unpack |> fromStructure |> hydrate
+// type |> dehydrate |> toStructure |> pack

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { DehydrationHooks, HydatrationHooks } from './mapping'
 import NotificationFilter from './notification-filter'
 
 /**
@@ -81,6 +82,8 @@ export class Config {
   resolver?: (address: string) => string[] | Promise<string[]>
   userAgent?: string
   telemetryDisabled?: boolean
+  hydrationHooks?: HydatrationHooks
+  dehydrationHooks?: DehydrationHooks
 
   /**
    * @constructor

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v1.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v1.js
@@ -74,7 +74,9 @@ export default class BoltProtocol {
     { disableLosslessIntegers, useBigInt } = {},
     createResponseHandler = () => null,
     log,
-    onProtocolError
+    onProtocolError,
+    hydrationHooks,
+    dehydrationHooks
   ) {
     this._server = server || {}
     this._chunker = chunker
@@ -86,11 +88,13 @@ export default class BoltProtocol {
     this._fatalError = null
     this._lastMessageSignature = null
     this._config = { disableLosslessIntegers, useBigInt }
+    this._hydrationHooks = hydrationHooks
+    this._dehydrationHooks = dehydrationHooks
   }
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v2.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v2.js
@@ -37,7 +37,7 @@ export default class BoltProtocol extends BoltProtocolV1 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v3.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v3.js
@@ -48,7 +48,7 @@ export default class BoltProtocol extends BoltProtocolV2 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x0.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x0.js
@@ -46,7 +46,7 @@ export default class BoltProtocol extends BoltProtocolV3 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x1.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x1.js
@@ -49,6 +49,8 @@ export default class BoltProtocol extends BoltProtocolV4 {
     createResponseHandler = () => null,
     log,
     onProtocolError,
+    hydrationHooks,
+    dehydrationHooks,
     serversideRouting
   ) {
     super(
@@ -57,7 +59,9 @@ export default class BoltProtocol extends BoltProtocolV4 {
       packstreamConfig,
       createResponseHandler,
       log,
-      onProtocolError
+      onProtocolError,
+      hydrationHooks,
+      dehydrationHooks
     )
     this._serversideRouting = serversideRouting
   }
@@ -68,7 +72,7 @@ export default class BoltProtocol extends BoltProtocolV4 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x2.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x2.js
@@ -34,7 +34,7 @@ export default class BoltProtocol extends BoltProtocolV41 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x3.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x3.js
@@ -39,7 +39,7 @@ export default class BoltProtocol extends BoltProtocolV42 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }
@@ -126,6 +126,6 @@ export default class BoltProtocol extends BoltProtocolV42 {
     this._transformer = new Transformer(Object.values({
       ...transformersFactories,
       ...utcTransformersFactories
-    }).map(create => create(this._config, this._log)))
+    }).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
   }
 }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x4.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x4.js
@@ -39,7 +39,7 @@ export default class BoltProtocol extends BoltProtocolV43 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }
@@ -178,6 +178,6 @@ export default class BoltProtocol extends BoltProtocolV43 {
     this._transformer = new Transformer(Object.values({
       ...transformersFactories,
       ...utcTransformersFactories
-    }).map(create => create(this._config, this._log)))
+    }).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
   }
 }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.js
@@ -37,7 +37,7 @@ export default class BoltProtocol extends BoltProtocolV44 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x1.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x1.js
@@ -37,7 +37,7 @@ export default class BoltProtocol extends BoltProtocolV5x0 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x2.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x2.js
@@ -36,7 +36,7 @@ export default class BoltProtocol extends BoltProtocolV5x1 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x3.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x3.js
@@ -36,7 +36,7 @@ export default class BoltProtocol extends BoltProtocolV5x2 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x4.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x4.js
@@ -36,7 +36,7 @@ export default class BoltProtocol extends BoltProtocolV5x3 {
 
   get transformer () {
     if (this._transformer === undefined) {
-      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)), this._hydrationHooks, this._dehydrationHooks)
     }
     return this._transformer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/create.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/create.js
@@ -48,6 +48,8 @@ import ResponseHandler from './response-handler.js'
  * @param {boolean} config.disableLosslessIntegers Disable the lossless integers
  * @param {boolean} packstreamConfig.useBigInt if this connection should convert all received integers to native BigInt numbers.
  * @param {boolean} config.serversideRouting It's using server side routing
+ * @param {HydatrationHooks} config.hydrationHooks Hydatration hooks used to map types
+ * @param {DehydrationHooks} config.dehydrationHooks Hydatration hooks used to map types
  */
 export default function create ({
   version,
@@ -59,7 +61,9 @@ export default function create ({
   serversideRouting,
   server, // server info
   log,
-  observer
+  observer,
+  hydrationHooks,
+  dehydrationHooks
 } = {}) {
   const createResponseHandler = protocol => {
     const responseHandler = new ResponseHandler({
@@ -94,7 +98,9 @@ export default function create ({
     serversideRouting,
     createResponseHandler,
     observer.onProtocolError.bind(observer),
-    log
+    log,
+    hydrationHooks,
+    dehydrationHooks
   )
 }
 
@@ -106,7 +112,9 @@ function createProtocol (
   serversideRouting,
   createResponseHandler,
   onProtocolError,
-  log
+  log,
+  hydrationHooks,
+  dehydrationHooks
 ) {
   switch (version) {
     case 1:
@@ -116,7 +124,9 @@ function createProtocol (
         packingConfig,
         createResponseHandler,
         log,
-        onProtocolError
+        onProtocolError,
+        hydrationHooks,
+        dehydrationHooks
       )
     case 2:
       return new BoltProtocolV2(
@@ -125,7 +135,9 @@ function createProtocol (
         packingConfig,
         createResponseHandler,
         log,
-        onProtocolError
+        onProtocolError,
+        hydrationHooks,
+        dehydrationHooks
       )
     case 3:
       return new BoltProtocolV3(
@@ -134,7 +146,9 @@ function createProtocol (
         packingConfig,
         createResponseHandler,
         log,
-        onProtocolError
+        onProtocolError,
+        hydrationHooks,
+        dehydrationHooks
       )
     case 4.0:
       return new BoltProtocolV4x0(
@@ -143,7 +157,9 @@ function createProtocol (
         packingConfig,
         createResponseHandler,
         log,
-        onProtocolError
+        onProtocolError,
+        hydrationHooks,
+        dehydrationHooks
       )
     case 4.1:
       return new BoltProtocolV4x1(
@@ -153,6 +169,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 4.2:
@@ -163,6 +181,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 4.3:
@@ -173,6 +193,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 4.4:
@@ -183,6 +205,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 5.0:
@@ -193,6 +217,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 5.1:
@@ -203,6 +229,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 5.2:
@@ -213,6 +241,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting
       )
     case 5.3:
@@ -222,6 +252,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting)
     case 5.4:
       return new BoltProtocolV5x4(server,
@@ -230,6 +262,8 @@ function createProtocol (
         createResponseHandler,
         log,
         onProtocolError,
+        hydrationHooks,
+        dehydrationHooks,
         serversideRouting)
     default:
       throw newError('Unknown Bolt protocol version: ' + version)

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -778,7 +778,7 @@ function _isFailFastError (error) {
 }
 
 function _isFailFastSecurityError (error) {
-  return error.code.startsWith('Neo.ClientError.Security.') &&
+  return error.code != null && error.code.startsWith('Neo.ClientError.Security.') &&
     ![
       AUTHORIZATION_EXPIRED_CODE
     ].includes(error.code)

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
@@ -75,7 +75,9 @@ export function createChannelConnection (
             onProtocolError: conn._handleProtocolError.bind(conn),
             onErrorApplyTransformation: error =>
               conn.handleAndTransformError(error, conn._address)
-          }
+          },
+          hydrationHooks: config.hydrationHooks,
+          dehydrationHooks: config.dehydrationHooks
         })
 
       const connection = new ChannelConnection(

--- a/packages/neo4j-driver-deno/lib/core/index.ts
+++ b/packages/neo4j-driver-deno/lib/core/index.ts
@@ -76,6 +76,11 @@ import NotificationFilter, {
   notificationFilterMinimumSeverityLevel,
   NotificationFilterMinimumSeverityLevel
 } from './notification-filter.ts'
+import {
+  HydatrationHooks,
+  DehytrationHook,
+  DehydrationHooks
+} from './mapping.ts'
 import Result, { QueryResult, ResultObserver } from './result.ts'
 import EagerResult from './result-eager.ts'
 import ConnectionProvider from './connection-provider.ts'
@@ -265,7 +270,10 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  HydatrationHooks,
+  DehytrationHook,
+  DehydrationHooks
 }
 
 export default forExport

--- a/packages/neo4j-driver-deno/lib/core/mapping.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Integer from './integer.ts'
+import { Point } from './spatial-types.ts'
+import { DateTime, Duration, LocalDateTime, LocalTime, Time } from './temporal-types.ts'
+
+
+/**
+ * Defines methods for hydrate and dehydrate objects
+ * 
+ * @interface
+ */
+export class HydatrationHooks {
+    public readonly Duration?: <V extends unknown> (duration: Duration) => V
+    public readonly LocalTime?: <V extends unknown> (localTime: LocalTime) => V
+    public readonly LocalDateTime?: <V extends unknown> (localDateTime: LocalDateTime) => V
+    public readonly Time?: <V extends unknown> (time: Time) => V
+    public readonly Date?: <V extends unknown> (date: Date) => V
+    public readonly DateTime?: <V extends unknown> (dateTime: DateTime) => V
+    public readonly Integer?: <V extends unknown> (integer: Integer) => V
+    public readonly Point?: <V extends unknown> (point: Point) => V
+
+    constructor() {
+        throw new Error('This class should not be instantiated')
+    }
+}
+
+export class DehytrationHook<I = unknown, O = unknown> {
+    
+    constructor() {
+        throw new Error('This class should not be instantiated')
+    }
+
+    public isTypeInstance (value: unknown): value is I {
+        throw new Error('Not Implemented')
+    }
+
+    public dehydrate (value: I): O {
+        throw new Error('Not Implemented')
+    }
+}
+
+export type DehydrationHooks = DehytrationHook[]
+// bytes |> unpack |> fromStructure |> hydrate
+// type |> dehydrate |> toStructure |> pack

--- a/packages/neo4j-driver-deno/lib/core/mapping.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.ts
@@ -21,40 +21,38 @@ import Integer from './integer.ts'
 import { Point } from './spatial-types.ts'
 import { DateTime, Duration, LocalDateTime, LocalTime, Time } from './temporal-types.ts'
 
-
 /**
  * Defines methods for hydrate and dehydrate objects
- * 
+ *
  * @interface
  */
 export class HydatrationHooks {
-    public readonly Duration?: <V extends unknown> (duration: Duration) => V
-    public readonly LocalTime?: <V extends unknown> (localTime: LocalTime) => V
-    public readonly LocalDateTime?: <V extends unknown> (localDateTime: LocalDateTime) => V
-    public readonly Time?: <V extends unknown> (time: Time) => V
-    public readonly Date?: <V extends unknown> (date: Date) => V
-    public readonly DateTime?: <V extends unknown> (dateTime: DateTime) => V
-    public readonly Integer?: <V extends unknown> (integer: Integer) => V
-    public readonly Point?: <V extends unknown> (point: Point) => V
+  public readonly Duration?: <V extends unknown> (duration: Duration) => V
+  public readonly LocalTime?: <V extends unknown> (localTime: LocalTime) => V
+  public readonly LocalDateTime?: <V extends unknown> (localDateTime: LocalDateTime) => V
+  public readonly Time?: <V extends unknown> (time: Time) => V
+  public readonly Date?: <V extends unknown> (date: Date) => V
+  public readonly DateTime?: <V extends unknown> (dateTime: DateTime) => V
+  public readonly Integer?: <V extends unknown> (integer: Integer) => V
+  public readonly Point?: <V extends unknown> (point: Point) => V
 
-    constructor() {
-        throw new Error('This class should not be instantiated')
-    }
+  constructor () {
+    throw new Error('This class should not be instantiated')
+  }
 }
 
 export class DehytrationHook<I = unknown, O = unknown> {
-    
-    constructor() {
-        throw new Error('This class should not be instantiated')
-    }
+  constructor () {
+    throw new Error('This class should not be instantiated')
+  }
 
-    public isTypeInstance (value: unknown): value is I {
-        throw new Error('Not Implemented')
-    }
+  public isTypeInstance (value: unknown): value is I {
+    throw new Error('Not Implemented')
+  }
 
-    public dehydrate (value: I): O {
-        throw new Error('Not Implemented')
-    }
+  public dehydrate (value: I): O {
+    throw new Error('Not Implemented')
+  }
 }
 
 export type DehydrationHooks = DehytrationHook[]

--- a/packages/neo4j-driver-deno/lib/core/types.ts
+++ b/packages/neo4j-driver-deno/lib/core/types.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { DehydrationHooks, HydatrationHooks } from './mapping.ts'
 import NotificationFilter from './notification-filter.ts'
 
 /**
@@ -81,6 +82,8 @@ export class Config {
   resolver?: (address: string) => string[] | Promise<string[]>
   userAgent?: string
   telemetryDisabled?: boolean
+  hydrationHooks?: HydatrationHooks
+  dehydrationHooks?: DehydrationHooks
 
   /**
    * @constructor

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -99,7 +99,10 @@ import {
   Transaction,
   TransactionPromise,
   types as coreTypes,
-  UnboundRelationship
+  UnboundRelationship,
+  DehytrationHook,
+  DehydrationHooks,
+  HydatrationHooks
 } from './core/index.ts'
 // @deno-types=./bolt-connection/types/index.d.ts
 import { DirectConnectionProvider, RoutingConnectionProvider } from './bolt-connection/index.js'
@@ -518,6 +521,9 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  HydatrationHooks,
+  DehytrationHook,
+  DehydrationHooks
 }
 export default forExport

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -99,7 +99,10 @@ import {
   Transaction,
   TransactionPromise,
   types as coreTypes,
-  UnboundRelationship
+  UnboundRelationship,
+  DehytrationHook,
+  DehydrationHooks,
+  HydatrationHooks
 } from 'neo4j-driver-core'
 import { DirectConnectionProvider, RoutingConnectionProvider } from 'neo4j-driver-bolt-connection'
 
@@ -517,6 +520,9 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  HydatrationHooks,
+  DehytrationHook,
+  DehydrationHooks
 }
 export default forExport

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -89,7 +89,10 @@ import {
   notificationFilterMinimumSeverityLevel,
   AuthTokenManager,
   AuthTokenAndExpiration,
-  types as coreTypes
+  types as coreTypes,
+  DehytrationHook,
+  DehydrationHooks,
+  HydatrationHooks
 } from 'neo4j-driver-core'
 import {
   AuthToken,
@@ -378,7 +381,10 @@ export type {
   NotificationFilterDisabledCategory,
   NotificationFilterMinimumSeverityLevel,
   AuthTokenManager,
-  AuthTokenAndExpiration
+  AuthTokenAndExpiration,
+  DehytrationHook,
+  DehydrationHooks,
+  HydatrationHooks
 }
 
 export default forExport

--- a/packages/testkit-backend/src/request-handlers-rx.js
+++ b/packages/testkit-backend/src/request-handlers-rx.js
@@ -98,8 +98,8 @@ export function SessionClose (_, context, data, wire) {
 export function SessionRun (_, context, data, wire) {
   const { sessionId, cypher, timeout } = data
   const session = context.getSession(sessionId)
-  const params = context.binder.objectToNative(data.params)
-  const metadata = context.binder.objectToNative(data.txMeta)
+  const params = data.param
+  const metadata = data.txMeta
 
   let rxResult
   try {
@@ -138,7 +138,7 @@ export function ResultConsume (_, context, data, wire) {
 export function SessionBeginTransaction (_, context, data, wire) {
   const { sessionId, timeout } = data
   const session = context.getSession(sessionId)
-  const metadata = context.binder.objectToNative(data.txMeta)
+  const metadata = data.txMeta
 
   try {
     return session.beginTransaction({ metadata, timeout })
@@ -159,11 +159,6 @@ export function SessionBeginTransaction (_, context, data, wire) {
 export function TransactionRun (_, context, data, wire) {
   const { txId, cypher, params } = data
   const tx = context.getTx(txId)
-  if (params) {
-    for (const [key, value] of Object.entries(params)) {
-      params[key] = context.binder.cypherToNative(value)
-    }
-  }
 
   tx.tx.run(cypher, params)
     ._toObservable()
@@ -215,7 +210,7 @@ export function TransactionClose (_, context, data, wire) {
 export function SessionReadTransaction (_, context, data, wire) {
   const { sessionId } = data
   const session = context.getSession(sessionId)
-  const metadata = context.binder.objectToNative(data.txMeta)
+  const metadata = data.txMeta
 
   try {
     return session.executeRead(tx => {
@@ -235,7 +230,7 @@ export function SessionReadTransaction (_, context, data, wire) {
 export function SessionWriteTransaction (_, context, data, wire) {
   const { sessionId } = data
   const session = context.getSession(sessionId)
-  const metadata = context.binder.objectToNative(data.txMeta)
+  const metadata = data.txMeta
 
   try {
     return session.executeWrite(tx => {

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -40,6 +40,7 @@ export function NewDriver ({ neo4j }, context, data, wire) {
     userAgent,
     resolver,
     useBigInt: true,
+    dehydrationHooks: context.binder.dehydrationHooks,
     logging: neo4j.logging.console(context.logLevel || context.environmentLogLevel)
   }
   if ('encrypted' in data) {
@@ -165,8 +166,8 @@ export function SessionClose (_, context, data, wire) {
 export function SessionRun (_, context, data, wire) {
   const { sessionId, cypher, timeout } = data
   const session = context.getSession(sessionId)
-  const params = context.binder.objectToNative(data.params)
-  const metadata = context.binder.objectToNative(data.txMeta)
+  const params = data.params
+  const metadata = data.txMeta
 
   let result
   try {
@@ -241,7 +242,7 @@ export function ResultList (_, context, data, wire) {
 export function SessionReadTransaction (_, context, data, wire) {
   const { sessionId } = data
   const session = context.getSession(sessionId)
-  const metadata = context.binder.objectToNative(data.txMeta)
+  const metadata = data.txMeta
 
   return session
     .executeRead(
@@ -258,11 +259,6 @@ export function SessionReadTransaction (_, context, data, wire) {
 export function TransactionRun (_, context, data, wire) {
   const { txId, cypher, params } = data
   const tx = context.getTx(txId)
-  if (params) {
-    for (const [key, value] of Object.entries(params)) {
-      params[key] = context.binder.cypherToNative(value)
-    }
-  }
   const result = tx.tx.run(cypher, params)
   const id = context.addResult(result)
 
@@ -287,7 +283,7 @@ export function RetryableNegative (_, context, data, wire) {
 export function SessionBeginTransaction (_, context, data, wire) {
   const { sessionId, timeout } = data
   const session = context.getSession(sessionId)
-  const metadata = context.binder.objectToNative(data.txMeta)
+  const metadata = data.txMeta
 
   try {
     return session.beginTransaction({ metadata, timeout })
@@ -341,7 +337,7 @@ export function SessionLastBookmarks (_, context, data, wire) {
 export function SessionWriteTransaction (_, context, data, wire) {
   const { sessionId } = data
   const session = context.getSession(sessionId)
-  const metadata = context.binder.objectToNative(data.txMeta)
+  const metadata = data.txMeta
 
   return session
     .executeWrite(
@@ -654,11 +650,6 @@ export function ForcedRoutingTableUpdate (_, context, { driverId, database, book
 
 export function ExecuteQuery ({ neo4j }, context, { driverId, cypher, params, config }, wire) {
   const driver = context.getDriver(driverId)
-  if (params) {
-    for (const [key, value] of Object.entries(params)) {
-      params[key] = context.binder.cypherToNative(value)
-    }
-  }
   const configuration = {}
 
   if (config) {

--- a/packages/testkit-backend/src/summary-binder.js
+++ b/packages/testkit-backend/src/summary-binder.js
@@ -53,7 +53,7 @@ export function nativeToTestkitSummary (summary, binder) {
     database: summary.database.name,
     query: {
       text: summary.query.text,
-      parameters: binder.objectToCypher(summary.query.parameters)
+      parameters: summary.query.parameters
     },
     serverInfo: {
       agent: summary.server.agent,


### PR DESCRIPTION
This hooks enable driver users to globaly map their own data types to Neo4j driver types and vice-versa.

Example: 

```typescript 
import neo4j, { DateTime } from 'neo4j-driver'

const driver = neo4j.driver('neo4j://localhost:7687', neo4j.auth.basic('neo4j', 'password'), {
    // converting types came from the Datebase
    hydrationHooks: {
        // converting neo4j.DateTime to ISO String, 
        // but you might also convert to some library
        DateTime: (datetime) => datetime.toString()
    },
    // Converting type which user supplied to neo4j types
    dehydrationHooks: [
        // Define a dehydration hook from javascript Date
        {
            // Checking if the type is instance of Date
            isTypeInstance: maybeStdDate => maybeStdDate instanceof Date,
            // Called when a types is Date and need to converted/dehydrated
            dehydrate: stdDate => DateTime.fromStandardDate(stdDate)
        }
    ]
})

const { records: [record]  } = await driver.executeQuery("RETURN $now AS now", { now: new Date()})
console.log(`Now is ${record.get('now')}`)

await driver.close()
```

The driver is able to hydrate `Duration`, `LocalTime`, `LocalDateTime`, `Time`, `Date`, `DateTime` and `Point`. Other types will not able to be hydrated since they are used by driver internals and the hydration step occurs while data is being received from the socket. 

Dehydration, in other hand, can be done from any data type since it got converted to types which driver can understand. 

