### PR TITLE
Fix BrowserChannel close when is already closing

### DIFF
--- a/packages/bolt-connection/test/channel/browser/browser-channel.test.js
+++ b/packages/bolt-connection/test/channel/browser/browser-channel.test.js
@@ -323,6 +323,41 @@ describe('WebSocketChannel', () => {
         fakeSetTimeout.uninstall()
       }
     })
+
+    it('should return always the same promise', async () => {
+      const fakeSetTimeout = setTimeoutMock.install()
+      try {
+        // do not execute setTimeout callbacks
+        fakeSetTimeout.pause()
+        const address = ServerAddress.fromUrl('bolt://localhost:8989')
+        const driverConfig = { connectionTimeout: 4242 }
+        const channelConfig = new ChannelConfig(
+          address,
+          driverConfig,
+          SERVICE_UNAVAILABLE
+        )
+        webSocketChannel = new WebSocketChannel(
+          channelConfig,
+          undefined,
+          createWebSocketFactory(WS_OPEN)
+        )
+
+        const promise1 = webSocketChannel.close()
+        const promise2 = webSocketChannel.close()
+
+        expect(promise1).toBe(promise2)
+
+        await Promise.all([promise1, promise2])
+
+        const promise3 = webSocketChannel.close()
+
+        expect(promise3).toBe(promise2)
+
+        await promise3
+      } finally {
+        fakeSetTimeout.uninstall()
+      }
+    })
   })
 
   describe('.setupReceiveTimeout()', () => {


### PR DESCRIPTION
WebSockets can take a while for closing, and when `WebSocket.close` is called while the status is `WS_CLOSING`, an error is thrown.

This situation can happen when the driver is being closed while sessions are still releasing connections back to the pool or after a receive timeout while closing the session.

BrowserChannel should wait for the original close socket to finish whenever a new close request happens to avoid this kind of error and provide a graceful shutdown for driver and session.
