### PR TITLE
Introduce Result, Record and Graph types mapping 

### DIFF
--- a/packages/core/src/graph-types.ts
+++ b/packages/core/src/graph-types.ts
@@ -18,6 +18,7 @@
  */
 import Integer from './integer'
 import { stringify } from './json'
+import { Rules, GenericConstructor, as } from './mapping.highlevel'
 
 type StandardDate = Date
 /**
@@ -82,6 +83,15 @@ class Node<T extends NumberOrInteger = Integer, P extends Properties = Propertie
      * @type {string}
      */
     this.elementId = _valueOrGetDefault(elementId, () => identity.toString())
+  }
+
+  as <T extends {} = Object>(rules: Rules): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    return as({
+      get: (key) => this.properties[key]
+    }, constructorOrRules, rules)
   }
 
   /**
@@ -199,6 +209,15 @@ class Relationship<T extends NumberOrInteger = Integer, P extends Properties = P
      * @type {string}
      */
     this.endNodeElementId = _valueOrGetDefault(endNodeElementId, () => end.toString())
+  }
+
+  as <T extends {} = Object>(rules: Rules): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    return as({
+      get: (key) => this.properties[key]
+    }, constructorOrRules, rules)
   }
 
   /**
@@ -320,6 +339,15 @@ class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Propert
       start.elementId,
       end.elementId
     )
+  }
+
+  as <T extends {} = Object>(rules: Rules): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    return as({
+      get: (key) => this.properties[key]
+    }, constructorOrRules, rules)
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,6 +94,8 @@ import * as types from './types'
 import * as json from './json'
 import resultTransformers, { ResultTransformer } from './result-transformers'
 import * as internal from './internal' // todo: removed afterwards
+import { Rule, Rules } from './mapping.highlevel'
+import { RulesFactories } from './mapping.rulesfactories'
 
 /**
  * Object containing string constants representing predefined {@link Neo4jError} codes.
@@ -171,7 +173,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  RulesFactories
 }
 
 export {
@@ -240,7 +243,8 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  RulesFactories
 }
 
 export type {
@@ -265,7 +269,9 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  Rule,
+  Rules
 }
 
 export default forExport

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,7 +94,7 @@ import * as types from './types'
 import * as json from './json'
 import resultTransformers, { ResultTransformer } from './result-transformers'
 import * as internal from './internal' // todo: removed afterwards
-import { Rule, Rules } from './mapping.highlevel'
+import { Rule, Rules, mapping } from './mapping.highlevel'
 import { RulesFactories } from './mapping.rulesfactories'
 
 /**
@@ -174,7 +174,8 @@ const forExport = {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  RulesFactories
+  RulesFactories,
+  mapping
 }
 
 export {
@@ -244,7 +245,8 @@ export {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  RulesFactories
+  RulesFactories,
+  mapping
 }
 
 export type {

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type GenericConstructor<T extends {}> = new (...args: any[]) => T
+
+export interface Rule {
+  optional?: boolean
+  from?: string
+  convert?: (recordValue: any, field: string) => any
+  validate?: (recordValue: any, field: string) => void
+}
+
+export type Rules = Record<string, Rule>
+
+interface Gettable { get: <V>(key: string) => V }
+
+export function as <T extends {} = Object> (gettable: Gettable, constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+  const GenericConstructor = typeof constructorOrRules === 'function' ? constructorOrRules : Object
+  const theRules = typeof constructorOrRules === 'object' ? constructorOrRules : rules
+  const vistedKeys: string[] = []
+
+  const obj = new GenericConstructor()
+
+  for (const [key, rule] of Object.entries(theRules ?? {})) {
+    vistedKeys.push(key)
+    _apply(gettable, obj, key, rule)
+  }
+
+  for (const key of Object.getOwnPropertyNames(obj)) {
+    if (!vistedKeys.includes(key)) {
+      _apply(gettable, obj, key, theRules?.[key])
+    }
+  }
+
+  return obj as unknown as T
+}
+
+function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: Rule): void {
+  const value = gettable.get(rule?.from ?? key)
+  const field = `${obj.constructor.name}#${key}`
+  const processedValue = valueAs(value, field, rule)
+
+  // @ts-expect-error
+  obj[key] = processedValue ?? obj[key]
+}
+
+export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
+  if (rule?.optional === true && value == null) {
+    return value
+  }
+
+  if (typeof rule?.validate === 'function') {
+    rule.validate(value, field)
+  }
+
+  return ((rule?.convert) != null) ? rule.convert(value, field) : value
+}

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Rule, valueAs } from './mapping.highlevel'
+
+import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
+import { isPoint } from './spatial-types'
+import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
+
+export const RulesFactories = Object.freeze({
+  asString (rule?: Rule): Rule {
+    return {
+      validate: (value, field) => {
+        if (typeof value !== 'string') {
+          throw new TypeError(`${field} should be a string but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asNumber (rule?: Rule & { acceptBigInt?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (typeof value !== 'number' && (rule?.acceptBigInt !== true || typeof value !== 'bigint')) {
+          throw new TypeError(`${field} should be a number but received ${typeof value}`)
+        }
+      },
+      convert: (value: number | bigint) => {
+        if (typeof value === 'bigint') {
+          return Number(value)
+        }
+        return value
+      },
+      ...rule
+    }
+  },
+  asBigInt (rule?: Rule & { acceptNumber?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number')) {
+          throw new TypeError(`${field} should be a bigint but received ${typeof value}`)
+        }
+      },
+      convert: (value: number | bigint) => {
+        if (typeof value === 'number') {
+          return BigInt(value)
+        }
+        return value
+      },
+      ...rule
+    }
+  },
+  asNode (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isNode(value)) {
+          throw new TypeError(`${field} should be a Node but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asRelationship (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isRelationship(value)) {
+          throw new TypeError(`${field} should be a Relationship but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asUnboundRelationship (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isUnboundRelationship(value)) {
+          throw new TypeError(`${field} should be a UnboundRelationship but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asPath (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isPath(value)) {
+          throw new TypeError(`${field} should be a Path but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asPoint (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isPoint(value)) {
+          throw new TypeError(`${field} should be a Point but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asDuration (rule?: Rule & { toString?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isDuration(value)) {
+          throw new TypeError(`${field} should be a Duration but received ${typeof value}`)
+        }
+      },
+      convert: (value: Duration) => rule?.toString === true ? value.toString() : value,
+      ...rule
+    }
+  },
+  asLocalTime (rule?: Rule & { toString?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isLocalTime(value)) {
+          throw new TypeError(`${field} should be a LocalTime but received ${typeof value}`)
+        }
+      },
+      convert: (value: LocalTime) => rule?.toString === true ? value.toString() : value,
+      ...rule
+    }
+  },
+  asTime (rule?: Rule & { toString?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isTime(value)) {
+          throw new TypeError(`${field} should be a Time but received ${typeof value}`)
+        }
+      },
+      convert: (value: Time) => rule?.toString === true ? value.toString() : value,
+      ...rule
+    }
+  },
+  asDate (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isDate(value)) {
+          throw new TypeError(`${field} should be a Date but received ${typeof value}`)
+        }
+      },
+      convert: (value: Date) => convertStdDate(value, rule),
+      ...rule
+    }
+  },
+  asLocalDateTime (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isLocalDateTime(value)) {
+          throw new TypeError(`${field} should be a LocalDateTime but received ${typeof value}`)
+        }
+      },
+      convert: (value: LocalDateTime) => convertStdDate(value, rule),
+      ...rule
+    }
+  },
+  asDateTime (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isDateTime(value)) {
+          throw new TypeError(`${field} should be a DateTime but received ${typeof value}`)
+        }
+      },
+      convert: (value: DateTime) => convertStdDate(value, rule),
+      ...rule
+    }
+  },
+  asList (rule?: Rule & { apply?: Rule }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!Array.isArray(value)) {
+          throw new TypeError(`${field} should be a string but received ${typeof value}`)
+        }
+      },
+      convert: (list: any[], field: string) => {
+        if (rule?.apply != null) {
+          return list.map((value, index) => valueAs(value, `${field}[${index}]`, rule.apply))
+        }
+        return list
+      },
+      ...rule
+    }
+  }
+})
+
+interface ConvertableToStdDateOrStr { toStandardDate: () => StandardDate, toString: () => string }
+
+function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { toString?: boolean, toStandardDate?: boolean }): string | V | StandardDate {
+  if (rule != null) {
+    if (rule.toString === true) {
+      return value.toString()
+    } else if (rule.toStandardDate === true) {
+      return value.toStandardDate()
+    }
+  }
+  return value
+}

--- a/packages/core/src/record.ts
+++ b/packages/core/src/record.ts
@@ -18,6 +18,7 @@
  */
 
 import { newError } from './error'
+import { Rules, GenericConstructor, as } from './mapping.highlevel'
 
 type RecordShape<Key extends PropertyKey = PropertyKey, Value = any> = {
   [K in Key]: Value
@@ -132,6 +133,13 @@ class Record<
     }
 
     return resultArray
+  }
+
+  as <T extends {} = Object>(rules: Rules): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    return as(this, constructorOrRules, rules)
   }
 
   /**

--- a/packages/core/src/result-transformers.ts
+++ b/packages/core/src/result-transformers.ts
@@ -22,6 +22,7 @@ import Result from './result'
 import EagerResult from './result-eager'
 import ResultSummary from './result-summary'
 import { newError } from './error'
+import { GenericConstructor, Rules } from './mapping.highlevel'
 
 async function createEagerResultFromResult<Entries extends RecordShape> (result: Result): Promise<EagerResult<Entries>> {
   const { summary, records } = await result
@@ -163,6 +164,12 @@ class ResultTransformers {
         })
       })
     }
+  }
+
+  hydratedResultTransformer <T extends {} = Object>(rules: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }>
+  hydratedResultTransformer <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }>
+  hydratedResultTransformer <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }> {
+    return async result => await result.as(constructorOrRules as unknown as GenericConstructor<T>, rules)
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/core/graph-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/graph-types.ts
@@ -20,7 +20,6 @@ import Integer from './integer.ts'
 import { stringify } from './json.ts'
 import { Rules, GenericConstructor, as } from './mapping.highlevel.ts'
 
-
 type StandardDate = Date
 /**
  * @typedef {number | Integer | bigint} NumberOrInteger
@@ -92,7 +91,7 @@ class Node<T extends NumberOrInteger = Integer, P extends Properties = Propertie
   as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
     return as({
       get: (key) => this.properties[key]
-    }, constructorOrRules, rules) 
+    }, constructorOrRules, rules)
   }
 
   /**
@@ -218,7 +217,7 @@ class Relationship<T extends NumberOrInteger = Integer, P extends Properties = P
   as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
     return as({
       get: (key) => this.properties[key]
-    }, constructorOrRules, rules) 
+    }, constructorOrRules, rules)
   }
 
   /**
@@ -348,7 +347,7 @@ class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Propert
   as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
     return as({
       get: (key) => this.properties[key]
-    }, constructorOrRules, rules) 
+    }, constructorOrRules, rules)
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/graph-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/graph-types.ts
@@ -18,6 +18,8 @@
  */
 import Integer from './integer.ts'
 import { stringify } from './json.ts'
+import { Rules, GenericConstructor, as } from './mapping.highlevel.ts'
+
 
 type StandardDate = Date
 /**
@@ -82,6 +84,15 @@ class Node<T extends NumberOrInteger = Integer, P extends Properties = Propertie
      * @type {string}
      */
     this.elementId = _valueOrGetDefault(elementId, () => identity.toString())
+  }
+
+  as <T extends {} = Object>(rules: Rules): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    return as({
+      get: (key) => this.properties[key]
+    }, constructorOrRules, rules) 
   }
 
   /**
@@ -199,6 +210,15 @@ class Relationship<T extends NumberOrInteger = Integer, P extends Properties = P
      * @type {string}
      */
     this.endNodeElementId = _valueOrGetDefault(endNodeElementId, () => end.toString())
+  }
+
+  as <T extends {} = Object>(rules: Rules): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    return as({
+      get: (key) => this.properties[key]
+    }, constructorOrRules, rules) 
   }
 
   /**
@@ -320,6 +340,15 @@ class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Propert
       start.elementId,
       end.elementId
     )
+  }
+
+  as <T extends {} = Object>(rules: Rules): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    return as({
+      get: (key) => this.properties[key]
+    }, constructorOrRules, rules) 
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/index.ts
+++ b/packages/neo4j-driver-deno/lib/core/index.ts
@@ -94,6 +94,8 @@ import * as types from './types.ts'
 import * as json from './json.ts'
 import resultTransformers, { ResultTransformer } from './result-transformers.ts'
 import * as internal from './internal/index.ts'
+import { Rule, Rules } from './mapping.highlevel.ts'
+import { RulesFactories } from './mapping.rulesfactories.ts'
 
 /**
  * Object containing string constants representing predefined {@link Neo4jError} codes.
@@ -171,7 +173,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  RulesFactories
 }
 
 export {
@@ -240,7 +243,8 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  RulesFactories
 }
 
 export type {
@@ -265,7 +269,9 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  Rule,
+  Rules
 }
 
 export default forExport

--- a/packages/neo4j-driver-deno/lib/core/index.ts
+++ b/packages/neo4j-driver-deno/lib/core/index.ts
@@ -94,7 +94,7 @@ import * as types from './types.ts'
 import * as json from './json.ts'
 import resultTransformers, { ResultTransformer } from './result-transformers.ts'
 import * as internal from './internal/index.ts'
-import { Rule, Rules } from './mapping.highlevel.ts'
+import { Rule, Rules, mapping } from './mapping.highlevel.ts'
 import { RulesFactories } from './mapping.rulesfactories.ts'
 
 /**
@@ -174,7 +174,8 @@ const forExport = {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  RulesFactories
+  RulesFactories,
+  mapping
 }
 
 export {
@@ -244,7 +245,8 @@ export {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  RulesFactories
+  RulesFactories,
+  mapping
 }
 
 export type {

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -30,11 +30,11 @@ export type Rules = Record<string, Rule>
 const rulesRegistry: Record<string, Rules> = {}
 
 export function register <T extends {} = Object> (constructor: GenericConstructor<T>, rules: Rules): void {
-    rulesRegistry[constructor.toString()] = rules
+  rulesRegistry[constructor.toString()] = rules
 }
 
 export const mapping = {
-    register
+  register
 }
 
 interface Gettable { get: <V>(key: string) => V }
@@ -80,12 +80,11 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
 
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
-function getRules<T extends {} = Object>(constructorOrRules: Rules | GenericConstructor<T>, rules: Rules | undefined): Rules | undefined {
-    const rulesDefined = typeof constructorOrRules === 'object' ? constructorOrRules : rules
-    if (rulesDefined != null) {
-        return rulesDefined
-    }
-    
-    return typeof constructorOrRules !== 'object' ? rulesRegistry[constructorOrRules.toString()] : undefined
-}
+function getRules<T extends {} = Object> (constructorOrRules: Rules | GenericConstructor<T>, rules: Rules | undefined): Rules | undefined {
+  const rulesDefined = typeof constructorOrRules === 'object' ? constructorOrRules : rules
+  if (rulesDefined != null) {
+    return rulesDefined
+  }
 
+  return typeof constructorOrRules !== 'object' ? rulesRegistry[constructorOrRules.toString()] : undefined
+}

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type GenericConstructor<T extends {}> = new (...args: any[]) => T
+
+export interface Rule {
+    optional?: boolean,
+    from?: string,
+    convert?: (recordValue: any, field: string) => any
+    validate?: (recordValue: any, field: string) => void 
+}
+
+export type Rules = Record<string, Rule>
+
+type Gettable = { get<V>(key: string): V }
+
+
+export function as <T extends {} = Object>(gettable: Gettable , constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    const GenericConstructor = typeof constructorOrRules === 'function' ? constructorOrRules : Object
+    const theRules = typeof constructorOrRules === 'object' ? constructorOrRules : rules
+    const vistedKeys: string[] = []
+
+    const obj = new GenericConstructor
+
+    for (const [key, rule] of Object.entries(theRules ?? {})) {
+        vistedKeys.push(key)
+        _apply(gettable, obj, key, rule)
+    }
+
+    for (const key of Object.getOwnPropertyNames(obj)) {
+        if (!vistedKeys.includes(key)) {
+            _apply(gettable, obj, key, theRules?.[key])
+        }
+    }
+    
+    return obj as unknown as T
+} 
+
+
+function _apply<T extends {}>(gettable: Gettable, obj: T, key: string, rule?: Rule): void {
+    const value = gettable.get(rule?.from ?? key)
+    const field = `${obj.constructor.name}#${key}`
+    const processedValue = valueAs(value, field, rule)
+
+    // @ts-ignore
+    obj[key] = processedValue ?? obj[key]
+}
+
+export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
+    if (rule?.optional === true && value == null) {
+        return value
+    }
+    
+    if (typeof rule?.validate === 'function') {
+        rule.validate(value, field)
+    }
+
+    return rule?.convert ? rule.convert(value, field) : value
+}
+
+

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Rule, valueAs } from './mapping.highlevel.ts'
+
+
+import {  StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
+import { isPoint } from './spatial-types.ts'
+import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
+
+
+export const RulesFactories = Object.freeze({
+    asString (rule?: Rule): Rule {
+        return {
+            validate: (value, field) => {
+                if (typeof value !== 'string') {
+                    throw new TypeError(`${field} should be a string but received ${typeof value}`)
+                }
+            },
+            ...rule
+        }
+    },
+    asNumber (rule?: Rule & { acceptBigInt?: boolean }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (typeof value !== 'number' && (rule?.acceptBigInt !== true || typeof value !== 'bigint')) {
+                    throw new TypeError(`${field} should be a number but received ${typeof value}`)
+                }
+            },
+            convert: (value: number | bigint) => {
+                if (typeof value === 'bigint') {
+                    return Number(value)
+                }
+                return value
+            },
+            ...rule
+        }
+    },
+    asBigInt (rule?: Rule & { acceptNumber?: boolean }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number')) {
+                    throw new TypeError(`${field} should be a bigint but received ${typeof value}`)
+                }
+            },
+            convert: (value: number | bigint) => {
+                if (typeof value === 'number') {
+                    return BigInt(value)
+                }
+                return value
+            },
+            ...rule
+        }
+    },
+    asNode (rule?: Rule) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isNode(value)) {
+                    throw new TypeError(`${field} should be a Node but received ${typeof value}`)
+                }
+            },
+            ...rule
+        }
+    },
+    asRelationship (rule?: Rule) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isRelationship(value)) {
+                    throw new TypeError(`${field} should be a Relationship but received ${typeof value}`)
+                }
+            },
+            ...rule
+        }
+    },
+    asUnboundRelationship (rule?: Rule) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isUnboundRelationship(value)) {
+                    throw new TypeError(`${field} should be a UnboundRelationship but received ${typeof value}`)
+                }
+            },
+            ...rule
+        }
+    },
+    asPath (rule?: Rule) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isPath(value)) {
+                    throw new TypeError(`${field} should be a Path but received ${typeof value}`)
+                }
+            },
+            ...rule
+        }
+    },
+    asPoint (rule?: Rule) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isPoint(value)) {
+                    throw new TypeError(`${field} should be a Point but received ${typeof value}`)
+                }
+            },
+            ...rule
+        }
+    },
+    asDuration (rule?: Rule & { toString?: boolean }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isDuration(value)) {
+                    throw new TypeError(`${field} should be a Duration but received ${typeof value}`)
+                }
+            },
+            convert: (value: Duration) => rule?.toString === true ? value.toString() : value,
+            ...rule
+        }
+    },
+    asLocalTime (rule?: Rule & { toString?: boolean }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isLocalTime(value)) {
+                    throw new TypeError(`${field} should be a LocalTime but received ${typeof value}`)
+                }
+            },
+            convert: (value: LocalTime) => rule?.toString === true ? value.toString() : value,
+            ...rule
+        }
+    },
+    asTime (rule?: Rule & { toString?: boolean }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isTime(value)) {
+                    throw new TypeError(`${field} should be a Time but received ${typeof value}`)
+                }
+            },
+            convert: (value: Time) => rule?.toString === true ? value.toString() : value,
+            ...rule
+        }
+    },
+    asDate (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isDate(value)) {
+                    throw new TypeError(`${field} should be a Date but received ${typeof value}`)
+                }
+            },
+            convert: (value: Date) => convertStdDate(value, rule),
+            ...rule
+        }
+    },
+    asLocalDateTime (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isLocalDateTime(value)) {
+                    throw new TypeError(`${field} should be a LocalDateTime but received ${typeof value}`)
+                }
+            },
+            convert: (value: LocalDateTime) => convertStdDate(value, rule),
+            ...rule
+        }
+    },
+    asDateTime (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!isDateTime(value)) {
+                    throw new TypeError(`${field} should be a DateTime but received ${typeof value}`)
+                }
+            },
+            convert: (value: DateTime) => convertStdDate(value, rule),
+            ...rule
+        }
+    },
+    asList (rule?: Rule & { apply?: Rule }) {
+        return {
+            validate: (value: any, field: string) => {
+                if (!Array.isArray(value)) {
+                    throw new TypeError(`${field} should be a string but received ${typeof value}`)
+                }
+            },
+            convert: (list: any[], field: string) => {
+                if (rule?.apply != null) {
+                    return list.map((value, index) => valueAs(value, `${field}[${index}]`, rule.apply))
+                }
+                return list
+            },
+            ...rule
+        }
+
+    }
+})
+
+type ConvertableToStdDateOrStr = { toStandardDate: () => StandardDate, toString: () => string }
+
+function convertStdDate<V extends ConvertableToStdDateOrStr>(value: V, rule?: { toString?: boolean, toStandardDate?: boolean }):string | V | StandardDate {
+    if (rule != null) {
+        if (rule.toString === true) {
+            return value.toString()
+        } else if (rule.toStandardDate === true) {
+            return value.toStandardDate()
+        }
+    }
+    return value
+}

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -19,199 +19,196 @@
 
 import { Rule, valueAs } from './mapping.highlevel.ts'
 
-
-import {  StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
+import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
 
-
 export const RulesFactories = Object.freeze({
-    asString (rule?: Rule): Rule {
-        return {
-            validate: (value, field) => {
-                if (typeof value !== 'string') {
-                    throw new TypeError(`${field} should be a string but received ${typeof value}`)
-                }
-            },
-            ...rule
+  asString (rule?: Rule): Rule {
+    return {
+      validate: (value, field) => {
+        if (typeof value !== 'string') {
+          throw new TypeError(`${field} should be a string but received ${typeof value}`)
         }
-    },
-    asNumber (rule?: Rule & { acceptBigInt?: boolean }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (typeof value !== 'number' && (rule?.acceptBigInt !== true || typeof value !== 'bigint')) {
-                    throw new TypeError(`${field} should be a number but received ${typeof value}`)
-                }
-            },
-            convert: (value: number | bigint) => {
-                if (typeof value === 'bigint') {
-                    return Number(value)
-                }
-                return value
-            },
-            ...rule
-        }
-    },
-    asBigInt (rule?: Rule & { acceptNumber?: boolean }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number')) {
-                    throw new TypeError(`${field} should be a bigint but received ${typeof value}`)
-                }
-            },
-            convert: (value: number | bigint) => {
-                if (typeof value === 'number') {
-                    return BigInt(value)
-                }
-                return value
-            },
-            ...rule
-        }
-    },
-    asNode (rule?: Rule) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isNode(value)) {
-                    throw new TypeError(`${field} should be a Node but received ${typeof value}`)
-                }
-            },
-            ...rule
-        }
-    },
-    asRelationship (rule?: Rule) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isRelationship(value)) {
-                    throw new TypeError(`${field} should be a Relationship but received ${typeof value}`)
-                }
-            },
-            ...rule
-        }
-    },
-    asUnboundRelationship (rule?: Rule) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isUnboundRelationship(value)) {
-                    throw new TypeError(`${field} should be a UnboundRelationship but received ${typeof value}`)
-                }
-            },
-            ...rule
-        }
-    },
-    asPath (rule?: Rule) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isPath(value)) {
-                    throw new TypeError(`${field} should be a Path but received ${typeof value}`)
-                }
-            },
-            ...rule
-        }
-    },
-    asPoint (rule?: Rule) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isPoint(value)) {
-                    throw new TypeError(`${field} should be a Point but received ${typeof value}`)
-                }
-            },
-            ...rule
-        }
-    },
-    asDuration (rule?: Rule & { toString?: boolean }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isDuration(value)) {
-                    throw new TypeError(`${field} should be a Duration but received ${typeof value}`)
-                }
-            },
-            convert: (value: Duration) => rule?.toString === true ? value.toString() : value,
-            ...rule
-        }
-    },
-    asLocalTime (rule?: Rule & { toString?: boolean }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isLocalTime(value)) {
-                    throw new TypeError(`${field} should be a LocalTime but received ${typeof value}`)
-                }
-            },
-            convert: (value: LocalTime) => rule?.toString === true ? value.toString() : value,
-            ...rule
-        }
-    },
-    asTime (rule?: Rule & { toString?: boolean }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isTime(value)) {
-                    throw new TypeError(`${field} should be a Time but received ${typeof value}`)
-                }
-            },
-            convert: (value: Time) => rule?.toString === true ? value.toString() : value,
-            ...rule
-        }
-    },
-    asDate (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isDate(value)) {
-                    throw new TypeError(`${field} should be a Date but received ${typeof value}`)
-                }
-            },
-            convert: (value: Date) => convertStdDate(value, rule),
-            ...rule
-        }
-    },
-    asLocalDateTime (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isLocalDateTime(value)) {
-                    throw new TypeError(`${field} should be a LocalDateTime but received ${typeof value}`)
-                }
-            },
-            convert: (value: LocalDateTime) => convertStdDate(value, rule),
-            ...rule
-        }
-    },
-    asDateTime (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!isDateTime(value)) {
-                    throw new TypeError(`${field} should be a DateTime but received ${typeof value}`)
-                }
-            },
-            convert: (value: DateTime) => convertStdDate(value, rule),
-            ...rule
-        }
-    },
-    asList (rule?: Rule & { apply?: Rule }) {
-        return {
-            validate: (value: any, field: string) => {
-                if (!Array.isArray(value)) {
-                    throw new TypeError(`${field} should be a string but received ${typeof value}`)
-                }
-            },
-            convert: (list: any[], field: string) => {
-                if (rule?.apply != null) {
-                    return list.map((value, index) => valueAs(value, `${field}[${index}]`, rule.apply))
-                }
-                return list
-            },
-            ...rule
-        }
-
+      },
+      ...rule
     }
+  },
+  asNumber (rule?: Rule & { acceptBigInt?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (typeof value !== 'number' && (rule?.acceptBigInt !== true || typeof value !== 'bigint')) {
+          throw new TypeError(`${field} should be a number but received ${typeof value}`)
+        }
+      },
+      convert: (value: number | bigint) => {
+        if (typeof value === 'bigint') {
+          return Number(value)
+        }
+        return value
+      },
+      ...rule
+    }
+  },
+  asBigInt (rule?: Rule & { acceptNumber?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number')) {
+          throw new TypeError(`${field} should be a bigint but received ${typeof value}`)
+        }
+      },
+      convert: (value: number | bigint) => {
+        if (typeof value === 'number') {
+          return BigInt(value)
+        }
+        return value
+      },
+      ...rule
+    }
+  },
+  asNode (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isNode(value)) {
+          throw new TypeError(`${field} should be a Node but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asRelationship (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isRelationship(value)) {
+          throw new TypeError(`${field} should be a Relationship but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asUnboundRelationship (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isUnboundRelationship(value)) {
+          throw new TypeError(`${field} should be a UnboundRelationship but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asPath (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isPath(value)) {
+          throw new TypeError(`${field} should be a Path but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asPoint (rule?: Rule) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isPoint(value)) {
+          throw new TypeError(`${field} should be a Point but received ${typeof value}`)
+        }
+      },
+      ...rule
+    }
+  },
+  asDuration (rule?: Rule & { toString?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isDuration(value)) {
+          throw new TypeError(`${field} should be a Duration but received ${typeof value}`)
+        }
+      },
+      convert: (value: Duration) => rule?.toString === true ? value.toString() : value,
+      ...rule
+    }
+  },
+  asLocalTime (rule?: Rule & { toString?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isLocalTime(value)) {
+          throw new TypeError(`${field} should be a LocalTime but received ${typeof value}`)
+        }
+      },
+      convert: (value: LocalTime) => rule?.toString === true ? value.toString() : value,
+      ...rule
+    }
+  },
+  asTime (rule?: Rule & { toString?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isTime(value)) {
+          throw new TypeError(`${field} should be a Time but received ${typeof value}`)
+        }
+      },
+      convert: (value: Time) => rule?.toString === true ? value.toString() : value,
+      ...rule
+    }
+  },
+  asDate (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isDate(value)) {
+          throw new TypeError(`${field} should be a Date but received ${typeof value}`)
+        }
+      },
+      convert: (value: Date) => convertStdDate(value, rule),
+      ...rule
+    }
+  },
+  asLocalDateTime (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isLocalDateTime(value)) {
+          throw new TypeError(`${field} should be a LocalDateTime but received ${typeof value}`)
+        }
+      },
+      convert: (value: LocalDateTime) => convertStdDate(value, rule),
+      ...rule
+    }
+  },
+  asDateTime (rule?: Rule & { toString?: boolean, toStandardDate?: boolean }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!isDateTime(value)) {
+          throw new TypeError(`${field} should be a DateTime but received ${typeof value}`)
+        }
+      },
+      convert: (value: DateTime) => convertStdDate(value, rule),
+      ...rule
+    }
+  },
+  asList (rule?: Rule & { apply?: Rule }) {
+    return {
+      validate: (value: any, field: string) => {
+        if (!Array.isArray(value)) {
+          throw new TypeError(`${field} should be a string but received ${typeof value}`)
+        }
+      },
+      convert: (list: any[], field: string) => {
+        if (rule?.apply != null) {
+          return list.map((value, index) => valueAs(value, `${field}[${index}]`, rule.apply))
+        }
+        return list
+      },
+      ...rule
+    }
+  }
 })
 
-type ConvertableToStdDateOrStr = { toStandardDate: () => StandardDate, toString: () => string }
+interface ConvertableToStdDateOrStr { toStandardDate: () => StandardDate, toString: () => string }
 
-function convertStdDate<V extends ConvertableToStdDateOrStr>(value: V, rule?: { toString?: boolean, toStandardDate?: boolean }):string | V | StandardDate {
-    if (rule != null) {
-        if (rule.toString === true) {
-            return value.toString()
-        } else if (rule.toStandardDate === true) {
-            return value.toStandardDate()
-        }
+function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { toString?: boolean, toStandardDate?: boolean }): string | V | StandardDate {
+  if (rule != null) {
+    if (rule.toString === true) {
+      return value.toString()
+    } else if (rule.toStandardDate === true) {
+      return value.toStandardDate()
     }
-    return value
+  }
+  return value
 }

--- a/packages/neo4j-driver-deno/lib/core/record.ts
+++ b/packages/neo4j-driver-deno/lib/core/record.ts
@@ -18,6 +18,7 @@
  */
 
 import { newError } from './error.ts'
+import { Rules, GenericConstructor, as } from './mapping.highlevel.ts'
 
 type RecordShape<Key extends PropertyKey = PropertyKey, Value = any> = {
   [K in Key]: Value
@@ -132,6 +133,13 @@ class Record<
     }
 
     return resultArray
+  }
+
+  as <T extends {} = Object>(rules: Rules): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
+    return as(this, constructorOrRules, rules) 
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/record.ts
+++ b/packages/neo4j-driver-deno/lib/core/record.ts
@@ -139,7 +139,7 @@ class Record<
   as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
   as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): T
   as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): T {
-    return as(this, constructorOrRules, rules) 
+    return as(this, constructorOrRules, rules)
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/result-transformers.ts
+++ b/packages/neo4j-driver-deno/lib/core/result-transformers.ts
@@ -22,6 +22,7 @@ import Result from './result.ts'
 import EagerResult from './result-eager.ts'
 import ResultSummary from './result-summary.ts'
 import { newError } from './error.ts'
+import { GenericConstructor, Rules } from './mapping.highlevel.ts'
 
 async function createEagerResultFromResult<Entries extends RecordShape> (result: Result): Promise<EagerResult<Entries>> {
   const { summary, records } = await result
@@ -163,6 +164,12 @@ class ResultTransformers {
         })
       })
     }
+  }
+
+  hydratedResultTransformer <T extends {} = Object>(rules: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }>
+  hydratedResultTransformer <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }>
+  hydratedResultTransformer <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }> {
+      return result => result.as(constructorOrRules as unknown as GenericConstructor<T>, rules)
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/core/result-transformers.ts
+++ b/packages/neo4j-driver-deno/lib/core/result-transformers.ts
@@ -169,7 +169,7 @@ class ResultTransformers {
   hydratedResultTransformer <T extends {} = Object>(rules: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }>
   hydratedResultTransformer <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }>
   hydratedResultTransformer <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }> {
-      return result => result.as(constructorOrRules as unknown as GenericConstructor<T>, rules)
+    return async result => await result.as(constructorOrRules as unknown as GenericConstructor<T>, rules)
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -25,6 +25,7 @@ import { Query, PeekableAsyncIterator } from './types.ts'
 import { observer, util, connectionHolder } from './internal/index.ts'
 import { newError, PROTOCOL_ERROR } from './error.ts'
 import { NumberOrInteger } from './graph-types.ts'
+import { GenericConstructor, Rules } from './mapping.highlevel.ts'
 
 const { EMPTY_CONNECTION_HOLDER } = connectionHolder
 
@@ -151,6 +152,13 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
     this._watermarks = watermarks
   }
 
+  as <T extends {} = Object>(rules: Rules): Promise<{ records: T[], summary: ResultSummary }>
+  as <T extends {} = Object>(genericConstructor: GenericConstructor<T>, rules?: Rules): Promise<{ records: T[], summary: ResultSummary }>
+  as <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): Promise<{ records: T[], summary: ResultSummary }> {
+    // @ts-expect-error
+    return this._getOrCreatePromise(r => r.as(constructorOrRules, rules))
+  }
+
   /**
    * Returns a promise for the field keys.
    *
@@ -212,13 +220,13 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
    * @private
    * @return {Promise} new Promise.
    */
-  private _getOrCreatePromise (): Promise<QueryResult<R>> {
+  private _getOrCreatePromise<O = Record> (mapper: (r: Record) => O = r => r  as unknown as R ): Promise<QueryResult<R>> {
     if (this._p == null) {
       this._p = new Promise((resolve, reject) => {
         const records: Array<Record<R>> = []
         const observer = {
           onNext: (record: Record<R>) => {
-            records.push(record)
+            records.push(mapper(record) as unknown as Record)
           },
           onCompleted: (summary: ResultSummary) => {
             resolve({ records, summary })

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -220,7 +220,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
    * @private
    * @return {Promise} new Promise.
    */
-  private _getOrCreatePromise<O = Record> (mapper: (r: Record) => O = r => r  as unknown as R ): Promise<QueryResult<R>> {
+  private _getOrCreatePromise<O = Record> (mapper: (r: Record) => O = r => r as unknown as R): Promise<QueryResult<R>> {
     if (this._p == null) {
       this._p = new Promise((resolve, reject) => {
         const records: Array<Record<R>> = []

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -102,7 +102,8 @@ import {
   UnboundRelationship,
   Rule,
   Rules,
-  RulesFactories
+  RulesFactories,
+  mapping
 } from './core/index.ts'
 // @deno-types=./bolt-connection/types/index.d.ts
 import { DirectConnectionProvider, RoutingConnectionProvider } from './bolt-connection/index.js'
@@ -430,7 +431,8 @@ const forExport = {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  RulesFactories
+  RulesFactories,
+  mapping
 }
 
 export {
@@ -498,7 +500,8 @@ export {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  RulesFactories
+  RulesFactories,
+  mapping
 }
 export type {
   QueryResult,

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -99,7 +99,10 @@ import {
   Transaction,
   TransactionPromise,
   types as coreTypes,
-  UnboundRelationship
+  UnboundRelationship,
+  Rule,
+  Rules,
+  RulesFactories
 } from './core/index.ts'
 // @deno-types=./bolt-connection/types/index.d.ts
 import { DirectConnectionProvider, RoutingConnectionProvider } from './bolt-connection/index.js'
@@ -426,7 +429,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  RulesFactories
 }
 
 export {
@@ -493,7 +497,8 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  RulesFactories
 }
 export type {
   QueryResult,
@@ -518,6 +523,8 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  Rule,
+  Rules
 }
 export default forExport

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -99,7 +99,10 @@ import {
   Transaction,
   TransactionPromise,
   types as coreTypes,
-  UnboundRelationship
+  UnboundRelationship,
+  Rule,
+  Rules,
+  RulesFactories
 } from 'neo4j-driver-core'
 import { DirectConnectionProvider, RoutingConnectionProvider } from 'neo4j-driver-bolt-connection'
 
@@ -425,7 +428,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  RulesFactories
 }
 
 export {
@@ -492,7 +496,8 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  RulesFactories
 }
 export type {
   QueryResult,
@@ -517,6 +522,8 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  Rule,
+  Rules
 }
 export default forExport

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -102,7 +102,8 @@ import {
   UnboundRelationship,
   Rule,
   Rules,
-  RulesFactories
+  RulesFactories,
+  mapping
 } from 'neo4j-driver-core'
 import { DirectConnectionProvider, RoutingConnectionProvider } from 'neo4j-driver-bolt-connection'
 
@@ -429,7 +430,8 @@ const forExport = {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  RulesFactories
+  RulesFactories,
+  mapping
 }
 
 export {
@@ -497,7 +499,8 @@ export {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  RulesFactories
+  RulesFactories,
+  mapping
 }
 export type {
   QueryResult,

--- a/packages/testkit-backend/package.json
+++ b/packages/testkit-backend/package.json
@@ -15,7 +15,8 @@
     "start::deno": "deno run --allow-read --allow-write --allow-net --allow-env --allow-sys --allow-run deno/index.ts",
     "clean": "rm -fr node_modules public/index.js",
     "prepare": "npm run build",
-    "node": "node"
+    "node": "node",
+    "deno": "deno run --allow-read --allow-write --allow-net --allow-env --allow-sys --allow-run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
⚠️ This a preview feature

## Getting Started

Let's say we have the following Cypher query:

```cypher
 MATCH (p:Person)-[:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
 WHERE id(p) <> id(c) 
 RETURN p AS person, m AS movie, COLLECT(c) AS costars
```

and we are going to load each of the records into Typescript objects like these:

```typescript
class ActingJobs {
    constructor(
        public readonly person: Person,
        public readonly movie: Movie,
        public readonly costars: Person[]
    ) {
    }
}

class  Movie {
    constructor(
        public readonly title: string,
        public readonly released?: number,
        public readonly tagline?: string
    ){
    }
}

class Person {
    constructor (
        public readonly name: string,
        public readonly born?: number
    ) {

    }
}
```

Each record in the results will result in an instance of `ActingJob` with the properties populated from the query results and type validation.

To do this at present, you would write something like the following:

```typescript 
const { records: actingJobsList } = await driver.executeQuery(QUERY, undefined, {
    database: 'neo4j',
    resultTransformer: neo4j.resultTransformers.mappedResultTransformer({ map: (record: Record): ActingJobs | undefined => {
        const person = fromNodeToPerson(record.get('person'))
        const movie = fromNodeToMovie(record.get('movie'))
        const costars = fromNodeListToPersonList(record.get('costars'))

        return new ActingJobs(person, movie, costars)
    } })
})

function fromNodeToPerson (node: any): Person {
    if (isNode(node)) {
        if (typeof node.properties.name !== 'string') {
            throw Error('Person.name is not a string')
        }
        
        if (node.properties.born != null &&  typeof node.properties.born !== 'bigint') {
            throw Error('Person.born is not a number')
        } 
        
        return new Person(node.properties.name, Number(node.properties.born))
    }
    throw Error('Person is not a valid node')
}

function fromNodeToMovie (node: any): Movie {
    if (isNode(node)) {
        if (typeof node.properties.title !== 'string') {
            throw Error('Movie.title is not a string')
        }

        if (node.properties.release != null && typeof node.properties.release !== 'bigint') {
            throw Error('Movie.release is not a string')
        }

        if (node.properties.tagline != null && typeof node.properties.tagline !== 'bigint') {
            throw Error('Movie.tagline is not a string')
        }

        return new Movie(node.properties.title, node.properties.release, node.properties.tagline)        
    }
    throw Error('Movie is not a valid node')
}

function fromNodeListToPersonList (list: any): Person[] {
    if (Array.isArray(list)) {
        return list.map(fromNodeToPerson)
    }
    throw Error('Person list not a valid list.') 
}
```

Using the new mapping functionality, the same result will be achieved using the following code:

```typescript
const personRules: Rules = {
    name: RulesFactories.asString(),
    born: RulesFactories.asNumber({ acceptBigInt: true, optional: true })
}

const movieRules: Rules = {
    title: RulesFactories.asString(),
    release: RulesFactories.asNumber({ acceptBigInt: true, optional: true }),
    tagline: RulesFactories.asString({ optional: true })
}

const actingJobsRules: Rules = {
    person: RulesFactories.asNode({
        convert: (node: Node) => node.as(Person, personRules)
    }),
    movie: RulesFactories.asNode({
        convert: (node: Node) => node.as(Movie, movieRules)
    }),
    costars: RulesFactories.asList({
        apply: RulesFactories.asNode({
            convert: (node: Node) => node.as(Person, personRules)
        })
    })
}
const { records: actingJobsList } = await driver.executeQuery(QUERY, undefined, {
    database: 'neo4j',
    resultTransformer: neo4j.resultTransformers.hydratedResultTransformer(ActingJobs, actingJobsRules)
})
```

The mapping will be done by combining rules definition and object properties created by the constructors. It's not necessary to use both (constructor and rules), but the usage of one of them is needed if you need a filled object since properties not present in instantiated object or rules are ignored by the method. 

For example, if values present in the `Movie` and `Person` objects are never null and no validation is needed. The code to process the result can be changed to:

```typescript

const actingJobsRules: Rules = {
    person: RulesFactories.asNode({
        convert: (node: Node) => node.as(Person)
    }),
    movie: RulesFactories.asNode({
        convert: (node: Node) => node.as(Movie)
    }),
    costars: RulesFactories.asList({
        apply: RulesFactories.asNode({
            convert: (node: Node) => node.as(Person)
        })
    })
}
const { records: actingJobsList } = await driver.executeQuery(QUERY, undefined, {
    database: 'neo4j',
    resultTransformer: neo4j.resultTransformers.hydratedResultTransformer(ActingJobs, actingJobsRules)

```

Another possible scenario is `Movie`, `Person` and `ActingJobs` be just typescript interfaces. The code to process the result can be changed to:

```typescript
const personRules: Rules = {
    name: RulesFactories.asString(),
    born: RulesFactories.asNumber({ acceptBigInt: true, optional: true })
}

const movieRules: Rules = {
    title: RulesFactories.asString(),
    release: RulesFactories.asNumber({ acceptBigInt: true, optional: true }),
    tagline: RulesFactories.asString({ optional: true })
}

const actingJobsRules: Rules = {
    person: RulesFactories.asNode({
        convert: (node: Node) => node.as(personRules)
    }),
    movie: RulesFactories.asNode({
        convert: (node: Node) => node.as(movieRules)
    }),
    costars: RulesFactories.asList({
        apply: RulesFactories.asNode({
            convert: (node: Node) => node.as(personRules)
        })
    })
}
const { records: actingJobsList } = await driver.executeQuery(QUERY, undefined, {
    database: 'neo4j',
    resultTransformer: neo4j.resultTransformers.hydratedResultTransformer<ActingJobs>(actingJobsRules)
})
````

_Note: In this scenario, the `ActingJobs` interface is set to the transformer for auto-complete and code validation, however this is not treated as an object constructor._


## Mapping from `Result` method

`Result.as` is introduced to the result for enable the mapping occur in the result.
Same rules of usage of constructor and rules are share with the `hydratedResultTransformer` transformer`.

```typescript 
const { records: actingJobsList } = await session.executeWrite(tx => tx.run().as(ActingJobs, actingJobsRules))
```

_Note: The current implementation transforms the Result in a promise. However, this should be update to transform the Result in a MappedResult with the hydrated objects being exposed instead of records. So, it will be possible to async iterate, subscribe and call other methods also._

## Direct mapping from an `Record`, `Node` and `Relationship` instance.

`Record.as`, `Node.as` and `Relationship.as` are introduced to enable the mapping of these types only.
Same rules of usage of constructor and rules are share with the `hydratedResultTransformer` transformer`.

```typescript
const actingJobs = record.as(ActingJobs, actingJobsRules) // example with construtor and rules
const person = node.as<Person>(personRules) // example using interfaces
const actedIn = relationship.as(ActedIn) // example without rules
```

_Note: In `Node` and `Relationship` only properties are mapped._
_Note: Properties not present in the `Record` will throw error since `Record.get` is used under the hood. However, properties which present and with value equals to `null` or `undefined` should only throw error when property is not defined as optional in the rules.
 
## Rules and Built-in Rules Factory

The driver provides RuleFactories for all data types which can be returned form a query.
There is no need for creating custom rules in most of cases. 
However, all the built-in rules are extensible.

```typescript
const personRules: Rules = {
    name: RulesFactories.asString({ 
       convert: name => `Name: $name` // change the convert method in the string rule
    }),
    born: RulesFactories.asNumber({ acceptBigInt: true, optional: true })
}
```

The Rule interface is defined as:

```typescript
interface Rule {
  optional?: boolean
  from?: string
  convert?: (recordValue: any, field: string) => any
  validate?: (recordValue: any, field: string) => void
}
```

where 

* `optional` (default: false): indicates with value accept undefined/null as value. 
In this case, the `convert` method will not be called.
* `from` (default: property name on the Rules object): indicates from which field on the Record, Node or Relationship the value will came from.
Used for cases where the property name in domain object is different to the one present in the database.
* `convert`: called to convert value to the domain value. 
Called after value be validated.
If optional is true and the value is null or undefined, the method is not called.
* `validate`: called to validate if values is valid.
Called before convert and after check if the value is optional. 
If optional is true and the value is null or undefined, the method is not called. 

⚠️ This a preview feature
