### PR TITLE
Fix connection receive timeout for single requests

### DIFF
--- a/packages/bolt-connection/src/bolt/response-handler.js
+++ b/packages/bolt-connection/src/bolt/response-handler.js
@@ -76,7 +76,7 @@ export default class ResponseHandler {
     this._transformMetadata = transformMetadata || NO_OP_IDENTITY
     this._observer = Object.assign(
       {
-        onPendingObserversChange: NO_OP,
+        onObserversCountChange: NO_OP,
         onError: NO_OP,
         onFailure: NO_OP,
         onErrorApplyTransformation: NO_OP_IDENTITY
@@ -156,7 +156,11 @@ export default class ResponseHandler {
    */
   _updateCurrentObserver () {
     this._currentObserver = this._pendingObservers.shift()
-    this._observer.onPendingObserversChange(this._pendingObservers.length)
+    this._observer.onObserversCountChange(this._observersCount)
+  }
+
+  get _observersCount () {
+    return this._currentObserver == null ? this._pendingObservers.length : this._pendingObservers.length + 1
   }
 
   _queueObserver (observer) {
@@ -169,7 +173,7 @@ export default class ResponseHandler {
     } else {
       this._pendingObservers.push(observer)
     }
-    this._observer.onPendingObserversChange(this._pendingObservers.length)
+    this._observer.onObserversCountChange(this._observersCount)
     return true
   }
 

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -67,7 +67,7 @@ export function createChannelConnection (
           server: conn.server,
           log: conn.logger,
           observer: {
-            onPendingObserversChange: conn._handleOngoingRequestsNumberChange.bind(conn),
+            onObserversCountChange: conn._handleOngoingRequestsNumberChange.bind(conn),
             onError: conn._handleFatalError.bind(conn),
             onFailure: conn._resetOnFailure.bind(conn),
             onProtocolError: conn._handleProtocolError.bind(conn),

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/response-handler.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/response-handler.js
@@ -76,7 +76,7 @@ export default class ResponseHandler {
     this._transformMetadata = transformMetadata || NO_OP_IDENTITY
     this._observer = Object.assign(
       {
-        onPendingObserversChange: NO_OP,
+        onObserversCountChange: NO_OP,
         onError: NO_OP,
         onFailure: NO_OP,
         onErrorApplyTransformation: NO_OP_IDENTITY
@@ -156,7 +156,11 @@ export default class ResponseHandler {
    */
   _updateCurrentObserver () {
     this._currentObserver = this._pendingObservers.shift()
-    this._observer.onPendingObserversChange(this._pendingObservers.length)
+    this._observer.onObserversCountChange(this._observersCount)
+  }
+
+  get _observersCount () {
+    return this._currentObserver == null ? this._pendingObservers.length : this._pendingObservers.length + 1
   }
 
   _queueObserver (observer) {
@@ -169,7 +173,7 @@ export default class ResponseHandler {
     } else {
       this._pendingObservers.push(observer)
     }
-    this._observer.onPendingObserversChange(this._pendingObservers.length)
+    this._observer.onObserversCountChange(this._observersCount)
     return true
   }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
@@ -67,7 +67,7 @@ export function createChannelConnection (
           server: conn.server,
           log: conn.logger,
           observer: {
-            onPendingObserversChange: conn._handleOngoingRequestsNumberChange.bind(conn),
+            onObserversCountChange: conn._handleOngoingRequestsNumberChange.bind(conn),
             onError: conn._handleFatalError.bind(conn),
             onFailure: conn._resetOnFailure.bind(conn),
             onProtocolError: conn._handleProtocolError.bind(conn),


### PR DESCRIPTION
Resets and non-pipeline requests were not triggering the connection receive timeout.
The problem happened because of the timeout mechanics only started when pending observers are set.
However, the current observer should be also be considered for this use case.