### PR TITLE
Fix duplicated `neo4j-javascript` string on  `boltAgent.product` object

### DIFF
--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -215,7 +215,7 @@ function driver (
 
   // Use default user agent or user agent specified by user.
   _config.userAgent = _config.userAgent ?? USER_AGENT
-  _config.boltAgent = internal.boltAgent.fromVersion('neo4j-javascript/' + VERSION)
+  _config.boltAgent = internal.boltAgent.fromVersion(VERSION)
 
   const address = ServerAddress.fromUrl(parsedUrl.hostAndPort)
 

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -214,7 +214,7 @@ function driver (
 
   // Use default user agent or user agent specified by user.
   _config.userAgent = _config.userAgent ?? USER_AGENT
-  _config.boltAgent = internal.boltAgent.fromVersion('neo4j-javascript/' + VERSION)
+  _config.boltAgent = internal.boltAgent.fromVersion(VERSION)
 
   const address = ServerAddress.fromUrl(parsedUrl.hostAndPort)
 

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -175,7 +175,7 @@ function driver (url, authToken, config = {}) {
 
   // Use default user agent or user agent specified by user.
   config.userAgent = config.userAgent || USER_AGENT
-  config.boltAgent = internal.boltAgent.fromVersion('neo4j-javascript/' + VERSION)
+  config.boltAgent = internal.boltAgent.fromVersion(VERSION)
   const address = ServerAddress.fromUrl(parsedUrl.hostAndPort)
 
   const meta = {


### PR DESCRIPTION
This duplication was happening because the neo4j methods were sending the agent string instead of the driver version the bolt agent factory.