### PR TITLE
Introduce `connectionLivenessCheckTimeout` configuration

### DIFF
--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -20,6 +20,7 @@ import Pool, { PoolConfig } from '../pool'
 import { error, ConnectionProvider, ServerInfo, newError } from 'neo4j-driver-core'
 import AuthenticationProvider from './authentication-provider'
 import { object } from '../lang'
+import LivenessCheckProvider from './liveness-check-provider'
 
 const { SERVICE_UNAVAILABLE } = error
 const AUTHENTICATION_ERRORS = [
@@ -40,6 +41,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     this._config = config
     this._log = log
     this._authenticationProvider = new AuthenticationProvider({ authTokenManager, userAgent, boltAgent })
+    this._livenessCheckProvider = new LivenessCheckProvider({ connectionLivenessCheckTimeout: config.connectionLivenessCheckTimeout })
     this._userAgent = userAgent
     this._boltAgent = boltAgent
     this._createChannelConnection =
@@ -81,6 +83,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
   _createConnection ({ auth }, address, release) {
     return this._createChannelConnection(address).then(connection => {
       connection.release = () => {
+        connection.idleTimestamp = Date.now()
         return release(address, connection)
       }
       this._openConnections[connection.id] = connection
@@ -97,6 +100,15 @@ export default class PooledConnectionProvider extends ConnectionProvider {
 
   async _validateConnectionOnAcquire ({ auth, skipReAuth }, conn) {
     if (!this._validateConnection(conn)) {
+      return false
+    }
+
+    try {
+      await this._livenessCheckProvider.check(conn)
+    } catch (error) {
+      this._log.debug(
+        `The connection ${conn.id} is not alive because of an error ${error.code} '${error.message}'`
+      )
       return false
     }
 

--- a/packages/bolt-connection/src/connection-provider/liveness-check-provider.js
+++ b/packages/bolt-connection/src/connection-provider/liveness-check-provider.js
@@ -20,11 +20,11 @@ export default class LivenessCheckProvider {
   }
 
   /**
-     * Checks connection liveness with configured params.
-     *
-     * @param {Connection} connection
-     * @returns {Promise<true>} If liveness checks succeed, throws otherwise
-     */
+   * Checks connection liveness with configured params.
+   *
+   * @param {Connection} connection
+   * @returns {Promise<true>} If liveness checks succeed, throws otherwise
+   */
   async check (connection) {
     if (this._connectionLivenessCheckTimeout == null ||
             this._connectionLivenessCheckTimeout < 0 ||
@@ -32,9 +32,14 @@ export default class LivenessCheckProvider {
       return true
     }
 
-    if (this._connectionLivenessCheckTimeout === 0) {
+    const idleFor = Date.now() - connection.idleTimestamp
+
+    if (this._connectionLivenessCheckTimeout === 0 ||
+         idleFor > this._connectionLivenessCheckTimeout) {
       return await connection.resetAndFlush()
         .then(() => true)
     }
+
+    return true
   }
 }

--- a/packages/bolt-connection/src/connection-provider/liveness-check-provider.js
+++ b/packages/bolt-connection/src/connection-provider/liveness-check-provider.js
@@ -26,9 +26,7 @@ export default class LivenessCheckProvider {
    * @returns {Promise<true>} If liveness checks succeed, throws otherwise
    */
   async check (connection) {
-    if (this._connectionLivenessCheckTimeout == null ||
-            this._connectionLivenessCheckTimeout < 0 ||
-            connection.authToken == null) {
+    if (this._isCheckDisabled || this._isNewlyCreatedConnection(connection)) {
       return true
     }
 
@@ -41,5 +39,13 @@ export default class LivenessCheckProvider {
     }
 
     return true
+  }
+
+  get _isCheckDisabled () {
+    return this._connectionLivenessCheckTimeout == null || this._connectionLivenessCheckTimeout < 0
+  }
+
+  _isNewlyCreatedConnection (connection) {
+    return connection.authToken == null
   }
 }

--- a/packages/bolt-connection/src/connection-provider/liveness-check-provider.js
+++ b/packages/bolt-connection/src/connection-provider/liveness-check-provider.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default class LivenessCheckProvider {
+  constructor ({ connectionLivenessCheckTimeout }) {
+    this._connectionLivenessCheckTimeout = connectionLivenessCheckTimeout
+  }
+
+  /**
+     * Checks connection liveness with configured params.
+     *
+     * @param {Connection} connection
+     * @returns {Promise<true>} If liveness checks succeed, throws otherwise
+     */
+  async check (connection) {
+    if (this._connectionLivenessCheckTimeout == null ||
+            this._connectionLivenessCheckTimeout < 0 ||
+            connection.authToken == null) {
+      return true
+    }
+
+    if (this._connectionLivenessCheckTimeout === 0) {
+      return await connection.resetAndFlush()
+        .then(() => true)
+    }
+  }
+}

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -130,7 +130,7 @@ export default class ChannelConnection extends Connection {
     this._id = idGenerator++
     this._address = address
     this._server = { address: address.asHostPort() }
-    this.creationTimestamp = Date.now()
+    this._creationTimestamp = Date.now()
     this._disableLosslessIntegers = disableLosslessIntegers
     this._ch = channel
     this._chunker = chunker
@@ -218,6 +218,18 @@ export default class ChannelConnection extends Connection {
 
   set databaseId (value) {
     this._dbConnectionId = value
+  }
+
+  set idleTimestamp (value) {
+    this._idleTimestamp = value
+  }
+
+  get idleTimestamp () {
+    return this._idleTimestamp
+  }
+
+  get creationTimestamp () {
+    return this._creationTimestamp
   }
 
   /**

--- a/packages/bolt-connection/src/connection/connection-delegate.js
+++ b/packages/bolt-connection/src/connection/connection-delegate.js
@@ -93,6 +93,18 @@ export default class DelegateConnection extends Connection {
     this._delegate.version = value
   }
 
+  get creationTimestamp () {
+    return this._delegate.creationTimestamp
+  }
+
+  set idleTimestamp (value) {
+    this._delegate.idleTimestamp = value
+  }
+
+  get idleTimestamp () {
+    return this._delegate.idleTimestamp
+  }
+
   isOpen () {
     return this._delegate.isOpen()
   }

--- a/packages/bolt-connection/src/connection/connection.js
+++ b/packages/bolt-connection/src/connection/connection.js
@@ -51,6 +51,18 @@ export default class Connection extends CoreConnection {
     throw new Error('not implemented')
   }
 
+  get creationTimestamp () {
+    throw new Error('not implemented')
+  }
+
+  set idleTimestamp (value) {
+    throw new Error('not implemented')
+  }
+
+  get idleTimestamp () {
+    throw new Error('not implemented')
+  }
+
   /**
    * @returns {BoltProtocol} the underlying bolt protocol assigned to this connection
    */

--- a/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
@@ -812,6 +812,22 @@ class FakeConnection extends Connection {
     return this._supportsReAuth
   }
 
+  set creationTimestamp (value) {
+    this._creationTimestamp = value
+  }
+
+  get creationTimestamp () {
+    return this._creationTimestamp
+  }
+
+  set idleTimestamp (value) {
+    this._idleTimestamp = value
+  }
+
+  get idleTimestamp () {
+    return this._idleTimestamp
+  }
+
   async close () {
     this._closed = true
   }

--- a/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-direct.test.js
@@ -282,16 +282,23 @@ describe('constructor', () => {
       })
 
       it('should register the release function into the connection', async () => {
-        const { create } = setup()
-        const releaseResult = { property: 'some property' }
-        const release = jest.fn(() => releaseResult)
+        jest.useFakeTimers()
+        try {
+          const { create } = setup()
+          const releaseResult = { property: 'some property' }
+          const release = jest.fn(() => releaseResult)
 
-        const connection = await create({}, server0, release)
+          const connection = await create({}, server0, release)
+          connection.idleTimestamp = -1234
 
-        const released = connection.release()
+          const released = connection.release()
 
-        expect(released).toBe(releaseResult)
-        expect(release).toHaveBeenCalledWith(server0, connection)
+          expect(released).toBe(releaseResult)
+          expect(release).toHaveBeenCalledWith(server0, connection)
+          expect(connection.idleTimestamp).toBeCloseTo(Date.now())
+        } finally {
+          jest.useRealTimers()
+        }
       })
 
       it.each([

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -3186,16 +3186,23 @@ describe.each([
         })
 
         it('should register the release function into the connection', async () => {
-          const { create } = setup()
-          const releaseResult = { property: 'some property' }
-          const release = jest.fn(() => releaseResult)
+          jest.useFakeTimers()
+          try {
+            const { create } = setup()
+            const releaseResult = { property: 'some property' }
+            const release = jest.fn(() => releaseResult)
 
-          const connection = await create({}, server0, release)
+            const connection = await create({}, server0, release)
+            connection.idleTimestamp = -1234
 
-          const released = connection.release()
+            const released = connection.release()
 
-          expect(released).toBe(releaseResult)
-          expect(release).toHaveBeenCalledWith(server0, connection)
+            expect(released).toBe(releaseResult)
+            expect(release).toHaveBeenCalledWith(server0, connection)
+            expect(connection.idleTimestamp).toBeCloseTo(Date.now())
+          } finally {
+            jest.useRealTimers()
+          }
         })
 
         it.each([

--- a/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
+++ b/packages/bolt-connection/test/connection-provider/connection-provider-routing.test.js
@@ -3942,6 +3942,22 @@ class FakeConnection extends Connection {
     this._closed = true
   }
 
+  set creationTimestamp (value) {
+    this._creationTimestamp = value
+  }
+
+  get creationTimestamp () {
+    return this._creationTimestamp
+  }
+
+  set idleTimestamp (value) {
+    this._idleTimestamp = value
+  }
+
+  get idleTimestamp () {
+    return this._idleTimestamp
+  }
+
   isOpen () {
     return !this._closed
   }

--- a/packages/bolt-connection/test/connection-provider/liveness-check-provider.test.js
+++ b/packages/bolt-connection/test/connection-provider/liveness-check-provider.test.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { newError } from 'neo4j-driver-core'
+import LivenessCheckProvider from '../../src/connection-provider/liveness-check-provider'
+
+describe('LivenessCheckProvider', () => {
+  describe('.check', () => {
+    describe.each([
+      [undefined, null],
+      [null, null],
+      [-1, undefined],
+      [undefined, undefined],
+      [null, undefined],
+      [-1, { scheme: 'none' }],
+      [undefined, { scheme: 'none' }],
+      [null, { scheme: 'none' }],
+      [0, undefined],
+      [0, null],
+      [123, undefined],
+      [3123, null]
+    ])('when connectionLivenessCheckTimeout=%s and connection.authToken=%s', (connectionLivenessCheckTimeout, authToken) => {
+      it('should return resolves with true', async () => {
+        const { provider, connection } = scenario()
+
+        await expect(provider.check(connection)).resolves.toBe(true)
+      })
+
+      it('should not reset connection', async () => {
+        const { provider, connection } = scenario()
+
+        await provider.check(connection)
+
+        expect(connection.resetAndFlush).not.toHaveBeenCalled()
+      })
+
+      function scenario () {
+        const provider = new LivenessCheckProvider({
+          connectionLivenessCheckTimeout
+        })
+
+        const connection = mockConnection({ authToken })
+
+        return { provider, connection }
+      }
+    })
+
+    describe.each([
+      [0, { scheme: 'none' }, 0],
+      [0, { scheme: 'none' }, 1234],
+      [0, { scheme: 'none' }, 3234]
+    ])('when connectionLivenessCheckTimeout=%s, authToken=%s and connectionIdleFor=%s', (connectionLivenessCheckTimeout, authToken, connectionIdleFor) => {
+      describe('and resetAndFlush succeed', () => {
+        it('should return resolves with true', async () => {
+          const { provider, connection } = scenario()
+
+          await expect(provider.check(connection)).resolves.toBe(true)
+        })
+
+        it('should reset connection once', async () => {
+          const { provider, connection } = scenario()
+
+          await provider.check(connection)
+
+          expect(connection.resetAndFlush).toHaveBeenCalledTimes(1)
+        })
+
+        function scenario () {
+          const provider = new LivenessCheckProvider({
+            connectionLivenessCheckTimeout
+          })
+
+          const connection = mockConnection({
+            authToken,
+            connectionIdleFor
+          })
+
+          return { provider, connection }
+        }
+      })
+
+      describe('and resetAndFlush fail', () => {
+        const error = newError('Something wrong is not right')
+
+        it('should reject with expected error', async () => {
+          const { provider, connection } = scenario()
+
+          await expect(provider.check(connection)).rejects.toBe(error)
+        })
+
+        it('should reset connection once', async () => {
+          const { provider, connection } = scenario()
+
+          await provider.check(connection).catch(() => {})
+
+          expect(connection.resetAndFlush).toHaveBeenCalledTimes(1)
+        })
+
+        function scenario () {
+          const provider = new LivenessCheckProvider({
+            connectionLivenessCheckTimeout
+          })
+
+          const connection = mockConnection({
+            authToken,
+            connectionIdleFor,
+            resetAndFlushPromise: Promise.reject(error)
+          })
+
+          return { provider, connection }
+        }
+      })
+    })
+  })
+
+  function mockConnection ({ resetAndFlushPromise, authToken } = {}) {
+    return {
+      resetAndFlush: jest.fn(() => resetAndFlushPromise || Promise.resolve()),
+      authToken
+    }
+  }
+})

--- a/packages/bolt-connection/test/fake-connection.js
+++ b/packages/bolt-connection/test/fake-connection.js
@@ -32,7 +32,7 @@ export default class FakeConnection extends Connection {
     this._id = 0
     this._databaseId = null
     this._requestRoutingInformationMock = null
-    this.creationTimestamp = Date.now()
+    this._creationTimestamp = Date.now()
 
     this.resetInvoked = 0
     this.releaseInvoked = 0
@@ -68,6 +68,22 @@ export default class FakeConnection extends Connection {
 
   set version (value) {
     this._server.version = value
+  }
+
+  set creationTimestamp (value) {
+    this._creationTimestamp = value
+  }
+
+  get creationTimestamp () {
+    return this._creationTimestamp
+  }
+
+  set idleTimestamp (value) {
+    this._idleTimestamp = value
+  }
+
+  get idleTimestamp () {
+    return this._idleTimestamp
   }
 
   protocol () {

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -107,6 +107,7 @@ interface DriverConfig {
   fetchSize?: number
   logging?: LoggingConfig
   notificationFilter?: NotificationFilter
+  connectionLivenessCheckTimeout?: number
 }
 
 /**
@@ -907,6 +908,9 @@ function sanitizeConfig (config: any): void {
     DEFAULT_FETCH_SIZE
   )
   config.connectionTimeout = extractConnectionTimeout(config)
+
+  config.connectionLivenessCheckTimeout =
+    validateConnectionLivenessCheckTimeoutSizeValue(config.connectionLivenessCheckTimeout)
 }
 
 /**
@@ -960,6 +964,24 @@ function extractConnectionTimeout (config: any): number | null {
     // timeout configured, use the provided value
     return configuredTimeout
   }
+}
+
+/**
+ * @private
+ */
+function validateConnectionLivenessCheckTimeoutSizeValue (
+  rawValue: any
+): number | undefined {
+  if (rawValue == null) {
+    return undefined
+  }
+  const connectionLivenessCheckTimeout = parseInt(rawValue, 10)
+  if (connectionLivenessCheckTimeout < 0 || Number.isNaN(connectionLivenessCheckTimeout)) {
+    throw new Error(
+      `The connectionLivenessCheckTimeout can only be a positive value or 0 for always. However connectionLivenessCheckTimeout = ${connectionLivenessCheckTimeout}`
+    )
+  }
+  return connectionLivenessCheckTimeout
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -71,6 +71,7 @@ export class Config {
   maxTransactionRetryTime?: number
   maxConnectionLifetime?: number
   connectionAcquisitionTimeout?: number
+  connectionLivenessCheckTimeout?: number
   connectionTimeout?: number
   disableLosslessIntegers?: boolean
   notificationFilter?: NotificationFilter
@@ -183,6 +184,33 @@ export class Config {
      * @type {number|undefined}
      */
     this.maxTransactionRetryTime = 30000 // 30 seconds
+
+    /**
+     * Specify the maximum time in milliseconds the connection can be idle without needing
+     * to perform a liveness check on acquire from the pool.
+     *
+     * Pooled connections that have been idle in the pool for longer than this
+     * timeout will be tested before they are used again, to ensure they are still live.
+     * If this option is set too low, an additional network call will be incurred
+     * when acquiring a connection, which causes a performance hit.
+     *
+     * If this is set high, you may receive sessions that are backed by no longer
+     * live connections, which will lead to exceptions in your application.
+     * Assuming the database is running, these exceptions will go away if you retry
+     * acquiring sessions.
+     *
+     * Hence, this parameter tunes a balance between the likelihood of your application
+     * seeing connection problems, and performance.
+     *
+     * You normally should not need to tune this parameter. No connection liveliness
+     * check is done by default. Value 0 means connections will always be tested for
+     * validity and negative values mean connections will never be tested.
+     *
+     * **Default**: ```undefined``` (Disabled)
+     *
+     * @type {number|undefined}
+     */
+    this.connectionLivenessCheckTimeout = undefined // Disabled
 
     /**
      * Specify socket connection timeout in milliseconds.

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/liveness-check-provider.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/liveness-check-provider.js
@@ -20,11 +20,11 @@ export default class LivenessCheckProvider {
   }
 
   /**
-     * Checks connection liveness with configured params.
-     *
-     * @param {Connection} connection
-     * @returns {Promise<true>} If liveness checks succeed, throws otherwise
-     */
+   * Checks connection liveness with configured params.
+   *
+   * @param {Connection} connection
+   * @returns {Promise<true>} If liveness checks succeed, throws otherwise
+   */
   async check (connection) {
     if (this._connectionLivenessCheckTimeout == null ||
             this._connectionLivenessCheckTimeout < 0 ||
@@ -32,9 +32,14 @@ export default class LivenessCheckProvider {
       return true
     }
 
-    if (this._connectionLivenessCheckTimeout === 0) {
+    const idleFor = Date.now() - connection.idleTimestamp
+
+    if (this._connectionLivenessCheckTimeout === 0 ||
+         idleFor > this._connectionLivenessCheckTimeout) {
       return await connection.resetAndFlush()
         .then(() => true)
     }
+
+    return true
   }
 }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/liveness-check-provider.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/liveness-check-provider.js
@@ -26,9 +26,7 @@ export default class LivenessCheckProvider {
    * @returns {Promise<true>} If liveness checks succeed, throws otherwise
    */
   async check (connection) {
-    if (this._connectionLivenessCheckTimeout == null ||
-            this._connectionLivenessCheckTimeout < 0 ||
-            connection.authToken == null) {
+    if (this._isCheckDisabled || this._isNewlyCreatedConnection(connection)) {
       return true
     }
 
@@ -41,5 +39,13 @@ export default class LivenessCheckProvider {
     }
 
     return true
+  }
+
+  get _isCheckDisabled () {
+    return this._connectionLivenessCheckTimeout == null || this._connectionLivenessCheckTimeout < 0
+  }
+
+  _isNewlyCreatedConnection (connection) {
+    return connection.authToken == null
   }
 }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/liveness-check-provider.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/liveness-check-provider.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default class LivenessCheckProvider {
+  constructor ({ connectionLivenessCheckTimeout }) {
+    this._connectionLivenessCheckTimeout = connectionLivenessCheckTimeout
+  }
+
+  /**
+     * Checks connection liveness with configured params.
+     *
+     * @param {Connection} connection
+     * @returns {Promise<true>} If liveness checks succeed, throws otherwise
+     */
+  async check (connection) {
+    if (this._connectionLivenessCheckTimeout == null ||
+            this._connectionLivenessCheckTimeout < 0 ||
+            connection.authToken == null) {
+      return true
+    }
+
+    if (this._connectionLivenessCheckTimeout === 0) {
+      return await connection.resetAndFlush()
+        .then(() => true)
+    }
+  }
+}

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
@@ -130,7 +130,7 @@ export default class ChannelConnection extends Connection {
     this._id = idGenerator++
     this._address = address
     this._server = { address: address.asHostPort() }
-    this.creationTimestamp = Date.now()
+    this._creationTimestamp = Date.now()
     this._disableLosslessIntegers = disableLosslessIntegers
     this._ch = channel
     this._chunker = chunker
@@ -218,6 +218,18 @@ export default class ChannelConnection extends Connection {
 
   set databaseId (value) {
     this._dbConnectionId = value
+  }
+
+  set idleTimestamp (value) {
+    this._idleTimestamp = value
+  }
+
+  get idleTimestamp () {
+    return this._idleTimestamp
+  }
+
+  get creationTimestamp () {
+    return this._creationTimestamp
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-delegate.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-delegate.js
@@ -93,6 +93,18 @@ export default class DelegateConnection extends Connection {
     this._delegate.version = value
   }
 
+  get creationTimestamp () {
+    return this._delegate.creationTimestamp
+  }
+
+  set idleTimestamp (value) {
+    this._delegate.idleTimestamp = value
+  }
+
+  get idleTimestamp () {
+    return this._delegate.idleTimestamp
+  }
+
   isOpen () {
     return this._delegate.isOpen()
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection.js
@@ -51,6 +51,18 @@ export default class Connection extends CoreConnection {
     throw new Error('not implemented')
   }
 
+  get creationTimestamp () {
+    throw new Error('not implemented')
+  }
+
+  set idleTimestamp (value) {
+    throw new Error('not implemented')
+  }
+
+  get idleTimestamp () {
+    throw new Error('not implemented')
+  }
+
   /**
    * @returns {BoltProtocol} the underlying bolt protocol assigned to this connection
    */

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -106,7 +106,8 @@ interface DriverConfig {
   trust?: TrustStrategy
   fetchSize?: number
   logging?: LoggingConfig
-  notificationFilter?: NotificationFilter
+  notificationFilter?: NotificationFilter,
+  connectionLivenessCheckTimeout?: number
 }
 
 /**
@@ -907,6 +908,9 @@ function sanitizeConfig (config: any): void {
     DEFAULT_FETCH_SIZE
   )
   config.connectionTimeout = extractConnectionTimeout(config)
+
+  config.connectionLivenessCheckTimeout = 
+    validateConnectionLivenessCheckTimeoutSizeValue(config.connectionLivenessCheckTimeout)
 }
 
 /**
@@ -960,6 +964,24 @@ function extractConnectionTimeout (config: any): number | null {
     // timeout configured, use the provided value
     return configuredTimeout
   }
+}
+
+/**
+ * @private
+ */
+function validateConnectionLivenessCheckTimeoutSizeValue (
+  rawValue: any
+): number | undefined {
+  if (rawValue == null) {
+    return undefined
+  }
+  const connectionLivenessCheckTimeout = parseInt(rawValue, 10)
+  if (connectionLivenessCheckTimeout < 0 || Number.isNaN(connectionLivenessCheckTimeout)) {
+    throw new Error(
+      `The connectionLivenessCheckTimeout can only be a positive value or 0 for always. However connectionLivenessCheckTimeout = ${connectionLivenessCheckTimeout}`
+    )
+  } 
+  return connectionLivenessCheckTimeout
 }
 
 /**

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -106,7 +106,7 @@ interface DriverConfig {
   trust?: TrustStrategy
   fetchSize?: number
   logging?: LoggingConfig
-  notificationFilter?: NotificationFilter,
+  notificationFilter?: NotificationFilter
   connectionLivenessCheckTimeout?: number
 }
 
@@ -909,7 +909,7 @@ function sanitizeConfig (config: any): void {
   )
   config.connectionTimeout = extractConnectionTimeout(config)
 
-  config.connectionLivenessCheckTimeout = 
+  config.connectionLivenessCheckTimeout =
     validateConnectionLivenessCheckTimeoutSizeValue(config.connectionLivenessCheckTimeout)
 }
 
@@ -980,7 +980,7 @@ function validateConnectionLivenessCheckTimeoutSizeValue (
     throw new Error(
       `The connectionLivenessCheckTimeout can only be a positive value or 0 for always. However connectionLivenessCheckTimeout = ${connectionLivenessCheckTimeout}`
     )
-  } 
+  }
   return connectionLivenessCheckTimeout
 }
 

--- a/packages/neo4j-driver-deno/lib/core/types.ts
+++ b/packages/neo4j-driver-deno/lib/core/types.ts
@@ -71,6 +71,7 @@ export class Config {
   maxTransactionRetryTime?: number
   maxConnectionLifetime?: number
   connectionAcquisitionTimeout?: number
+  connectionLivenessCheckTimeout?: number
   connectionTimeout?: number
   disableLosslessIntegers?: boolean
   notificationFilter?: NotificationFilter
@@ -183,6 +184,33 @@ export class Config {
      * @type {number|undefined}
      */
     this.maxTransactionRetryTime = 30000 // 30 seconds
+
+    /**
+     * Specify the maximum time in milliseconds the connection can be idle without needing
+     * to perform a liveness check on acquire from the pool.
+     *
+     * Pooled connections that have been idle in the pool for longer than this
+     * timeout will be tested before they are used again, to ensure they are still live.
+     * If this option is set too low, an additional network call will be incurred
+     * when acquiring a connection, which causes a performance hit.
+     *
+     * If this is set high, you may receive sessions that are backed by no longer
+     * live connections, which will lead to exceptions in your application.
+     * Assuming the database is running, these exceptions will go away if you retry
+     * acquiring sessions.
+     *
+     * Hence, this parameter tunes a balance between the likelihood of your application
+     * seeing connection problems, and performance.
+     *
+     * You normally should not need to tune this parameter. No connection liveliness
+     * check is done by default. Value 0 means connections will always be tested for
+     * validity and negative values mean connections will never be tested.
+     *
+     * **Default**: ```undefined``` (Disabled)
+     *
+     * @type {number|undefined}
+     */
+    this.connectionLivenessCheckTimeout = undefined // Disabled
 
     /**
      * Specify socket connection timeout in milliseconds.

--- a/packages/neo4j-driver/test/internal/fake-connection.js
+++ b/packages/neo4j-driver/test/internal/fake-connection.js
@@ -38,7 +38,7 @@ export default class FakeConnection extends Connection {
     this._id = 0
     this._databaseId = null
     this._requestRoutingInformationMock = null
-    this.creationTimestamp = Date.now()
+    this._creationTimestamp = Date.now()
 
     this.resetInvoked = 0
     this.releaseInvoked = 0
@@ -83,6 +83,22 @@ export default class FakeConnection extends Connection {
 
   set authToken (authToken) {
     this._authToken = authToken
+  }
+
+  set creationTimestamp (value) {
+    this._creationTimestamp = value
+  }
+
+  get creationTimestamp () {
+    return this._creationTimestamp
+  }
+
+  set idleTimestamp (value) {
+    this._idleTimestamp = value
+  }
+
+  get idleTimestamp () {
+    return this._idleTimestamp
   }
 
   protocol () {

--- a/packages/testkit-backend/src/feature/common.js
+++ b/packages/testkit-backend/src/feature/common.js
@@ -32,6 +32,7 @@ const features = [
   'Feature:API:Driver.VerifyAuthentication',
   'Feature:API:Driver.VerifyConnectivity',
   'Feature:API:Session:NotificationsConfig',
+  'Feature:API:Liveness.Check',
   'Optimization:AuthPipelining',
   'Optimization:EagerTransactionBegin',
   'Optimization:ExecuteQueryPipelining',

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -82,6 +82,10 @@ export function NewDriver ({ neo4j }, context, data, wire) {
     config.telemetryDisabled = data.telemetryDisabled
   }
 
+  if ('livenessCheckTimeoutMs' in data) {
+    config.connectionLivenessCheckTimeout = data.livenessCheckTimeoutMs
+  }
+
   let driver
   try {
     driver = neo4j.driver(uri, parsedAuthToken, config)

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -187,6 +187,12 @@ const skippedTests = [
           endsWith('test_error_on_rollback_using_tx_run')
         )
       )
+  ),
+  skip(
+    'Behaviour pending unification',
+    ifStartsWith('stub.routing.test_routing_')
+      .and(
+        ifEndsWith('.test_should_drop_connections_failing_liveness_check'))
   )
 ]
 


### PR DESCRIPTION
This configuration defines the number of milliseconds the connection might be idle before need to perform a liveness check on acquiring from the pool.

```typescript
const driver = neo4j.driver(URL, AUTH, {
  // other configurations, then
  connectionLivenessCheckTimeout: 30000 // 30 seconds
})
```

Check the API docs for more information.