### PR TITLE
Optimize usage of Intl API to speed up response parsing with many datetime objects

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js
@@ -157,9 +157,9 @@ function getOffsetFromZoneId (timeZoneId, epochSecond, nanosecond) {
   return offset
 }
 
-const dateTimeFormatCache = new Map();
+const dateTimeFormatCache = new Map()
 
-function getDateTimeFormatForZoneId(timeZoneId) {
+function getDateTimeFormatForZoneId (timeZoneId) {
   if (!dateTimeFormatCache.has(timeZoneId)) {
     const formatter = new Intl.DateTimeFormat('en-US', {
       timeZone: timeZoneId,

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js
@@ -157,18 +157,30 @@ function getOffsetFromZoneId (timeZoneId, epochSecond, nanosecond) {
   return offset
 }
 
+const dateTimeFormatCache = new Map();
+
+function getDateTimeFormatForZoneId(timeZoneId) {
+  if (!dateTimeFormatCache.has(timeZoneId)) {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timeZoneId,
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      hour12: false,
+      era: 'narrow'
+    })
+
+    dateTimeFormatCache.set(timeZoneId, formatter)
+  }
+
+  return dateTimeFormatCache.get(timeZoneId)
+}
+
 function getTimeInZoneId (timeZoneId, epochSecond, nano) {
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone: timeZoneId,
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    hour12: false,
-    era: 'narrow'
-  })
+  const formatter = getDateTimeFormatForZoneId(timeZoneId)
 
   const utc = int(epochSecond)
     .multiply(1000)

--- a/packages/core/src/internal/temporal-util.ts
+++ b/packages/core/src/internal/temporal-util.ts
@@ -428,13 +428,20 @@ export function assertValidNanosecond (
   )
 }
 
-export function assertValidZoneId (fieldName: string, zoneId: string): void {
+const timeZoneValidityCache = new Map();
+
+export function assertValidZoneId(fieldName: string, zoneId: string): void {
+  let result = false;
+
   try {
-    Intl.DateTimeFormat(undefined, { timeZone: zoneId })
+    if (timeZoneValidityCache.get(zoneId)) return;
+    result = !!Intl.DateTimeFormat(undefined, { timeZone: zoneId });
   } catch (e) {
     throw newError(
       `${fieldName} is expected to be a valid ZoneId but was: "${zoneId}"`
-    )
+    );
+  } finally {
+    timeZoneValidityCache.set(zoneId, result)
   }
 }
 

--- a/packages/core/src/internal/temporal-util.ts
+++ b/packages/core/src/internal/temporal-util.ts
@@ -16,7 +16,7 @@
  */
 
 import Integer, { int, isInt } from '../integer'
-import { newError } from '../error'
+import { Neo4jError, newError } from '../error'
 import { assertNumberOrInteger } from './util'
 import { NumberOrInteger } from '../graph-types'
 
@@ -428,20 +428,28 @@ export function assertValidNanosecond (
   )
 }
 
-const timeZoneValidityCache = new Map();
+const timeZoneValidityCache = new Map<string, boolean>()
+const newInvalidZoneIdError = (zoneId: string, fieldName: string): Neo4jError => newError(
+  `${fieldName} is expected to be a valid ZoneId but was: "${zoneId}"`
+)
 
-export function assertValidZoneId(fieldName: string, zoneId: string): void {
-  let result = false;
+export function assertValidZoneId (fieldName: string, zoneId: string): void {
+  const cachedResult = timeZoneValidityCache.get(zoneId)
+
+  if (cachedResult === true) {
+    return
+  }
+
+  if (cachedResult === false) {
+    throw newInvalidZoneIdError(zoneId, fieldName)
+  }
 
   try {
-    if (timeZoneValidityCache.get(zoneId)) return;
-    result = !!Intl.DateTimeFormat(undefined, { timeZone: zoneId });
+    Intl.DateTimeFormat(undefined, { timeZone: zoneId })
+    timeZoneValidityCache.set(zoneId, true)
   } catch (e) {
-    throw newError(
-      `${fieldName} is expected to be a valid ZoneId but was: "${zoneId}"`
-    );
-  } finally {
-    timeZoneValidityCache.set(zoneId, result)
+    timeZoneValidityCache.set(zoneId, false)
+    throw newInvalidZoneIdError(zoneId, fieldName)
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.utc.transformer.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.utc.transformer.js
@@ -157,9 +157,9 @@ function getOffsetFromZoneId (timeZoneId, epochSecond, nanosecond) {
   return offset
 }
 
-const dateTimeFormatCache = new Map();
+const dateTimeFormatCache = new Map()
 
-function getDateTimeFormatForZoneId(timeZoneId) {
+function getDateTimeFormatForZoneId (timeZoneId) {
   if (!dateTimeFormatCache.has(timeZoneId)) {
     const formatter = new Intl.DateTimeFormat('en-US', {
       timeZone: timeZoneId,

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.utc.transformer.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.utc.transformer.js
@@ -157,18 +157,30 @@ function getOffsetFromZoneId (timeZoneId, epochSecond, nanosecond) {
   return offset
 }
 
+const dateTimeFormatCache = new Map();
+
+function getDateTimeFormatForZoneId(timeZoneId) {
+  if (!dateTimeFormatCache.has(timeZoneId)) {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timeZoneId,
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      hour12: false,
+      era: 'narrow'
+    })
+
+    dateTimeFormatCache.set(timeZoneId, formatter)
+  }
+
+  return dateTimeFormatCache.get(timeZoneId)
+}
+
 function getTimeInZoneId (timeZoneId, epochSecond, nano) {
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone: timeZoneId,
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    hour12: false,
-    era: 'narrow'
-  })
+  const formatter = getDateTimeFormatForZoneId(timeZoneId)
 
   const utc = int(epochSecond)
     .multiply(1000)

--- a/packages/neo4j-driver-deno/lib/core/internal/temporal-util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/temporal-util.ts
@@ -428,13 +428,20 @@ export function assertValidNanosecond (
   )
 }
 
-export function assertValidZoneId (fieldName: string, zoneId: string): void {
+const timeZoneValidityCache = new Map();
+
+export function assertValidZoneId(fieldName: string, zoneId: string): void {
+  let result = false
+
   try {
-    Intl.DateTimeFormat(undefined, { timeZone: zoneId })
+    if (timeZoneValidityCache.get(zoneId)) return
+    result = !!Intl.DateTimeFormat(undefined, { timeZone: zoneId })
   } catch (e) {
     throw newError(
       `${fieldName} is expected to be a valid ZoneId but was: "${zoneId}"`
-    )
+    );
+  } finally {
+    timeZoneValidityCache.set(zoneId, result)
   }
 }
 

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,0 +1,26 @@
+npm install -g gulp typescript jest
+
+npm ci
+npm run build -- --no-private
+
+if [ -n "$2" ]; then
+  export NEOCTRL_ARGS="$2"
+fi
+
+trap "npm run stop-neo4j" EXIT
+
+npm run start-neo4j
+
+if [ $? -ne 0 ]; then
+  echo "Unable to start neo4j"
+  exit 1
+fi
+
+npm test -- --no-private
+
+if [ $? -eq 0 ]; then
+  echo "Exit with code 0"
+else
+  echo "Exit with code 1"
+  exit 1
+fi


### PR DESCRIPTION
## Background
Lately, I've been upgrading a big business application that was using the latest 4.x version of the neo4j driver to use the latest 5.x version (we still use neo4j 4.x, but they are compatible [according to docs](https://neo4j.com/developer/kb/neo4j-supported-versions/#_neo4j_database_enterprise_edition_4)). The upgrade itself was very smooth, but while testing everything afterwards, we noticed that (almost) all of our requests to the backend took considerably longer to finish (~2x).

After doing some investigation (mainly by using [clinic flamegraphs](https://clinicjs.org/flame/)) I noticed that there was a considerable increase in the time spent parsing the raw neo4j responses in the driver. Looking at it in more detail revealed that most of the increase stems from one particular codepath, namely from calls to [`getTimeInZoneId`](https://github.com/neo4j/neo4j-javascript-driver/blob/5.0/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js#L160).

Looking at it almost immediately revealed the culprit, which is how the `Intl` API is used there. It seems that a new `Intl.DateTimeFormat` object is created for each date time returned in the response. The `Intl` API is notoriously slow afaik, hence we should reduce the usage of those APIs to an absolute minimum in hot code paths, such as response parsing. Also, since the application I was upgrading is basically doing nothing else than managing timestamps at its core, it made sense that we noticed the performance degradation in such a severe way.

## Changes in this MR
I decided to try out to cache the `DateTimeFormat` to prevent intializing the formatter for a given time zone more than once, and it seems to have helped quite a lot (in our case the "big" requests got a speedup of 60-70%). I also checked for other usages of `Intl` in the code base, but luckily only found one other place, where it's used to check the validity of a given timezone string. I added caching there as well, though I'm not entirely sure if this is a case of premature optimization, since we personally didn't run into performance issues where this particular method was involved. I'll leave this up to you guys to decide if we should include those changes in this MR as well, or revert them.

## Remarks/questions
* Is the Deno implementation totally seperate from the node implementation? If not I'd like to put the new helpers in some shared project to prevent code duplication.
*  I haven't added any explicit test for this refactoring/improvement, since the `getTimeInZoneId` method is extensively tested with the test suite already. Is this fine for you?
* What's the release schedule for new driver versions? We're currently stuck on using our own version until this fix is merged.
* Note the bash script I've added, which is basically a 1:1 copy of the PowerShell script at the root of the project.

Maybe there's a better way to achieve the same, and since I'm in no way an expert on the `Intl` API or this driver, I'm very open to suggestions and other ideas how to solve this (also because I'm a first time contributor, see below).

Looking forward to hearing from you guys, hopefully we can get this resolved as quickly as possible.

Thanks in advance! :)

# CLA
I'm a first time contributor and the issue template said that I need to mention it here somewhere. I signed the CLA, let me know in case anything else is needed from my side.