### PR TITLE
Skip test not supported on browser suite

### DIFF
--- a/packages/testkit-backend/src/skipped-tests/browser.js
+++ b/packages/testkit-backend/src/skipped-tests/browser.js
@@ -10,7 +10,8 @@ const skippedTests = [
     ifEquals('stub.disconnects.test_disconnects.TestDisconnects.test_fail_on_reset'),
     ifEquals('stub.tx_begin_parameters.test_tx_begin_parameters.TestTxBeginParameters.test_impersonation_fails_on_v4x3'),
     ifEquals('stub.session_run_parameters.test_session_run_parameters.TestSessionRunParameters.test_impersonation_fails_on_v4x3'),
-    ifEquals('stub.driver_parameters.test_liveness_check.TestLivenessCheck.test_timeout_recv_timeout')
+    ifEquals('stub.driver_parameters.test_liveness_check.TestLivenessCheck.test_timeout_recv_timeout'),
+    ifEquals('stub.driver_parameters.test_liveness_check.TestLivenessCheckRouting.test_timeout_recv_timeout')
   ),
   skip(
     'TLS Tests not implemented for browser',


### PR DESCRIPTION
Closing sockets in browser takes too much time, so the test just times out.
