### PR TITLE
Introduce Client Certificate configuration

### DIFF
--- a/packages/bolt-connection/src/channel/browser/browser-client-certificates-loader.js
+++ b/packages/bolt-connection/src/channel/browser/browser-client-certificates-loader.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  async load (clientCertificate) {
+    return clientCertificate
+  }
+}

--- a/packages/bolt-connection/src/channel/browser/index.js
+++ b/packages/bolt-connection/src/channel/browser/index.js
@@ -17,7 +17,7 @@
 
 import WebSocketChannel from './browser-channel'
 import BrowserHosNameResolver from './browser-host-name-resolver'
-
+import BrowserClientCertificatesLoader from './browser-client-certificates-loader'
 /*
 
 This module exports a set of components to be used in browser environment.
@@ -30,3 +30,4 @@ NOTE: exports in this module should have exactly the same names/structure as exp
  */
 export const Channel = WebSocketChannel
 export const HostNameResolver = BrowserHosNameResolver
+export const ClientCertificatesLoader = BrowserClientCertificatesLoader

--- a/packages/bolt-connection/src/channel/channel-config.js
+++ b/packages/bolt-connection/src/channel/channel-config.js
@@ -46,8 +46,9 @@ export default class ChannelConfig {
    * @param {ServerAddress} address the address for the channel to connect to.
    * @param {Object} driverConfig the driver config provided by the user when driver is created.
    * @param {string} connectionErrorCode the default error code to use on connection errors.
+   * @param {object} clientCertificate the client certificate
    */
-  constructor (address, driverConfig, connectionErrorCode) {
+  constructor (address, driverConfig, connectionErrorCode, clientCertificate) {
     this.address = address
     this.encrypted = extractEncrypted(driverConfig)
     this.trust = extractTrust(driverConfig)
@@ -55,6 +56,7 @@ export default class ChannelConfig {
     this.knownHostsPath = extractKnownHostsPath(driverConfig)
     this.connectionErrorCode = connectionErrorCode || SERVICE_UNAVAILABLE
     this.connectionTimeout = driverConfig.connectionTimeout
+    this.clientCertificate = clientCertificate
   }
 }
 

--- a/packages/bolt-connection/src/channel/deno/deno-channel.js
+++ b/packages/bolt-connection/src/channel/deno/deno-channel.js
@@ -239,6 +239,8 @@ const TrustStrategy = {
       );
     }
 
+    assertNotClientCertificates(config)
+
     const caCerts = await Promise.all(
       config.trustedCertificates.map(f => Deno.readTextFile(f))
     )
@@ -250,6 +252,8 @@ const TrustStrategy = {
     })
   },
   TRUST_SYSTEM_CA_SIGNED_CERTIFICATES: function (config) {
+    assertNotClientCertificates(config)
+    
     return Deno.connectTls({ 
       hostname: config.address.resolvedHost(), 
       port: config.address.port()
@@ -263,6 +267,13 @@ const TrustStrategy = {
       'See, https://deno.com/blog/v1.13#disable-tls-verification'
     )
   }
+}
+
+async function assertNotClientCertificates (config) {
+  if (config.clientCertificate != null) {
+    throw newError('clientCertificates are not supported in DenoJS since the API does not ' +
+      'support its configuration. See, https://deno.land/api@v1.29.0?s=Deno.ConnectTlsOptions.')
+  } 
 }
 
 async function _connect (config) {

--- a/packages/bolt-connection/src/channel/deno/deno-client-certificates-loader.js
+++ b/packages/bolt-connection/src/channel/deno/deno-client-certificates-loader.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  async load (clientCertificate) {
+    return clientCertificate
+  }
+}

--- a/packages/bolt-connection/src/channel/deno/index.js
+++ b/packages/bolt-connection/src/channel/deno/index.js
@@ -17,7 +17,7 @@
 
 import DenoChannel from './deno-channel'
 import DenoHostNameResolver from './deno-host-name-resolver'
-
+import DenoClientCertificatesLoader from './deno-client-certificates-loader'
 /*
 
  This module exports a set of components to be used in deno environment.
@@ -30,3 +30,4 @@ import DenoHostNameResolver from './deno-host-name-resolver'
   */
 export const Channel = DenoChannel
 export const HostNameResolver = DenoHostNameResolver
+export const ClientCertificatesLoader = DenoClientCertificatesLoader

--- a/packages/bolt-connection/src/channel/node/index.js
+++ b/packages/bolt-connection/src/channel/node/index.js
@@ -17,7 +17,7 @@
 
 import NodeChannel from './node-channel'
 import NodeHostNameResolver from './node-host-name-resolver'
-
+import NodeClientCertificatesLoader from './node-client-certificates-loader'
 /*
 
 This module exports a set of components to be used in NodeJS environment.
@@ -31,3 +31,4 @@ NOTE: exports in this module should have exactly the same names/structure as exp
 
 export const Channel = NodeChannel
 export const HostNameResolver = NodeHostNameResolver
+export const ClientCertificatesLoader = NodeClientCertificatesLoader

--- a/packages/bolt-connection/src/channel/node/node-channel.js
+++ b/packages/bolt-connection/src/channel/node/node-channel.js
@@ -50,9 +50,7 @@ const TrustStrategy = {
     const tlsOpts = newTlsOptions(
       config.address.host(),
       config.trustedCertificates.map(f => fs.readFileSync(f)),
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
-      config.clientCertificate != null ? config.clientCertificate.password : undefined
+      config.clientCertificate
     )
     const socket = tls.connect(
       config.address.port(),
@@ -85,9 +83,7 @@ const TrustStrategy = {
     const tlsOpts = newTlsOptions(
       config.address.host(),
       undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
-      config.clientCertificate != null ? config.clientCertificate.password : undefined
+      config.clientCertificate
     )
     const socket = tls.connect(
       config.address.port(),
@@ -121,9 +117,7 @@ const TrustStrategy = {
     const tlsOpts = newTlsOptions(
       config.address.host(),
       undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
-      config.clientCertificate != null ? config.clientCertificate.password : undefined
+      config.clientCertificate
     )
     const socket = tls.connect(
       config.address.port(),
@@ -218,14 +212,12 @@ function trustStrategyName (config) {
  * @param {string|undefined} passphrase an optional client cert passphrase
  * @return {Object} a new options object.
  */
-function newTlsOptions (hostname, ca = undefined, cert = undefined, key = undefined, passphrase = undefined) {
+function newTlsOptions (hostname, ca = undefined, clientCertificate = undefined) {
   return {
     rejectUnauthorized: false, // we manually check for this in the connect callback, to give a more helpful error to the user
     servername: hostname, // server name for the SNI (Server Name Indication) TLS extension
     ca, // optional CA useful for TRUST_CUSTOM_CA_SIGNED_CERTIFICATES trust mode,
-    cert,
-    key,
-    passphrase
+    ...clientCertificate
   }
 }
 

--- a/packages/bolt-connection/src/channel/node/node-channel.js
+++ b/packages/bolt-connection/src/channel/node/node-channel.js
@@ -51,7 +51,7 @@ const TrustStrategy = {
       config.address.host(),
       config.trustedCertificates.map(f => fs.readFileSync(f)),
       config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
       config.clientCertificate != null ? config.clientCertificate.password : undefined
     )
     const socket = tls.connect(
@@ -86,7 +86,7 @@ const TrustStrategy = {
       config.address.host(),
       undefined,
       config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
       config.clientCertificate != null ? config.clientCertificate.password : undefined
     )
     const socket = tls.connect(
@@ -122,7 +122,7 @@ const TrustStrategy = {
       config.address.host(),
       undefined,
       config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
       config.clientCertificate != null ? config.clientCertificate.password : undefined
     )
     const socket = tls.connect(

--- a/packages/bolt-connection/src/channel/node/node-channel.js
+++ b/packages/bolt-connection/src/channel/node/node-channel.js
@@ -49,7 +49,10 @@ const TrustStrategy = {
 
     const tlsOpts = newTlsOptions(
       config.address.host(),
-      config.trustedCertificates.map(f => fs.readFileSync(f))
+      config.trustedCertificates.map(f => fs.readFileSync(f)),
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? config.clientCertificate.password : undefined
     )
     const socket = tls.connect(
       config.address.port(),
@@ -79,7 +82,13 @@ const TrustStrategy = {
     return configureSocket(socket)
   },
   TRUST_SYSTEM_CA_SIGNED_CERTIFICATES: function (config, onSuccess, onFailure) {
-    const tlsOpts = newTlsOptions(config.address.host())
+    const tlsOpts = newTlsOptions(
+      config.address.host(),
+      undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? config.clientCertificate.password : undefined
+    )
     const socket = tls.connect(
       config.address.port(),
       config.address.resolvedHost(),
@@ -109,7 +118,13 @@ const TrustStrategy = {
     return configureSocket(socket)
   },
   TRUST_ALL_CERTIFICATES: function (config, onSuccess, onFailure) {
-    const tlsOpts = newTlsOptions(config.address.host())
+    const tlsOpts = newTlsOptions(
+      config.address.host(),
+      undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? config.clientCertificate.password : undefined
+    )
     const socket = tls.connect(
       config.address.port(),
       config.address.resolvedHost(),
@@ -198,13 +213,19 @@ function trustStrategyName (config) {
  * Create a new configuration options object for the {@code tls.connect()} call.
  * @param {string} hostname the target hostname.
  * @param {string|undefined} ca an optional CA.
+ * @param {string|undefined} cert an optional client cert.
+ * @param {string|undefined} key an optional client cert key.
+ * @param {string|undefined} passphrase an optional client cert passphrase
  * @return {Object} a new options object.
  */
-function newTlsOptions (hostname, ca = undefined) {
+function newTlsOptions (hostname, ca = undefined, cert = undefined, key = undefined, passphrase = undefined) {
   return {
     rejectUnauthorized: false, // we manually check for this in the connect callback, to give a more helpful error to the user
     servername: hostname, // server name for the SNI (Server Name Indication) TLS extension
-    ca // optional CA useful for TRUST_CUSTOM_CA_SIGNED_CERTIFICATES trust mode
+    ca, // optional CA useful for TRUST_CUSTOM_CA_SIGNED_CERTIFICATES trust mode,
+    cert,
+    key,
+    passphrase
   }
 }
 

--- a/packages/bolt-connection/src/channel/node/node-client-certificates-loader.js
+++ b/packages/bolt-connection/src/channel/node/node-client-certificates-loader.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs'
+
+function readFile (file) {
+  return new Promise((resolve, reject) => fs.readFile(file, (err, data) => {
+    if (err) {
+      return reject(err)
+    }
+    return resolve(data)
+  }))
+}
+
+function loadCert (fileOrFiles) {
+  if (Array.isArray(fileOrFiles)) {
+    return Promise.all(fileOrFiles.map(loadCert))
+  }
+  return readFile(fileOrFiles)
+}
+
+function loadKey (fileOrFiles) {
+  if (Array.isArray(fileOrFiles)) {
+    return Promise.all(fileOrFiles.map(loadKey))
+  }
+
+  if (typeof fileOrFiles === 'string') {
+    return readFile(fileOrFiles)
+  }
+
+  return readFile(fileOrFiles.path)
+    .then(pem => ({
+      pem,
+      passphrase: fileOrFiles.password
+    }))
+}
+
+export default {
+  async load (clientCertificate) {
+    const certPromise = loadCert(clientCertificate.certfile)
+    const keyPromise = loadKey(clientCertificate.keyfile)
+
+    const [cert, key] = await Promise.all([certPromise, keyPromise])
+
+    return {
+      cert,
+      key,
+      passphrase: clientCertificate.password
+    }
+  }
+}

--- a/packages/bolt-connection/src/connection-provider/client-certificate-holder.js
+++ b/packages/bolt-connection/src/connection-provider/client-certificate-holder.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ClientCertificatesLoader } from '../channel'
+
+export default class ClientCertificateHolder {
+  constructor ({ clientCertificateProvider, loader }) {
+    this._clientCertificateProvider = clientCertificateProvider
+    this._loader = loader || ClientCertificatesLoader
+    this._clientCertificate = null
+  }
+
+  async getClientCertificate () {
+    if (this._clientCertificateProvider != null &&
+      (this._clientCertificate == null || await this._clientCertificateProvider.hasUpdate())) {
+      this._clientCertificate = Promise.resolve(this._clientCertificateProvider.getClientCertificate())
+        .then(this._loader.load)
+        .then(clientCertificate => {
+          this._clientCertificate = clientCertificate
+          return this._clientCertificate
+        })
+        .catch(error => {
+          this._clientCertificate = null
+          throw error
+        })
+    }
+
+    return this._clientCertificate
+  }
+}

--- a/packages/bolt-connection/src/connection-provider/connection-provider-direct.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-direct.js
@@ -17,7 +17,6 @@
 
 import PooledConnectionProvider from './connection-provider-pooled'
 import {
-  createChannelConnection,
   DelegateConnection,
   ConnectionErrorHandler
 } from '../connection'
@@ -75,12 +74,7 @@ export default class DirectConnectionProvider extends PooledConnectionProvider {
   }
 
   async _hasProtocolVersion (versionPredicate) {
-    const connection = await createChannelConnection(
-      this._address,
-      this._config,
-      this._createConnectionErrorHandler(),
-      this._log
-    )
+    const connection = await this._createChannelConnection(this._address)
 
     const protocolVersion = connection.protocol()
       ? connection.protocol().version

--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -83,11 +83,15 @@ export default class PooledConnectionProvider extends ConnectionProvider {
       return
     }
     if (this._clientCertificate == null || await this._config.clientCertificate.hasUpdate()) {
-      this._clientCertificate = this._config.clientCertificate.getClientCertificate()
+      this._clientCertificate = this._getClientCertificate()
         .then(clientCertificate => {
           this._clientCertificate = clientCertificate
         })
     }
+  }
+
+  async _getClientCertificate () {
+    return this._config.clientCertificate.getClientCertificate()
   }
 
   /**

--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -21,6 +21,7 @@ import { error, ConnectionProvider, ServerInfo, newError } from 'neo4j-driver-co
 import AuthenticationProvider from './authentication-provider'
 import { object } from '../lang'
 import LivenessCheckProvider from './liveness-check-provider'
+import { ClientCertificatesLoader } from '../channel'
 
 const { SERVICE_UNAVAILABLE } = error
 const AUTHENTICATION_ERRORS = [
@@ -84,6 +85,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     }
     if (this._clientCertificate == null || await this._config.clientCertificate.hasUpdate()) {
       this._clientCertificate = this._getClientCertificate()
+        .then(ClientCertificatesLoader.load)
         .then(clientCertificate => {
           this._clientCertificate = clientCertificate
         })

--- a/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-pooled.js
@@ -49,7 +49,6 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     this._createChannelConnection =
       createChannelConnectionHook ||
       (async address => {
-        await this._updateClientCertificateWhenNeeded()
         return createChannelConnection(
           address,
           this._config,

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -71,12 +71,14 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     routingTablePurgeDelay,
     newPool
   }) {
-    super({ id, config, log, userAgent, boltAgent, authTokenManager, newPool }, address => {
+    super({ id, config, log, userAgent, boltAgent, authTokenManager, newPool }, async address => {
+      await this._updateClientCertificateWhenNeeded()
       return createChannelConnection(
         address,
         this._config,
         this._createConnectionErrorHandler(),
         this._log,
+        await this._clientCertificate,
         this._routingContext
       )
     })
@@ -212,12 +214,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     let lastError
     for (let i = 0; i < addresses.length; i++) {
       try {
-        const connection = await createChannelConnection(
-          addresses[i],
-          this._config,
-          this._createConnectionErrorHandler(),
-          this._log
-        )
+        const connection = await this._createChannelConnection(addresses[i])
         const protocolVersion = connection.protocol()
           ? connection.protocol().version
           : null

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -72,13 +72,12 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     newPool
   }) {
     super({ id, config, log, userAgent, boltAgent, authTokenManager, newPool }, async address => {
-      await this._updateClientCertificateWhenNeeded()
       return createChannelConnection(
         address,
         this._config,
         this._createConnectionErrorHandler(),
         this._log,
-        await this._clientCertificate,
+        await this._clientCertificateHolder.getClientCertificate(),
         this._routingContext
       )
     })

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -33,6 +33,7 @@ let idGenerator = 0
  * @param {Object} config - the driver configuration.
  * @param {ConnectionErrorHandler} errorHandler - the error handler for connection errors.
  * @param {Logger} log - configured logger.
+ * @param {clientCertificate} clientCertificate - configured client certificate
  * @return {Connection} - new connection.
  */
 export function createChannelConnection (
@@ -40,13 +41,15 @@ export function createChannelConnection (
   config,
   errorHandler,
   log,
+  clientCertificate,
   serversideRouting = null,
   createChannel = channelConfig => new Channel(channelConfig)
 ) {
   const channelConfig = new ChannelConfig(
     address,
     config,
-    errorHandler.errorCode()
+    errorHandler.errorCode(),
+    clientCertificate
   )
 
   const channel = createChannel(channelConfig)

--- a/packages/bolt-connection/test/connection-provider/client-certificate-holder.test.js
+++ b/packages/bolt-connection/test/connection-provider/client-certificate-holder.test.js
@@ -1,0 +1,313 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { clientCertificateProviders, newError } from 'neo4j-driver-core'
+import ClientCertificateHolder from '../../src/connection-provider/client-certificate-holder'
+
+describe('ClientCertificateHolder', () => {
+  describe('.getClientCertificate()', () => {
+    describe('when provider is not set', () => {
+      it('should resolve as null when provider is not set', async () => {
+        const config = extendsDefaultConfigWith()
+        const holder = new ClientCertificateHolder(config)
+
+        await expect(holder.getClientCertificate()).resolves.toBe(null)
+        expect(config.loader.load).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when provider is set', () => {
+      it('should load and resolve the loaded certificate in the first call', async () => {
+        const initialCertificate = {
+          keyfile: 'the file',
+          certfile: 'cert file'
+        }
+        const clientCertificateProvider = clientCertificateProviders.rotating({
+          initialCertificate
+        })
+
+        const config = extendsDefaultConfigWith({ clientCertificateProvider })
+        const holder = new ClientCertificateHolder(config)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...initialCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(initialCertificate)
+      })
+
+      it('should resolve the previous certificate if certificate was not updated', async () => {
+        const initialCertificate = {
+          keyfile: 'the file',
+          certfile: 'cert file'
+        }
+        const clientCertificateProvider = clientCertificateProviders.rotating({
+          initialCertificate
+        })
+
+        const config = extendsDefaultConfigWith({ clientCertificateProvider })
+        const holder = new ClientCertificateHolder(config)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...initialCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(initialCertificate)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...initialCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledTimes(1)
+      })
+
+      it('should update certificate when certificate get updated', async () => {
+        const initialCertificate = {
+          keyfile: 'the file',
+          certfile: 'cert file'
+        }
+        const newCertificate = {
+          keyfile: 'the new file',
+          certfile: 'new cert file'
+        }
+
+        const clientCertificateProvider = clientCertificateProviders.rotating({
+          initialCertificate
+        })
+
+        const config = extendsDefaultConfigWith({ clientCertificateProvider })
+        const holder = new ClientCertificateHolder(config)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...initialCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(initialCertificate)
+
+        clientCertificateProvider.updateCertificate(newCertificate)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...newCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledTimes(2)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...newCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledTimes(2)
+      })
+
+      it('should return same promise when multiple requests are depending on same loaded certificate', async () => {
+        const initialCertificate = {
+          keyfile: 'the file',
+          certfile: 'cert file'
+        }
+
+        const clientCertificateProvider = clientCertificateProviders.rotating({
+          initialCertificate
+        })
+
+        const promiseStates = []
+
+        clientCertificateProvider.getClientCertificate = jest.fn(() => {
+          const promiseState = {}
+          const promise = new Promise((resolve, reject) => {
+            promiseState.resolve = resolve
+            promiseState.reject = reject
+          })
+
+          promiseStates.push(promiseState)
+          return promise
+        })
+
+        const config = extendsDefaultConfigWith({ clientCertificateProvider })
+        const holder = new ClientCertificateHolder(config)
+
+        const certPromises = [
+          holder.getClientCertificate(),
+          holder.getClientCertificate(),
+          holder.getClientCertificate()
+        ]
+
+        expect(promiseStates.length).toBe(1)
+        promiseStates.forEach(promiseState => promiseState.resolve(initialCertificate))
+
+        for (let i = 0; i < certPromises.length - 1; i++) {
+          await expect(certPromises[i]).resolves.toEqual({
+            ...initialCertificate,
+            loaded: true
+          })
+        }
+
+        expect(config.loader.load).toHaveBeenCalledTimes(1)
+      })
+
+      it('should throws when getting certificates fail', async () => {
+        const initialCertificate = {
+          keyfile: 'the file',
+          certfile: 'cert file'
+        }
+        const newCertificate = {
+          keyfile: 'the new file',
+          certfile: 'new cert file'
+        }
+        const clientCertificateProvider = clientCertificateProviders.rotating({
+          initialCertificate
+        })
+
+        const config = extendsDefaultConfigWith({ clientCertificateProvider })
+        const holder = new ClientCertificateHolder(config)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...initialCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(initialCertificate)
+
+        clientCertificateProvider.updateCertificate(newCertificate)
+
+        const expectedError = newError('Error')
+        clientCertificateProvider.getClientCertificate = jest.fn(() => Promise.reject(expectedError))
+
+        await expect(holder.getClientCertificate()).rejects.toEqual(expectedError)
+
+        expect(config.loader.load).toHaveBeenCalledTimes(1)
+      })
+
+      it('should recover from getting certificates failures', async () => {
+        const initialCertificate = {
+          keyfile: 'the file',
+          certfile: 'cert file'
+        }
+        const newCertificate = {
+          keyfile: 'the new file',
+          certfile: 'new cert file'
+        }
+        const clientCertificateProvider = clientCertificateProviders.rotating({
+          initialCertificate
+        })
+
+        const config = extendsDefaultConfigWith({ clientCertificateProvider })
+        const holder = new ClientCertificateHolder(config)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...initialCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(initialCertificate)
+
+        clientCertificateProvider.updateCertificate(newCertificate)
+
+        const expectedError = newError('Error')
+        clientCertificateProvider.getClientCertificate = jest.fn(() => Promise.reject(expectedError))
+
+        await expect(holder.getClientCertificate()).rejects.toEqual(expectedError)
+        expect(config.loader.load).toHaveBeenCalledTimes(1)
+
+        clientCertificateProvider.getClientCertificate = jest.fn(() => Promise.resolve(newCertificate))
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...newCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(newCertificate)
+      })
+
+      it('should throws when loading certificates fail', async () => {
+        const initialCertificate = {
+          keyfile: 'the file',
+          certfile: 'cert file'
+        }
+        const newCertificate = {
+          keyfile: 'the new file',
+          certfile: 'new cert file'
+        }
+        const clientCertificateProvider = clientCertificateProviders.rotating({
+          initialCertificate
+        })
+
+        const config = extendsDefaultConfigWith({ clientCertificateProvider })
+        const holder = new ClientCertificateHolder(config)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...initialCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(initialCertificate)
+
+        clientCertificateProvider.updateCertificate(newCertificate)
+
+        const expectedError = newError('Error')
+        config.loader.load.mockReturnValueOnce(Promise.reject(expectedError))
+
+        await expect(holder.getClientCertificate()).rejects.toEqual(expectedError)
+
+        expect(config.loader.load).toHaveBeenCalledTimes(2)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...newCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(newCertificate)
+        expect(config.loader.load).toHaveBeenCalledTimes(3)
+      })
+
+      it('should recover from loading certificates fail', async () => {
+        const initialCertificate = {
+          keyfile: 'the file',
+          certfile: 'cert file'
+        }
+        const newCertificate = {
+          keyfile: 'the new file',
+          certfile: 'new cert file'
+        }
+        const clientCertificateProvider = clientCertificateProviders.rotating({
+          initialCertificate
+        })
+
+        const config = extendsDefaultConfigWith({ clientCertificateProvider })
+        const holder = new ClientCertificateHolder(config)
+
+        await expect(holder.getClientCertificate()).resolves.toEqual({
+          ...initialCertificate,
+          loaded: true
+        })
+        expect(config.loader.load).toHaveBeenCalledWith(initialCertificate)
+
+        clientCertificateProvider.updateCertificate(newCertificate)
+
+        const expectedError = newError('Error')
+        config.loader.load.mockReturnValueOnce(Promise.reject(expectedError))
+
+        await expect(holder.getClientCertificate()).rejects.toEqual(expectedError)
+
+        expect(config.loader.load).toHaveBeenCalledTimes(2)
+      })
+    })
+  })
+})
+
+function extendsDefaultConfigWith (params) {
+  return {
+    clientCertificateProvider: null,
+    loader: {
+      load: jest.fn(async a => ({ ...a, loaded: true }))
+    },
+    ...params
+  }
+}

--- a/packages/core/src/client-certificate.ts
+++ b/packages/core/src/client-certificate.ts
@@ -63,7 +63,7 @@ export default class ClientCertificate {
     this.keyfile = ''
 
     /**
-     * The certificate's password.
+     * The key's password.
      *
      * @type {string|undefined}
      */

--- a/packages/core/src/client-certificate.ts
+++ b/packages/core/src/client-certificate.ts
@@ -32,24 +32,24 @@ export default class ClientCertificate {
 
   private constructor () {
     /**
-             * The path to client certificate file.
-             *
-             * @type {string}
-             */
+     * The path to client certificate file.
+     *
+     * @type {string}
+     */
     this.certfile = ''
 
     /**
-             * The path to the key file.
-             *
-             * @type {string}
-             */
+     * The path to the key file.
+     *
+     * @type {string}
+     */
     this.keyfile = ''
 
     /**
-             * The certificate's password.
-             *
-             * @type {string|undefined}
-             */
+     * The certificate's password.
+     *
+     * @type {string|undefined}
+     */
     this.password = undefined
   }
 }
@@ -73,22 +73,22 @@ export default class ClientCertificate {
  */
 export class ClientCertificateProvider {
   /**
-     * Indicates whether the client wants the driver to update the certificate.
-     *
-     * @returns {Promise<boolean>|boolean} true if the client wants the driver to update the certificate
-    */
+   * Indicates whether the client wants the driver to update the certificate.
+   *
+   * @returns {Promise<boolean>|boolean} true if the client wants the driver to update the certificate
+   */
   hasUpdate (): boolean | Promise<boolean> {
     throw new Error('Not Implemented')
   }
 
   /**
-     * Returns the certificate to use for new connections.
-     *
-     * Will be called by the driver after {@link ClientCertificateProvider#hasUpdate()} returned true
-     * or when the driver establishes the first connection.
-     *
-     * @returns {Promise<ClientCertificate>|ClientCertificate} the certificate to use for new connections
-     */
+   * Returns the certificate to use for new connections.
+   *
+   * Will be called by the driver after {@link ClientCertificateProvider#hasUpdate()} returned true
+   * or when the driver establishes the first connection.
+   *
+   * @returns {Promise<ClientCertificate>|ClientCertificate} the certificate to use for new connections
+   */
   getClientCertificate (): ClientCertificate | Promise<ClientCertificate> {
     throw new Error('Not Implemented')
   }
@@ -100,12 +100,12 @@ export class ClientCertificateProvider {
  */
 export class RotatingClientCertificateProvider extends ClientCertificateProvider {
   /**
-     * Updates the certificate stored in the provider.
-     *
-     * To be called by user-code when a new client certificate is available.
-     *
-     * @param {ClientCertificate} certificate - the new certificate
-     */
+   * Updates the certificate stored in the provider.
+   *
+   * To be called by user-code when a new client certificate is available.
+   *
+   * @param {ClientCertificate} certificate - the new certificate
+   */
   updateCertificate (certificate: ClientCertificate): void {
     throw new Error('Not implemented')
   }
@@ -116,12 +116,12 @@ export class RotatingClientCertificateProvider extends ClientCertificateProvider
  */
 class ClientCertificateProviders {
   /**
-     *
-     * @param {object} param0 - The params
-     * @param {ClientCertificate} param0.initialCertificate - The certificated used by the driver until {@link RotatingClientCertificateProvider#updateCertificate} get called.
-     *
-     * @returns {RotatingClientCertificateProvider} The rotating client certificate provider
-     */
+   *
+   * @param {object} param0 - The params
+   * @param {ClientCertificate} param0.initialCertificate - The certificated used by the driver until {@link RotatingClientCertificateProvider#updateCertificate} get called.
+   *
+   * @returns {RotatingClientCertificateProvider} The rotating client certificate provider
+   */
   rotating ({ initialCertificate }: { initialCertificate: ClientCertificate }): RotatingClientCertificateProvider {
     if (initialCertificate == null || typeof initialCertificate !== 'object') {
       throw new TypeError(`initialCertificate should be ClientCertificate, but got ${json.stringify(initialCertificate)}`)

--- a/packages/core/src/client-certificate.ts
+++ b/packages/core/src/client-certificate.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Holds the Client TLS certificate information.
+ *
+ * Browser instances of the driver should configure the certificate
+ * in the system.
+ *
+ * @interface
+ */
+export default class ClientCertificate {
+  public readonly certfile: string
+  public readonly keyfile: string
+  public readonly password?: string
+
+  private constructor () {
+    /**
+         * The path to client certificate file.
+         *
+         * @type {string}
+         */
+    this.certfile = ''
+
+    /**
+         * The path to the key file.
+         *
+         * @type {string}
+         */
+    this.keyfile = ''
+
+    /**
+         * The certificate's password.
+         *
+         * @type {string|undefined}
+         */
+    this.password = undefined
+  }
+}
+
+/**
+ * Provides a client certificate to the driver for mutual TLS.
+ *
+ * The driver will call {@link ClientCertificateProvider#hasUpdate()} to check if the client wants to update the certificate.
+ * If so, it will call {@link ClientCertificateProvider#getCertificate()} to get the new certificate.
+ *
+ * The certificate is only used as a second factor for authentication authenticating the client.
+ * The DMBS user still needs to authenticate with an authentication token.
+ *
+ * All implementations of this interface must be thread-safe and non-blocking for caller threads.
+ * For instance, IO operations must not be done on the calling thread.
+ *
+ * Note that the work done in the methods of this interface count towards the connectionAcquisition.
+ * Should fetching the certificate be particularly slow, it might be necessary to increase the timeout.
+ *
+ * @interface
+ */
+export class ClientCertificateProvider {
+  /**
+     * Indicates whether the client wants the driver to update the certificate.
+     *
+     * @returns {Promise<boolean>|boolean} true if the client wants the driver to update the certificate
+     */
+
+  hasUpdate (): boolean | Promise<boolean> {
+    throw new Error('Not Implemented')
+  }
+
+  /**
+     * Returns the certificate to use for new connections.
+     *
+     * Will be called by the driver after {@link ClientCertificateProvider#hasUpdate()} returned true
+     * or when the driver establishes the first connection.
+     *
+     * @returns {Promise<ClientCertificate>|ClientCertificate} the certificate to use for new connections
+     */
+  getClientCertificate (): ClientCertificate | Promise<ClientCertificate> {
+    throw new Error('Not Implemented')
+  }
+}
+
+/**
+ * Interface for  {@link ClientCertificateProvider} which provides update certificate function.
+ * @interface
+ */
+export class RotatingClientCertificateProvider extends ClientCertificateProvider {
+  /**
+     * Updates the certificate stored in the provider.
+     *
+     * To be called by user-code when a new client certificate is available.
+     *
+     * @param {ClientCertificate} certificate - the new certificate
+     */
+  updateCertificate (certificate: ClientCertificate): void {
+    throw new Error('Not implemented')
+  }
+}
+
+/**
+ * Defines the object which holds the common {@link ClientCertificateProviders} used in the Driver
+ */
+class ClientCertificateProviders {
+  /**
+     *
+     * @param {object} param0 - The params
+     * @param {ClientCertificate} param0.initialCertificate - The certificated used by the driver until {@link RotatingClientCertificateProvider#updateCertificate} get called.
+     *
+     * @returns {RotatingClientCertificateProvider} The rotating client certificate provider
+     */
+  rotating ({ initialCertificate }: { initialCertificate: ClientCertificate }): RotatingClientCertificateProvider {
+    throw new Error('Not implemented')
+  }
+}
+
+/**
+ * Holds the common {@link ClientCertificateProviders} used in the Driver.
+ */
+const clientCertificateProviders: ClientCertificateProviders = new ClientCertificateProviders()
+
+Object.freeze(clientCertificateProviders)
+
+export {
+  clientCertificateProviders
+}
+
+export type {
+  ClientCertificateProviders
+}

--- a/packages/core/src/client-certificate.ts
+++ b/packages/core/src/client-certificate.ts
@@ -147,6 +147,28 @@ export type {
   ClientCertificateProviders
 }
 
+export function resolveCertificateProvider (input: unknown): ClientCertificateProvider | undefined {
+  if (input == null) {
+    return undefined
+  }
+
+  if (typeof input === 'object' && 'hasUpdate' in input && 'getClientCertificate' in input &&
+      typeof input.getClientCertificate === 'function' && typeof input.hasUpdate === 'function') {
+    return input as ClientCertificateProvider
+  }
+
+  if (typeof input === 'object' && 'certfile' in input && 'keyfile' in input &&
+    typeof input.certfile === 'string' && typeof input.keyfile === 'string') {
+    const certificate = { ...input } as unknown as ClientCertificate
+    return {
+      getClientCertificate: () => certificate,
+      hasUpdate: () => false
+    }
+  }
+
+  throw new TypeError(`clientCertificate should be configured with ClientCertificate or ClientCertificateProvider, but got ${json.stringify(input)}`)
+}
+
 /**
  * Internal implementation
  *

--- a/packages/core/src/client-certificate.ts
+++ b/packages/core/src/client-certificate.ts
@@ -17,31 +17,46 @@
 
 import * as json from './json'
 
+type KeyFile = string | { path: string, password?: string }
+
 /**
  * Holds the Client TLS certificate information.
  *
  * Browser instances of the driver should configure the certificate
  * in the system.
  *
+ * Files defined in the {@link ClientCertificate#certfile}
+ * and {@link ClientCertificate#keyfile} will read and loaded to
+ * memory to fill the fields `cert` and `key` in security context.
+ *
  * @interface
+ * @see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
+ */
+/**
+ * Represents KeyFile represented as file.
+ *
+ * @typedef {object} KeyFileObject
+ * @property {string} path - The path of the file
+ * @property {string?} password - the password of the key. If none,
+ * the password defined at {@link ClientCertificate} will be used.
  */
 export default class ClientCertificate {
-  public readonly certfile: string
-  public readonly keyfile: string
+  public readonly certfile: string | string[]
+  public readonly keyfile: KeyFile | KeyFile[]
   public readonly password?: string
 
   private constructor () {
     /**
      * The path to client certificate file.
      *
-     * @type {string}
+     * @type {string | string}
      */
     this.certfile = ''
 
     /**
      * The path to the key file.
      *
-     * @type {string}
+     * @type {string | string[] | KeyFileObject | KeyFileObject[] }
      */
     this.keyfile = ''
 
@@ -190,9 +205,75 @@ export function resolveCertificateProvider (input: unknown): ClientCertificatePr
 function isClientClientCertificate (maybeClientCertificate: unknown): maybeClientCertificate is ClientCertificate {
   return maybeClientCertificate != null &&
     typeof maybeClientCertificate === 'object' &&
-    'certfile' in maybeClientCertificate && typeof maybeClientCertificate.certfile === 'string' &&
-    'keyfile' in maybeClientCertificate && typeof maybeClientCertificate.keyfile === 'string' &&
-    (!('password' in maybeClientCertificate) || maybeClientCertificate.password == null || typeof maybeClientCertificate.password === 'string')
+    'certfile' in maybeClientCertificate && isCertFile(maybeClientCertificate.certfile) &&
+    'keyfile' in maybeClientCertificate && isKeyFile(maybeClientCertificate.keyfile) &&
+    isStringOrNotPresent('password', maybeClientCertificate)
+}
+
+/**
+ * Check value is a cert file
+ * @private
+ * @param {any} value the value
+ * @returns {boolean} is a cert file
+ */
+function isCertFile (value: unknown): value is string | string [] {
+  return isString(value) || isArrayOf(value, isString)
+}
+
+/**
+ * Check if the value is a keyfile.
+ *
+ * @private
+ * @param {any} maybeKeyFile might be a keyfile value
+ * @returns {boolean} the value is a KeyFile
+ */
+function isKeyFile (maybeKeyFile: unknown): maybeKeyFile is KeyFile {
+  function check (obj: unknown): obj is KeyFile {
+    return typeof obj === 'string' ||
+      (obj != null &&
+      typeof obj === 'object' &&
+      'path' in obj && typeof obj.path === 'string' &&
+      isStringOrNotPresent('password', obj))
+  }
+
+  return check(maybeKeyFile) || isArrayOf(maybeKeyFile, check)
+}
+
+/**
+ * Verify if value is string
+ *
+ * @private
+ * @param {any} value the value
+ * @returns {boolean} is string
+ */
+function isString (value: unknown): value is string {
+  return typeof value === 'string'
+}
+
+/**
+ * Verifies if value is a array of type
+ *
+ * @private
+ * @param {any} value the value
+ * @param {function} isType the type checker
+ * @returns {boolean} value is array of type
+ */
+function isArrayOf<T> (value: unknown, isType: (val: unknown) => val is T, allowEmpty: boolean = false): value is T[] {
+  return Array.isArray(value) &&
+    (allowEmpty || value.length > 0) &&
+    value.filter(isType).length === value.length
+}
+
+/**
+ * Verify if valueName is present in the object and is a string, or not present at all.
+ *
+ * @private
+ * @param {string} valueName The value in the object
+ * @param {object} obj The object
+ * @returns {boolean} if the value is present in object as string or not present
+ */
+function isStringOrNotPresent (valueName: string, obj: Record<string, any>): boolean {
+  return !(valueName in obj) || obj[valueName] == null || typeof obj[valueName] === 'string'
 }
 
 /**

--- a/packages/core/src/client-certificate.ts
+++ b/packages/core/src/client-certificate.ts
@@ -20,6 +20,14 @@ import * as json from './json'
 type KeyFile = string | { path: string, password?: string }
 
 /**
+ * Represents KeyFile represented as file.
+ *
+ * @typedef {object} KeyFileObject
+ * @property {string} path - The path of the file
+ * @property {string|undefined} password - the password of the key. If none,
+ * the password defined at {@link ClientCertificate} will be used.
+ */
+/**
  * Holds the Client TLS certificate information.
  *
  * Browser instances of the driver should configure the certificate
@@ -32,14 +40,6 @@ type KeyFile = string | { path: string, password?: string }
  * @interface
  * @see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
  */
-/**
- * Represents KeyFile represented as file.
- *
- * @typedef {object} KeyFileObject
- * @property {string} path - The path of the file
- * @property {string?} password - the password of the key. If none,
- * the password defined at {@link ClientCertificate} will be used.
- */
 export default class ClientCertificate {
   public readonly certfile: string | string[]
   public readonly keyfile: KeyFile | KeyFile[]
@@ -49,14 +49,14 @@ export default class ClientCertificate {
     /**
      * The path to client certificate file.
      *
-     * @type {string | string}
+     * @type {string|string[]}
      */
     this.certfile = ''
 
     /**
      * The path to the key file.
      *
-     * @type {string | string[] | KeyFileObject | KeyFileObject[] }
+     * @type {string|string[]|KeyFileObject|KeyFileObject[]}
      */
     this.keyfile = ''
 
@@ -200,7 +200,6 @@ export function resolveCertificateProvider (input: unknown): ClientCertificatePr
  * @private
  * @param maybeClientCertificate - Maybe the certificate
  * @returns {boolean} if maybeClientCertificate is a client certificate object
- *
  */
 function isClientClientCertificate (maybeClientCertificate: unknown): maybeClientCertificate is ClientCertificate {
   return maybeClientCertificate != null &&
@@ -287,6 +286,11 @@ class InternalRotatingClientCertificateProvider {
     private _updated: boolean = false) {
   }
 
+  /**
+   *
+   * @returns {boolean|Promise<boolean>}
+   */
+
   hasUpdate (): boolean | Promise<boolean> {
     try {
       return this._updated
@@ -295,10 +299,19 @@ class InternalRotatingClientCertificateProvider {
     }
   }
 
+  /**
+   *
+   * @returns {ClientCertificate|Promise<ClientCertificate>}
+   */
   getClientCertificate (): ClientCertificate | Promise<ClientCertificate> {
     return this._certificate
   }
 
+  /**
+   *
+   * @param certificate
+   * @returns {void}
+   */
   updateCertificate (certificate: ClientCertificate): void {
     if (!isClientClientCertificate(certificate)) {
       throw new TypeError(`certificate should be ClientCertificate, but got ${json.stringify(certificate)}`)

--- a/packages/core/src/client-certificate.ts
+++ b/packages/core/src/client-certificate.ts
@@ -39,6 +39,8 @@ type KeyFile = string | { path: string, password?: string }
  *
  * @interface
  * @see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 export default class ClientCertificate {
   public readonly certfile: string | string[]
@@ -85,6 +87,8 @@ export default class ClientCertificate {
  * Should fetching the certificate be particularly slow, it might be necessary to increase the timeout.
  *
  * @interface
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 export class ClientCertificateProvider {
   /**
@@ -112,6 +116,8 @@ export class ClientCertificateProvider {
 /**
  * Interface for  {@link ClientCertificateProvider} which provides update certificate function.
  * @interface
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 export class RotatingClientCertificateProvider extends ClientCertificateProvider {
   /**
@@ -129,6 +135,9 @@ export class RotatingClientCertificateProvider extends ClientCertificateProvider
 
 /**
  * Defines the object which holds the common {@link ClientCertificateProviders} used in the Driver
+ *
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 class ClientCertificateProviders {
   /**
@@ -151,6 +160,9 @@ class ClientCertificateProviders {
 
 /**
  * Holds the common {@link ClientCertificateProviders} used in the Driver.
+ *
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 const clientCertificateProviders: ClientCertificateProviders = new ClientCertificateProviders()
 

--- a/packages/core/src/connection-provider.ts
+++ b/packages/core/src/connection-provider.ts
@@ -28,6 +28,9 @@ import { AuthToken } from './types'
  * @interface
  */
 class Releasable {
+  /**
+   * @returns {Promise<void>}
+   */
   release (): Promise<void> {
     throw new Error('Not implemented')
   }

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -72,34 +72,72 @@ interface RunQueryConfig extends BeginTransactionConfig {
  * @interface
  */
 class Connection {
+  /**
+   *
+   * @param config
+   * @returns {ResultStreamObserver}
+   */
   beginTransaction (config: BeginTransactionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @param query
+   * @param parameters
+   * @param config
+   * @returns {ResultStreamObserver}
+   */
   run (query: string, parameters?: Record<string, unknown>, config?: RunQueryConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @param config
+   * @returns {ResultStreamObserver}
+   */
   commitTransaction (config: CommitTransactionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @param config
+   * @returns {ResultStreamObserver}
+   */
   rollbackTransaction (config: RollbackConnectionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @returns {Promise<void>}
+   */
   resetAndFlush (): Promise<void> {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @returns {boolean}
+   */
   isOpen (): boolean {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @returns {number}
+   */
   getProtocolVersion (): number {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @returns {boolean}
+   */
   hasOngoingObservableRequests (): boolean {
     throw new Error('Not implemented')
   }

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -906,6 +906,7 @@ function validateConfig (config: any, log: Logger): any {
 
 /**
  * @private
+ * @returns {void}
  */
 function sanitizeConfig (config: any): void {
   config.maxConnectionLifetime = sanitizeIntValue(
@@ -932,6 +933,7 @@ function sanitizeConfig (config: any): void {
 
 /**
  * @private
+ * @returns {number}
  */
 function sanitizeIntValue (rawValue: any, defaultWhenAbsent: number): number {
   const sanitizedValue = parseInt(rawValue, 10)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,7 +91,7 @@ import { Config } from './types'
 import * as types from './types'
 import * as json from './json'
 import resultTransformers, { ResultTransformer } from './result-transformers'
-import ClientCertificate, { clientCertificateProviders, ClientCertificateProvider, ClientCertificateProviders, RotatingClientCertificateProvider } from './client-certificate'
+import ClientCertificate, { clientCertificateProviders, ClientCertificateProvider, ClientCertificateProviders, RotatingClientCertificateProvider, resolveCertificateProvider } from './client-certificate'
 import * as internal from './internal' // todo: removed afterwards
 
 /**
@@ -171,7 +171,8 @@ const forExport = {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  clientCertificateProviders
+  clientCertificateProviders,
+  resolveCertificateProvider
 }
 
 export {
@@ -241,7 +242,8 @@ export {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  clientCertificateProviders
+  clientCertificateProviders,
+  resolveCertificateProvider
 }
 
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,7 @@ import { Config } from './types'
 import * as types from './types'
 import * as json from './json'
 import resultTransformers, { ResultTransformer } from './result-transformers'
+import ClientCertificate, { clientCertificateProviders, ClientCertificateProvider, ClientCertificateProviders, RotatingClientCertificateProvider } from './client-certificate'
 import * as internal from './internal' // todo: removed afterwards
 
 /**
@@ -169,7 +170,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 
 export {
@@ -238,7 +240,8 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 
 export type {
@@ -263,7 +266,11 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  ClientCertificate,
+  ClientCertificateProvider,
+  ClientCertificateProviders,
+  RotatingClientCertificateProvider
 }
 
 export default forExport

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -350,6 +350,8 @@ export class Config {
      * where the {@link ClientCertificate} might change over time.
      *
      * @type {ClientCertificate|ClientCertificateProvider|undefined}
+     * @experimental Exposed as preview feature.
+     * @since 5.19
      */
     this.clientCertificate = undefined
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import ClientCertificate, { ClientCertificateProvider } from './client-certificate'
 import NotificationFilter from './notification-filter'
 
 /**
@@ -80,6 +81,7 @@ export class Config {
   resolver?: (address: string) => string[] | Promise<string[]>
   userAgent?: string
   telemetryDisabled?: boolean
+  clientCertificate?: ClientCertificate | ClientCertificateProvider
 
   /**
    * @constructor
@@ -340,6 +342,16 @@ export class Config {
      * @type {boolean}
      */
     this.telemetryDisabled = false
+
+    /**
+     * Client Certificate used for mutual TLS.
+     *
+     * A {@link ClientCertificateProvider} can be configure for scenarios
+     * where the {@link ClientCertificate} might change over time.
+     *
+     * @type {ClientCertificate|ClientCertificateProvider|undefined}
+     */
+    this.clientCertificate = undefined
   }
 }
 

--- a/packages/core/test/client-certificate.test.ts
+++ b/packages/core/test/client-certificate.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { clientCertificateProviders } from '../src/client-certificate'
+
+describe('clientCertificateProviders', () => {
+  describe('.rotating()', () => {
+    describe.each([
+      undefined,
+      null,
+      {},
+      { initialCertificate: null },
+      {
+        someOtherProperty: {
+          certfile: 'other_file',
+          keyfile: 'some_file',
+          password: 'pass'
+        }
+      }
+    ])('when invalid configuration (%o)', (config) => {
+      it('should thrown TypeError', () => {
+        // @ts-expect-error
+        expect(() => clientCertificateProviders.rotating(config))
+          .toThrow(TypeError)
+      })
+    })
+
+    describe.each([
+      {
+        initialCertificate: {
+          certfile: 'other_file',
+          keyfile: 'some_file',
+          password: 'pass'
+        }
+      },
+      {
+        initialCertificate: {
+          certfile: 'other_file',
+          keyfile: 'some_file'
+        }
+      }
+    ])('when valid configuration (%o)', (config) => {
+      it('should return a RotatingClientCertificateProvider', () => {
+        const provider = clientCertificateProviders.rotating(config)
+
+        expect(provider).toBeDefined()
+        expect(provider.getClientCertificate).toBeInstanceOf(Function)
+        expect(provider.hasUpdate).toBeInstanceOf(Function)
+        expect(provider.updateCertificate).toBeInstanceOf(Function)
+      })
+
+      it('should getClientCertificate return a copy of initialCertificate until certificate is not update', async () => {
+        const provider = clientCertificateProviders.rotating(config)
+
+        for (let i = 0; i < 100; i++) {
+          const certificate = await provider.getClientCertificate()
+          expect(certificate).toEqual(config.initialCertificate)
+          expect(certificate).not.toBe(config.initialCertificate)
+        }
+
+        provider.updateCertificate({
+          certfile: 'new_cert_file',
+          keyfile: 'new_key_file',
+          password: 'new_pass_word'
+        })
+
+        const certificate = await provider.getClientCertificate()
+        expect(certificate).not.toEqual(config.initialCertificate)
+        expect(certificate).not.toBe(config.initialCertificate)
+      })
+
+      it('should updateCertificate change certificate for a new one', async () => {
+        const provider = clientCertificateProviders.rotating(config)
+
+        await expect(Promise.resolve(provider.getClientCertificate())).resolves.toEqual(config.initialCertificate)
+
+        for (let i = 0; i < 100; i++) {
+          const certificate = {
+            certfile: `new_cert_file${i}`,
+            keyfile: `new_key_file${i}`,
+            password: i % 2 === 0 ? `new_pass_word${i}` : undefined
+          }
+
+          provider.updateCertificate(certificate)
+
+          await expect(Promise.resolve(provider.getClientCertificate())).resolves.toEqual(certificate)
+          await expect(Promise.resolve(provider.getClientCertificate())).resolves.toEqual(certificate)
+          await expect(Promise.resolve(provider.getClientCertificate())).resolves.toEqual(certificate)
+        }
+      })
+
+      it('should hasUpdate Return false, unless updateCertificate() was called since the last call of hasUpdate', async () => {
+        const provider = clientCertificateProviders.rotating(config)
+
+        await expect(Promise.resolve(provider.hasUpdate())).resolves.toBe(false)
+
+        const certificate = {
+          certfile: 'new_cert_file',
+          keyfile: 'new_key_file'
+        }
+        provider.updateCertificate(certificate)
+
+        await expect(Promise.resolve(provider.hasUpdate())).resolves.toBe(true)
+        await expect(Promise.resolve(provider.hasUpdate())).resolves.toBe(false)
+
+        await expect(Promise.resolve(provider.getClientCertificate())).resolves.toEqual(certificate)
+        provider.updateCertificate(certificate)
+        await expect(Promise.resolve(provider.getClientCertificate())).resolves.toEqual(certificate)
+
+        await expect(Promise.resolve(provider.hasUpdate())).resolves.toBe(true)
+        await expect(Promise.resolve(provider.hasUpdate())).resolves.toBe(false)
+      })
+    })
+  })
+})

--- a/packages/core/test/client-certificate.test.ts
+++ b/packages/core/test/client-certificate.test.ts
@@ -126,7 +126,6 @@ describe('clientCertificateProviders', () => {
 
         await expect(Promise.resolve(provider.getClientCertificate())).resolves.toEqual(config.initialCertificate)
 
-        // @ts-expect-error
         expect(() => provider.updateCertificate(invalidCertificate)).toThrow(TypeError)
       })
 

--- a/packages/neo4j-driver-deno/README.md
+++ b/packages/neo4j-driver-deno/README.md
@@ -48,6 +48,8 @@ For Deno versions bellow `1.27.1`, you should use the flag `--allow-env` instead
 For using system certificates, the `DENO_TLS_CA_STORE` should be set to `"system"`.
 `TRUST_ALL_CERTIFICATES` should be handle by `--unsafely-ignore-certificate-errors` and not by driver configuration. See, https://deno.com/blog/v1.13#disable-tls-verification;
 
+Client certificates are not support in this version of the driver since there is no support for this feature in the DenoJS API. See, https://deno.land/api@v1.29.0?s=Deno.ConnectTlsOptions.
+
 ### Basic Example
 
 ```typescript

--- a/packages/neo4j-driver-deno/lib/README.md
+++ b/packages/neo4j-driver-deno/lib/README.md
@@ -48,6 +48,8 @@ For Deno versions bellow `1.27.1`, you should use the flag `--allow-env` instead
 For using system certificates, the `DENO_TLS_CA_STORE` should be set to `"system"`.
 `TRUST_ALL_CERTIFICATES` should be handle by `--unsafely-ignore-certificate-errors` and not by driver configuration. See, https://deno.com/blog/v1.13#disable-tls-verification;
 
+Client certificates are not support in this version of the driver since there is no support for this feature in the DenoJS API. See, https://deno.land/api@v1.29.0?s=Deno.ConnectTlsOptions.
+
 ### Basic Example
 
 ```typescript

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/browser/browser-client-certificates-loader.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/browser/browser-client-certificates-loader.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  async load (clientCertificate) {
+    return clientCertificate
+  }
+}

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/browser/index.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/browser/index.js
@@ -17,7 +17,7 @@
 
 import WebSocketChannel from './browser-channel.js'
 import BrowserHosNameResolver from './browser-host-name-resolver.js'
-
+import BrowserClientCertificatesLoader from './browser-client-certificates-loader.js'
 /*
 
 This module exports a set of components to be used in browser environment.
@@ -30,3 +30,4 @@ NOTE: exports in this module should have exactly the same names/structure as exp
  */
 export const Channel = WebSocketChannel
 export const HostNameResolver = BrowserHosNameResolver
+export const ClientCertificatesLoader = BrowserClientCertificatesLoader

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/channel-config.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/channel-config.js
@@ -46,8 +46,9 @@ export default class ChannelConfig {
    * @param {ServerAddress} address the address for the channel to connect to.
    * @param {Object} driverConfig the driver config provided by the user when driver is created.
    * @param {string} connectionErrorCode the default error code to use on connection errors.
+   * @param {object} clientCertificate the client certificate
    */
-  constructor (address, driverConfig, connectionErrorCode) {
+  constructor (address, driverConfig, connectionErrorCode, clientCertificate) {
     this.address = address
     this.encrypted = extractEncrypted(driverConfig)
     this.trust = extractTrust(driverConfig)
@@ -55,6 +56,7 @@ export default class ChannelConfig {
     this.knownHostsPath = extractKnownHostsPath(driverConfig)
     this.connectionErrorCode = connectionErrorCode || SERVICE_UNAVAILABLE
     this.connectionTimeout = driverConfig.connectionTimeout
+    this.clientCertificate = clientCertificate
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/deno/deno-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/deno/deno-channel.js
@@ -239,6 +239,8 @@ const TrustStrategy = {
       );
     }
 
+    assertNotClientCertificates(config)
+
     const caCerts = await Promise.all(
       config.trustedCertificates.map(f => Deno.readTextFile(f))
     )
@@ -250,6 +252,8 @@ const TrustStrategy = {
     })
   },
   TRUST_SYSTEM_CA_SIGNED_CERTIFICATES: function (config) {
+    assertNotClientCertificates(config)
+    
     return Deno.connectTls({ 
       hostname: config.address.resolvedHost(), 
       port: config.address.port()
@@ -263,6 +267,13 @@ const TrustStrategy = {
       'See, https://deno.com/blog/v1.13#disable-tls-verification'
     )
   }
+}
+
+async function assertNotClientCertificates (config) {
+  if (config.clientCertificate != null) {
+    throw newError('clientCertificates are not supported in DenoJS since the API does not ' +
+      'support its configuration. See, https://deno.land/api@v1.29.0?s=Deno.ConnectTlsOptions.')
+  } 
 }
 
 async function _connect (config) {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/deno/deno-client-certificates-loader.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/deno/deno-client-certificates-loader.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  async load (clientCertificate) {
+    return clientCertificate
+  }
+}

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/deno/index.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/deno/index.js
@@ -17,7 +17,7 @@
 
 import DenoChannel from './deno-channel.js'
 import DenoHostNameResolver from './deno-host-name-resolver.js'
-
+import DenoClientCertificatesLoader from './deno-client-certificates-loader.js'
 /*
 
  This module exports a set of components to be used in deno environment.
@@ -30,3 +30,4 @@ import DenoHostNameResolver from './deno-host-name-resolver.js'
   */
 export const Channel = DenoChannel
 export const HostNameResolver = DenoHostNameResolver
+export const ClientCertificatesLoader = DenoClientCertificatesLoader

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/index.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/index.js
@@ -17,7 +17,7 @@
 
 import NodeChannel from './node-channel.js'
 import NodeHostNameResolver from './node-host-name-resolver.js'
-
+import NodeClientCertificatesLoader from './node-client-certificates-loader.js'
 /*
 
 This module exports a set of components to be used in NodeJS environment.
@@ -31,3 +31,4 @@ NOTE: exports in this module should have exactly the same names/structure as exp
 
 export const Channel = NodeChannel
 export const HostNameResolver = NodeHostNameResolver
+export const ClientCertificatesLoader = NodeClientCertificatesLoader

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
@@ -50,9 +50,7 @@ const TrustStrategy = {
     const tlsOpts = newTlsOptions(
       config.address.host(),
       config.trustedCertificates.map(f => fs.readFileSync(f)),
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
-      config.clientCertificate != null ? config.clientCertificate.password : undefined
+      config.clientCertificate
     )
     const socket = tls.connect(
       config.address.port(),
@@ -85,9 +83,7 @@ const TrustStrategy = {
     const tlsOpts = newTlsOptions(
       config.address.host(),
       undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
-      config.clientCertificate != null ? config.clientCertificate.password : undefined
+      config.clientCertificate
     )
     const socket = tls.connect(
       config.address.port(),
@@ -121,9 +117,7 @@ const TrustStrategy = {
     const tlsOpts = newTlsOptions(
       config.address.host(),
       undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
-      config.clientCertificate != null ? config.clientCertificate.password : undefined
+      config.clientCertificate
     )
     const socket = tls.connect(
       config.address.port(),
@@ -218,14 +212,12 @@ function trustStrategyName (config) {
  * @param {string|undefined} passphrase an optional client cert passphrase
  * @return {Object} a new options object.
  */
-function newTlsOptions (hostname, ca = undefined, cert = undefined, key = undefined, passphrase = undefined) {
+function newTlsOptions (hostname, ca = undefined, clientCertificate = undefined) {
   return {
     rejectUnauthorized: false, // we manually check for this in the connect callback, to give a more helpful error to the user
     servername: hostname, // server name for the SNI (Server Name Indication) TLS extension
     ca, // optional CA useful for TRUST_CUSTOM_CA_SIGNED_CERTIFICATES trust mode,
-    cert,
-    key,
-    passphrase
+    ...clientCertificate
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
@@ -51,7 +51,7 @@ const TrustStrategy = {
       config.address.host(),
       config.trustedCertificates.map(f => fs.readFileSync(f)),
       config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
       config.clientCertificate != null ? config.clientCertificate.password : undefined
     )
     const socket = tls.connect(
@@ -86,7 +86,7 @@ const TrustStrategy = {
       config.address.host(),
       undefined,
       config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
       config.clientCertificate != null ? config.clientCertificate.password : undefined
     )
     const socket = tls.connect(
@@ -122,7 +122,7 @@ const TrustStrategy = {
       config.address.host(),
       undefined,
       config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
-      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.keyfile) : undefined,
       config.clientCertificate != null ? config.clientCertificate.password : undefined
     )
     const socket = tls.connect(

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
@@ -49,7 +49,10 @@ const TrustStrategy = {
 
     const tlsOpts = newTlsOptions(
       config.address.host(),
-      config.trustedCertificates.map(f => fs.readFileSync(f))
+      config.trustedCertificates.map(f => fs.readFileSync(f)),
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? config.clientCertificate.password : undefined
     )
     const socket = tls.connect(
       config.address.port(),
@@ -79,7 +82,13 @@ const TrustStrategy = {
     return configureSocket(socket)
   },
   TRUST_SYSTEM_CA_SIGNED_CERTIFICATES: function (config, onSuccess, onFailure) {
-    const tlsOpts = newTlsOptions(config.address.host())
+    const tlsOpts = newTlsOptions(
+      config.address.host(),
+      undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? config.clientCertificate.password : undefined
+    )
     const socket = tls.connect(
       config.address.port(),
       config.address.resolvedHost(),
@@ -109,7 +118,13 @@ const TrustStrategy = {
     return configureSocket(socket)
   },
   TRUST_ALL_CERTIFICATES: function (config, onSuccess, onFailure) {
-    const tlsOpts = newTlsOptions(config.address.host())
+    const tlsOpts = newTlsOptions(
+      config.address.host(),
+      undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.certfile) : undefined,
+      config.clientCertificate != null ? fs.readFileSync(config.clientCertificate.key) : undefined,
+      config.clientCertificate != null ? config.clientCertificate.password : undefined
+    )
     const socket = tls.connect(
       config.address.port(),
       config.address.resolvedHost(),
@@ -198,13 +213,19 @@ function trustStrategyName (config) {
  * Create a new configuration options object for the {@code tls.connect()} call.
  * @param {string} hostname the target hostname.
  * @param {string|undefined} ca an optional CA.
+ * @param {string|undefined} cert an optional client cert.
+ * @param {string|undefined} key an optional client cert key.
+ * @param {string|undefined} passphrase an optional client cert passphrase
  * @return {Object} a new options object.
  */
-function newTlsOptions (hostname, ca = undefined) {
+function newTlsOptions (hostname, ca = undefined, cert = undefined, key = undefined, passphrase = undefined) {
   return {
     rejectUnauthorized: false, // we manually check for this in the connect callback, to give a more helpful error to the user
     servername: hostname, // server name for the SNI (Server Name Indication) TLS extension
-    ca // optional CA useful for TRUST_CUSTOM_CA_SIGNED_CERTIFICATES trust mode
+    ca, // optional CA useful for TRUST_CUSTOM_CA_SIGNED_CERTIFICATES trust mode,
+    cert,
+    key,
+    passphrase
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-client-certificates-loader.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-client-certificates-loader.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs'
+
+function readFile (file) {
+  return new Promise((resolve, reject) => fs.readFile(file, (err, data) => {
+    if (err) {
+      return reject(err)
+    }
+    return resolve(data)
+  }))
+}
+
+function loadCert (fileOrFiles) {
+  if (Array.isArray(fileOrFiles)) {
+    return Promise.all(fileOrFiles.map(loadCert))
+  }
+  return readFile(fileOrFiles)
+}
+
+function loadKey (fileOrFiles) {
+  if (Array.isArray(fileOrFiles)) {
+    return Promise.all(fileOrFiles.map(loadKey))
+  }
+
+  if (typeof fileOrFiles === 'string') {
+    return readFile(fileOrFiles)
+  }
+
+  return readFile(fileOrFiles.path)
+    .then(pem => ({
+      pem,
+      passphrase: fileOrFiles.password
+    }))
+}
+
+export default {
+  async load (clientCertificate) {
+    const certPromise = loadCert(clientCertificate.certfile)
+    const keyPromise = loadKey(clientCertificate.keyfile)
+
+    const [cert, key] = await Promise.all([certPromise, keyPromise])
+
+    return {
+      cert,
+      key,
+      passphrase: clientCertificate.password
+    }
+  }
+}

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/client-certificate-holder.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/client-certificate-holder.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ClientCertificatesLoader } from '../channel/index.js'
+
+export default class ClientCertificateHolder {
+  constructor ({ clientCertificateProvider, loader }) {
+    this._clientCertificateProvider = clientCertificateProvider
+    this._loader = loader || ClientCertificatesLoader
+    this._clientCertificate = null
+  }
+
+  async getClientCertificate () {
+    if (this._clientCertificateProvider != null &&
+      (this._clientCertificate == null || await this._clientCertificateProvider.hasUpdate())) {
+      this._clientCertificate = Promise.resolve(this._clientCertificateProvider.getClientCertificate())
+        .then(this._loader.load)
+        .then(clientCertificate => {
+          this._clientCertificate = clientCertificate
+          return this._clientCertificate
+        })
+        .catch(error => {
+          this._clientCertificate = null
+          throw error
+        })
+    }
+
+    return this._clientCertificate
+  }
+}

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-direct.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-direct.js
@@ -17,7 +17,6 @@
 
 import PooledConnectionProvider from './connection-provider-pooled.js'
 import {
-  createChannelConnection,
   DelegateConnection,
   ConnectionErrorHandler
 } from '../connection/index.js'
@@ -75,12 +74,7 @@ export default class DirectConnectionProvider extends PooledConnectionProvider {
   }
 
   async _hasProtocolVersion (versionPredicate) {
-    const connection = await createChannelConnection(
-      this._address,
-      this._config,
-      this._createConnectionErrorHandler(),
-      this._log
-    )
+    const connection = await this._createChannelConnection(this._address)
 
     const protocolVersion = connection.protocol()
       ? connection.protocol().version

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
@@ -83,11 +83,15 @@ export default class PooledConnectionProvider extends ConnectionProvider {
       return
     }
     if (this._clientCertificate == null || await this._config.clientCertificate.hasUpdate()) {
-      this._clientCertificate = this._config.clientCertificate.getClientCertificate()
+      this._clientCertificate = this._getClientCertificate()
         .then(clientCertificate => {
           this._clientCertificate = clientCertificate
         })
     }
+  }
+
+  async _getClientCertificate () {
+    return this._config.clientCertificate.getClientCertificate()
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
@@ -21,6 +21,7 @@ import { error, ConnectionProvider, ServerInfo, newError } from '../../core/inde
 import AuthenticationProvider from './authentication-provider.js'
 import { object } from '../lang/index.js'
 import LivenessCheckProvider from './liveness-check-provider.js'
+import { ClientCertificatesLoader } from '../channel/index.js'
 
 const { SERVICE_UNAVAILABLE } = error
 const AUTHENTICATION_ERRORS = [
@@ -84,6 +85,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     }
     if (this._clientCertificate == null || await this._config.clientCertificate.hasUpdate()) {
       this._clientCertificate = this._getClientCertificate()
+        .then(ClientCertificatesLoader.load)
         .then(clientCertificate => {
           this._clientCertificate = clientCertificate
         })

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
@@ -21,7 +21,7 @@ import { error, ConnectionProvider, ServerInfo, newError } from '../../core/inde
 import AuthenticationProvider from './authentication-provider.js'
 import { object } from '../lang/index.js'
 import LivenessCheckProvider from './liveness-check-provider.js'
-import { ClientCertificatesLoader } from '../channel/index.js'
+import ClientCertificateHolder from './client-certificate-holder.js'
 
 const { SERVICE_UNAVAILABLE } = error
 const AUTHENTICATION_ERRORS = [
@@ -41,7 +41,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     this._id = id
     this._config = config
     this._log = log
-    this._clientCertificate = null
+    this._clientCertificateHolder = new ClientCertificateHolder({ clientCertificateProvider: this._config.clientCertificate })
     this._authenticationProvider = new AuthenticationProvider({ authTokenManager, userAgent, boltAgent })
     this._livenessCheckProvider = new LivenessCheckProvider({ connectionLivenessCheckTimeout: config.connectionLivenessCheckTimeout })
     this._userAgent = userAgent
@@ -55,7 +55,7 @@ export default class PooledConnectionProvider extends ConnectionProvider {
           this._config,
           this._createConnectionErrorHandler(),
           this._log,
-          await this._clientCertificate
+          await this._clientCertificateHolder.getClientCertificate()
         )
       })
     this._connectionPool = newPool({
@@ -77,19 +77,6 @@ export default class PooledConnectionProvider extends ConnectionProvider {
 
   _createConnectionErrorHandler () {
     return new ConnectionErrorHandler(SERVICE_UNAVAILABLE)
-  }
-
-  async _updateClientCertificateWhenNeeded () {
-    if (this._config.clientCertificate == null) {
-      return
-    }
-    if (this._clientCertificate == null || await this._config.clientCertificate.hasUpdate()) {
-      this._clientCertificate = this._getClientCertificate()
-        .then(ClientCertificatesLoader.load)
-        .then(clientCertificate => {
-          this._clientCertificate = clientCertificate
-        })
-    }
   }
 
   async _getClientCertificate () {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-pooled.js
@@ -49,7 +49,6 @@ export default class PooledConnectionProvider extends ConnectionProvider {
     this._createChannelConnection =
       createChannelConnectionHook ||
       (async address => {
-        await this._updateClientCertificateWhenNeeded()
         return createChannelConnection(
           address,
           this._config,

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -71,12 +71,14 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     routingTablePurgeDelay,
     newPool
   }) {
-    super({ id, config, log, userAgent, boltAgent, authTokenManager, newPool }, address => {
+    super({ id, config, log, userAgent, boltAgent, authTokenManager, newPool }, async address => {
+      await this._updateClientCertificateWhenNeeded()
       return createChannelConnection(
         address,
         this._config,
         this._createConnectionErrorHandler(),
         this._log,
+        await this._clientCertificate,
         this._routingContext
       )
     })
@@ -212,12 +214,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     let lastError
     for (let i = 0; i < addresses.length; i++) {
       try {
-        const connection = await createChannelConnection(
-          addresses[i],
-          this._config,
-          this._createConnectionErrorHandler(),
-          this._log
-        )
+        const connection = await this._createChannelConnection(addresses[i])
         const protocolVersion = connection.protocol()
           ? connection.protocol().version
           : null

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -72,13 +72,12 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
     newPool
   }) {
     super({ id, config, log, userAgent, boltAgent, authTokenManager, newPool }, async address => {
-      await this._updateClientCertificateWhenNeeded()
       return createChannelConnection(
         address,
         this._config,
         this._createConnectionErrorHandler(),
         this._log,
-        await this._clientCertificate,
+        await this._clientCertificateHolder.getClientCertificate(),
         this._routingContext
       )
     })

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection/connection-channel.js
@@ -33,6 +33,7 @@ let idGenerator = 0
  * @param {Object} config - the driver configuration.
  * @param {ConnectionErrorHandler} errorHandler - the error handler for connection errors.
  * @param {Logger} log - configured logger.
+ * @param {clientCertificate} clientCertificate - configured client certificate
  * @return {Connection} - new connection.
  */
 export function createChannelConnection (
@@ -40,13 +41,15 @@ export function createChannelConnection (
   config,
   errorHandler,
   log,
+  clientCertificate,
   serversideRouting = null,
   createChannel = channelConfig => new Channel(channelConfig)
 ) {
   const channelConfig = new ChannelConfig(
     address,
     config,
-    errorHandler.errorCode()
+    errorHandler.errorCode(),
+    clientCertificate
   )
 
   const channel = createChannel(channelConfig)

--- a/packages/neo4j-driver-deno/lib/core/client-certificate.ts
+++ b/packages/neo4j-driver-deno/lib/core/client-certificate.ts
@@ -63,7 +63,7 @@ export default class ClientCertificate {
     this.keyfile = ''
 
     /**
-     * The certificate's password.
+     * The key's password.
      *
      * @type {string|undefined}
      */
@@ -135,7 +135,7 @@ export class RotatingClientCertificateProvider extends ClientCertificateProvider
 
 /**
  * Defines the object which holds the common {@link ClientCertificateProviders} used in the Driver
- * 
+ *
  * @experimental Exposed as preview feature.
  * @since 5.19
  */
@@ -160,7 +160,7 @@ class ClientCertificateProviders {
 
 /**
  * Holds the common {@link ClientCertificateProviders} used in the Driver.
- * 
+ *
  * @experimental Exposed as preview feature.
  * @since 5.19
  */

--- a/packages/neo4j-driver-deno/lib/core/client-certificate.ts
+++ b/packages/neo4j-driver-deno/lib/core/client-certificate.ts
@@ -20,6 +20,14 @@ import * as json from './json.ts'
 type KeyFile = string | { path: string, password?: string }
 
 /**
+ * Represents KeyFile represented as file.
+ *
+ * @typedef {object} KeyFileObject
+ * @property {string} path - The path of the file
+ * @property {string|undefined} password - the password of the key. If none,
+ * the password defined at {@link ClientCertificate} will be used.
+ */
+/**
  * Holds the Client TLS certificate information.
  *
  * Browser instances of the driver should configure the certificate
@@ -32,14 +40,6 @@ type KeyFile = string | { path: string, password?: string }
  * @interface
  * @see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
  */
-/**
- * Represents KeyFile represented as file.
- *
- * @typedef {object} KeyFileObject
- * @property {string} path - The path of the file
- * @property {string?} password - the password of the key. If none,
- * the password defined at {@link ClientCertificate} will be used.
- */
 export default class ClientCertificate {
   public readonly certfile: string | string[]
   public readonly keyfile: KeyFile | KeyFile[]
@@ -49,14 +49,14 @@ export default class ClientCertificate {
     /**
      * The path to client certificate file.
      *
-     * @type {string | string}
+     * @type {string|string[]}
      */
     this.certfile = ''
 
     /**
      * The path to the key file.
      *
-     * @type {string | string[] | KeyFileObject | KeyFileObject[] }
+     * @type {string|string[]|KeyFileObject|KeyFileObject[]}
      */
     this.keyfile = ''
 
@@ -200,7 +200,6 @@ export function resolveCertificateProvider (input: unknown): ClientCertificatePr
  * @private
  * @param maybeClientCertificate - Maybe the certificate
  * @returns {boolean} if maybeClientCertificate is a client certificate object
- *
  */
 function isClientClientCertificate (maybeClientCertificate: unknown): maybeClientCertificate is ClientCertificate {
   return maybeClientCertificate != null &&
@@ -287,6 +286,11 @@ class InternalRotatingClientCertificateProvider {
     private _updated: boolean = false) {
   }
 
+  /**
+   *
+   * @returns {boolean|Promise<boolean>}
+   */
+
   hasUpdate (): boolean | Promise<boolean> {
     try {
       return this._updated
@@ -295,10 +299,19 @@ class InternalRotatingClientCertificateProvider {
     }
   }
 
+  /**
+   *
+   * @returns {ClientCertificate|Promise<ClientCertificate>}
+   */
   getClientCertificate (): ClientCertificate | Promise<ClientCertificate> {
     return this._certificate
   }
 
+  /**
+   *
+   * @param certificate
+   * @returns {void}
+   */
   updateCertificate (certificate: ClientCertificate): void {
     if (!isClientClientCertificate(certificate)) {
       throw new TypeError(`certificate should be ClientCertificate, but got ${json.stringify(certificate)}`)

--- a/packages/neo4j-driver-deno/lib/core/client-certificate.ts
+++ b/packages/neo4j-driver-deno/lib/core/client-certificate.ts
@@ -105,6 +105,7 @@ export class RotatingClientCertificateProvider extends ClientCertificateProvider
    * To be called by user-code when a new client certificate is available.
    *
    * @param {ClientCertificate} certificate - the new certificate
+   * @throws {TypeError} If initialCertificate is not a ClientCertificate.
    */
   updateCertificate (certificate: ClientCertificate): void {
     throw new Error('Not implemented')
@@ -121,9 +122,10 @@ class ClientCertificateProviders {
    * @param {ClientCertificate} param0.initialCertificate - The certificated used by the driver until {@link RotatingClientCertificateProvider#updateCertificate} get called.
    *
    * @returns {RotatingClientCertificateProvider} The rotating client certificate provider
+   * @throws {TypeError} If initialCertificate is not a ClientCertificate.
    */
   rotating ({ initialCertificate }: { initialCertificate: ClientCertificate }): RotatingClientCertificateProvider {
-    if (initialCertificate == null || typeof initialCertificate !== 'object') {
+    if (initialCertificate == null || !isClientClientCertificate(initialCertificate)) {
       throw new TypeError(`initialCertificate should be ClientCertificate, but got ${json.stringify(initialCertificate)}`)
     }
 
@@ -147,18 +149,27 @@ export type {
   ClientCertificateProviders
 }
 
+/**
+ * Resolves ClientCertificate or ClientCertificateProvider to a ClientCertificateProvider
+ *
+ * Method validates the input.
+ *
+ * @private
+ * @param input
+ * @returns {ClientCertificateProvider?} A client certificate provider if provided a ClientCertificate or a ClientCertificateProvider
+ * @throws {TypeError} If input is not a ClientCertificate, ClientCertificateProvider, undefined or null.
+ */
 export function resolveCertificateProvider (input: unknown): ClientCertificateProvider | undefined {
   if (input == null) {
     return undefined
   }
 
-  if (typeof input === 'object' && 'hasUpdate' in input && 'getClientCertificate' in input
-      && typeof input.getClientCertificate === 'function' && typeof input.hasUpdate === 'function') {
+  if (typeof input === 'object' && 'hasUpdate' in input && 'getClientCertificate' in input &&
+      typeof input.getClientCertificate === 'function' && typeof input.hasUpdate === 'function') {
     return input as ClientCertificateProvider
   }
 
-  if (typeof input === 'object' && 'certfile' in input && 'keyfile' in input && 
-    typeof input.certfile === 'string' && typeof input.keyfile === 'string') {
+  if (isClientClientCertificate(input)) {
     const certificate = { ...input } as unknown as ClientCertificate
     return {
       getClientCertificate: () => certificate,
@@ -167,6 +178,21 @@ export function resolveCertificateProvider (input: unknown): ClientCertificatePr
   }
 
   throw new TypeError(`clientCertificate should be configured with ClientCertificate or ClientCertificateProvider, but got ${json.stringify(input)}`)
+}
+
+/**
+ * Verify if object is a client certificate
+ * @private
+ * @param maybeClientCertificate - Maybe the certificate
+ * @returns {boolean} if maybeClientCertificate is a client certificate object
+ *
+ */
+function isClientClientCertificate (maybeClientCertificate: unknown): maybeClientCertificate is ClientCertificate {
+  return maybeClientCertificate != null &&
+    typeof maybeClientCertificate === 'object' &&
+    'certfile' in maybeClientCertificate && typeof maybeClientCertificate.certfile === 'string' &&
+    'keyfile' in maybeClientCertificate && typeof maybeClientCertificate.keyfile === 'string' &&
+    (!('password' in maybeClientCertificate) || maybeClientCertificate.password == null || typeof maybeClientCertificate.password === 'string')
 }
 
 /**
@@ -193,6 +219,9 @@ class InternalRotatingClientCertificateProvider {
   }
 
   updateCertificate (certificate: ClientCertificate): void {
+    if (!isClientClientCertificate(certificate)) {
+      throw new TypeError(`certificate should be ClientCertificate, but got ${json.stringify(certificate)}`)
+    }
     this._certificate = { ...certificate }
     this._updated = true
   }

--- a/packages/neo4j-driver-deno/lib/core/client-certificate.ts
+++ b/packages/neo4j-driver-deno/lib/core/client-certificate.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Holds the Client TLS certificate information.
+ *
+ * Browser instances of the driver should configure the certificate
+ * in the system.
+ *
+ * @interface
+ */
+export default class ClientCertificate {
+  public readonly certfile: string
+  public readonly keyfile: string
+  public readonly password?: string
+
+  private constructor () {
+    /**
+         * The path to client certificate file.
+         *
+         * @type {string}
+         */
+    this.certfile = ''
+
+    /**
+         * The path to the key file.
+         *
+         * @type {string}
+         */
+    this.keyfile = ''
+
+    /**
+         * The certificate's password.
+         *
+         * @type {string|undefined}
+         */
+    this.password = undefined
+  }
+}
+
+/**
+ * Provides a client certificate to the driver for mutual TLS.
+ *
+ * The driver will call {@link ClientCertificateProvider#hasUpdate()} to check if the client wants to update the certificate.
+ * If so, it will call {@link ClientCertificateProvider#getCertificate()} to get the new certificate.
+ *
+ * The certificate is only used as a second factor for authentication authenticating the client.
+ * The DMBS user still needs to authenticate with an authentication token.
+ *
+ * All implementations of this interface must be thread-safe and non-blocking for caller threads.
+ * For instance, IO operations must not be done on the calling thread.
+ *
+ * Note that the work done in the methods of this interface count towards the connectionAcquisition.
+ * Should fetching the certificate be particularly slow, it might be necessary to increase the timeout.
+ *
+ * @interface
+ */
+export class ClientCertificateProvider {
+  /**
+     * Indicates whether the client wants the driver to update the certificate.
+     *
+     * @returns {Promise<boolean>|boolean} true if the client wants the driver to update the certificate
+     */
+
+  hasUpdate (): boolean | Promise<boolean> {
+    throw new Error('Not Implemented')
+  }
+
+  /**
+     * Returns the certificate to use for new connections.
+     *
+     * Will be called by the driver after {@link ClientCertificateProvider#hasUpdate()} returned true
+     * or when the driver establishes the first connection.
+     *
+     * @returns {Promise<ClientCertificate>|ClientCertificate} the certificate to use for new connections
+     */
+  getClientCertificate (): ClientCertificate | Promise<ClientCertificate> {
+    throw new Error('Not Implemented')
+  }
+}
+
+/**
+ * Interface for  {@link ClientCertificateProvider} which provides update certificate function.
+ * @interface
+ */
+export class RotatingClientCertificateProvider extends ClientCertificateProvider {
+  /**
+     * Updates the certificate stored in the provider.
+     *
+     * To be called by user-code when a new client certificate is available.
+     *
+     * @param {ClientCertificate} certificate - the new certificate
+     */
+  updateCertificate (certificate: ClientCertificate): void {
+    throw new Error('Not implemented')
+  }
+}
+
+/**
+ * Defines the object which holds the common {@link ClientCertificateProviders} used in the Driver
+ */
+class ClientCertificateProviders {
+  /**
+     *
+     * @param {object} param0 - The params
+     * @param {ClientCertificate} param0.initialCertificate - The certificated used by the driver until {@link RotatingClientCertificateProvider#updateCertificate} get called.
+     *
+     * @returns {RotatingClientCertificateProvider} The rotating client certificate provider
+     */
+  rotating ({ initialCertificate }: { initialCertificate: ClientCertificate }): RotatingClientCertificateProvider {
+    throw new Error('Not implemented')
+  }
+}
+
+/**
+ * Holds the common {@link ClientCertificateProviders} used in the Driver.
+ */
+const clientCertificateProviders: ClientCertificateProviders = new ClientCertificateProviders()
+
+Object.freeze(clientCertificateProviders)
+
+export {
+  clientCertificateProviders
+}
+
+export type {
+  ClientCertificateProviders
+}

--- a/packages/neo4j-driver-deno/lib/core/client-certificate.ts
+++ b/packages/neo4j-driver-deno/lib/core/client-certificate.ts
@@ -39,6 +39,8 @@ type KeyFile = string | { path: string, password?: string }
  *
  * @interface
  * @see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 export default class ClientCertificate {
   public readonly certfile: string | string[]
@@ -85,6 +87,8 @@ export default class ClientCertificate {
  * Should fetching the certificate be particularly slow, it might be necessary to increase the timeout.
  *
  * @interface
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 export class ClientCertificateProvider {
   /**
@@ -112,6 +116,8 @@ export class ClientCertificateProvider {
 /**
  * Interface for  {@link ClientCertificateProvider} which provides update certificate function.
  * @interface
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 export class RotatingClientCertificateProvider extends ClientCertificateProvider {
   /**
@@ -129,6 +135,9 @@ export class RotatingClientCertificateProvider extends ClientCertificateProvider
 
 /**
  * Defines the object which holds the common {@link ClientCertificateProviders} used in the Driver
+ * 
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 class ClientCertificateProviders {
   /**
@@ -151,6 +160,9 @@ class ClientCertificateProviders {
 
 /**
  * Holds the common {@link ClientCertificateProviders} used in the Driver.
+ * 
+ * @experimental Exposed as preview feature.
+ * @since 5.19
  */
 const clientCertificateProviders: ClientCertificateProviders = new ClientCertificateProviders()
 

--- a/packages/neo4j-driver-deno/lib/core/connection-provider.ts
+++ b/packages/neo4j-driver-deno/lib/core/connection-provider.ts
@@ -28,6 +28,9 @@ import { AuthToken } from './types.ts'
  * @interface
  */
 class Releasable {
+  /**
+   * @returns {Promise<void>}
+   */
   release (): Promise<void> {
     throw new Error('Not implemented')
   }

--- a/packages/neo4j-driver-deno/lib/core/connection.ts
+++ b/packages/neo4j-driver-deno/lib/core/connection.ts
@@ -72,34 +72,72 @@ interface RunQueryConfig extends BeginTransactionConfig {
  * @interface
  */
 class Connection {
+  /**
+   *
+   * @param config
+   * @returns {ResultStreamObserver}
+   */
   beginTransaction (config: BeginTransactionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @param query
+   * @param parameters
+   * @param config
+   * @returns {ResultStreamObserver}
+   */
   run (query: string, parameters?: Record<string, unknown>, config?: RunQueryConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @param config
+   * @returns {ResultStreamObserver}
+   */
   commitTransaction (config: CommitTransactionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @param config
+   * @returns {ResultStreamObserver}
+   */
   rollbackTransaction (config: RollbackConnectionConfig): ResultStreamObserver {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @returns {Promise<void>}
+   */
   resetAndFlush (): Promise<void> {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @returns {boolean}
+   */
   isOpen (): boolean {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @returns {number}
+   */
   getProtocolVersion (): number {
     throw new Error('Not implemented')
   }
 
+  /**
+   *
+   * @returns {boolean}
+   */
   hasOngoingObservableRequests (): boolean {
     throw new Error('Not implemented')
   }

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -906,6 +906,7 @@ function validateConfig (config: any, log: Logger): any {
 
 /**
  * @private
+ * @returns {void}
  */
 function sanitizeConfig (config: any): void {
   config.maxConnectionLifetime = sanitizeIntValue(
@@ -932,6 +933,7 @@ function sanitizeConfig (config: any): void {
 
 /**
  * @private
+ * @returns {number}
  */
 function sanitizeIntValue (rawValue: any, defaultWhenAbsent: number): number {
   const sanitizedValue = parseInt(rawValue, 10)

--- a/packages/neo4j-driver-deno/lib/core/index.ts
+++ b/packages/neo4j-driver-deno/lib/core/index.ts
@@ -91,7 +91,7 @@ import { Config } from './types.ts'
 import * as types from './types.ts'
 import * as json from './json.ts'
 import resultTransformers, { ResultTransformer } from './result-transformers.ts'
-import ClientCertificate, { clientCertificateProviders, ClientCertificateProvider, ClientCertificateProviders, RotatingClientCertificateProvider } from './client-certificate.ts'
+import ClientCertificate, { clientCertificateProviders, ClientCertificateProvider, ClientCertificateProviders, RotatingClientCertificateProvider, resolveCertificateProvider } from './client-certificate.ts'
 import * as internal from './internal/index.ts'
 
 /**
@@ -171,7 +171,8 @@ const forExport = {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  clientCertificateProviders
+  clientCertificateProviders,
+  resolveCertificateProvider
 }
 
 export {
@@ -241,7 +242,8 @@ export {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  clientCertificateProviders
+  clientCertificateProviders,
+  resolveCertificateProvider
 }
 
 export type {

--- a/packages/neo4j-driver-deno/lib/core/index.ts
+++ b/packages/neo4j-driver-deno/lib/core/index.ts
@@ -91,6 +91,7 @@ import { Config } from './types.ts'
 import * as types from './types.ts'
 import * as json from './json.ts'
 import resultTransformers, { ResultTransformer } from './result-transformers.ts'
+import ClientCertificate, { clientCertificateProviders, ClientCertificateProvider, ClientCertificateProviders, RotatingClientCertificateProvider } from './client-certificate.ts'
 import * as internal from './internal/index.ts'
 
 /**
@@ -169,7 +170,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 
 export {
@@ -238,7 +240,8 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 
 export type {
@@ -263,7 +266,11 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  ClientCertificate,
+  ClientCertificateProvider,
+  ClientCertificateProviders,
+  RotatingClientCertificateProvider
 }
 
 export default forExport

--- a/packages/neo4j-driver-deno/lib/core/types.ts
+++ b/packages/neo4j-driver-deno/lib/core/types.ts
@@ -350,6 +350,8 @@ export class Config {
      * where the {@link ClientCertificate} might change over time.
      *
      * @type {ClientCertificate|ClientCertificateProvider|undefined}
+     * @experimental Exposed as preview feature.
+     * @since 5.19
      */
     this.clientCertificate = undefined
   }

--- a/packages/neo4j-driver-deno/lib/core/types.ts
+++ b/packages/neo4j-driver-deno/lib/core/types.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import ClientCertificate, { ClientCertificateProvider } from './client-certificate.ts'
 import NotificationFilter from './notification-filter.ts'
 
 /**
@@ -80,6 +81,7 @@ export class Config {
   resolver?: (address: string) => string[] | Promise<string[]>
   userAgent?: string
   telemetryDisabled?: boolean
+  clientCertificate?: ClientCertificate | ClientCertificateProvider
 
   /**
    * @constructor
@@ -340,6 +342,16 @@ export class Config {
      * @type {boolean}
      */
     this.telemetryDisabled = false
+
+    /**
+     * Client Certificate used for mutual TLS.
+     *
+     * A {@link ClientCertificateProvider} can be configure for scenarios
+     * where the {@link ClientCertificate} might change over time.
+     *
+     * @type {ClientCertificate|ClientCertificateProvider|undefined}
+     */
+    this.clientCertificate = undefined
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -97,7 +97,12 @@ import {
   Transaction,
   TransactionPromise,
   types as coreTypes,
-  UnboundRelationship
+  UnboundRelationship,
+  ClientCertificate,
+  ClientCertificateProvider,
+  ClientCertificateProviders,
+  RotatingClientCertificateProvider,
+  clientCertificateProviders
 } from './core/index.ts'
 // @deno-types=./bolt-connection/types/index.d.ts
 import { DirectConnectionProvider, RoutingConnectionProvider } from './bolt-connection/index.js'
@@ -424,7 +429,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 
 export {
@@ -491,7 +497,8 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 export type {
   QueryResult,
@@ -516,6 +523,10 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  ClientCertificate,
+  ClientCertificateProvider,
+  ClientCertificateProviders,
+  RotatingClientCertificateProvider
 }
 export default forExport

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -102,7 +102,8 @@ import {
   ClientCertificateProvider,
   ClientCertificateProviders,
   RotatingClientCertificateProvider,
-  clientCertificateProviders
+  clientCertificateProviders,
+  resolveCertificateProvider
 } from './core/index.ts'
 // @deno-types=./bolt-connection/types/index.d.ts
 import { DirectConnectionProvider, RoutingConnectionProvider } from './bolt-connection/index.js'
@@ -214,6 +215,7 @@ function driver (
     }
     _config.encrypted = ENCRYPTION_ON
     _config.trust = trust
+    _config.clientCertificate = resolveCertificateProvider(config.clientCertificate)
   }
 
   const authTokenManager = createAuthManager(authToken)

--- a/packages/neo4j-driver-deno/test/neo4j.test.ts
+++ b/packages/neo4j-driver-deno/test/neo4j.test.ts
@@ -64,9 +64,10 @@ Deno.test('session.beginTransaction should rollback the transaction if not commi
 // Deno will fail with resource leaks
 Deno.test('session.beginTransaction should noop if resource committed', async () => {
   await using driver = neo4j.driver(uri, authToken)
+  const name = "Must Be Conor"
+  
   try {
     await using session = driver.session()
-    const name = "Must Be Conor"
   
     {
       await using tx = session.beginTransaction()

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -97,7 +97,12 @@ import {
   Transaction,
   TransactionPromise,
   types as coreTypes,
-  UnboundRelationship
+  UnboundRelationship,
+  ClientCertificate,
+  ClientCertificateProvider,
+  ClientCertificateProviders,
+  RotatingClientCertificateProvider,
+  clientCertificateProviders
 } from 'neo4j-driver-core'
 import { DirectConnectionProvider, RoutingConnectionProvider } from 'neo4j-driver-bolt-connection'
 
@@ -423,7 +428,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 
 export {
@@ -490,7 +496,8 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 export type {
   QueryResult,
@@ -515,6 +522,10 @@ export type {
   NotificationSeverityLevel,
   NotificationFilter,
   NotificationFilterDisabledCategory,
-  NotificationFilterMinimumSeverityLevel
+  NotificationFilterMinimumSeverityLevel,
+  ClientCertificate,
+  ClientCertificateProvider,
+  ClientCertificateProviders,
+  RotatingClientCertificateProvider
 }
 export default forExport

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -102,7 +102,8 @@ import {
   ClientCertificateProvider,
   ClientCertificateProviders,
   RotatingClientCertificateProvider,
-  clientCertificateProviders
+  clientCertificateProviders,
+  resolveCertificateProvider
 } from 'neo4j-driver-core'
 import { DirectConnectionProvider, RoutingConnectionProvider } from 'neo4j-driver-bolt-connection'
 
@@ -213,6 +214,7 @@ function driver (
     }
     _config.encrypted = ENCRYPTION_ON
     _config.trust = trust
+    _config.clientCertificate = resolveCertificateProvider(config.clientCertificate)
   }
 
   const authTokenManager = createAuthManager(authToken)

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -73,7 +73,8 @@ import {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  staticAuthTokenManager
+  staticAuthTokenManager,
+  clientCertificateProviders
 } from 'neo4j-driver-core'
 import {
   DirectConnectionProvider,
@@ -394,7 +395,8 @@ const forExport = {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 
 export {
@@ -462,6 +464,7 @@ export {
   notificationCategory,
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
-  notificationFilterMinimumSeverityLevel
+  notificationFilterMinimumSeverityLevel,
+  clientCertificateProviders
 }
 export default forExport

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -74,7 +74,8 @@ import {
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
   staticAuthTokenManager,
-  clientCertificateProviders
+  clientCertificateProviders,
+  resolveCertificateProvider
 } from 'neo4j-driver-core'
 import {
   DirectConnectionProvider,
@@ -170,6 +171,7 @@ function driver (url, authToken, config = {}) {
     }
     config.encrypted = ENCRYPTION_ON
     config.trust = trust
+    config.clientCertificate = resolveCertificateProvider(config.clientCertificate)
   }
 
   const authTokenManager = createAuthManager(authToken)

--- a/packages/neo4j-driver/test/internal/connection-channel.test.js
+++ b/packages/neo4j-driver/test/internal/connection-channel.test.js
@@ -157,6 +157,7 @@ describe('#integration ChannelConnection', () => {
       new ConnectionErrorHandler(SERVICE_UNAVAILABLE),
       Logger.noOp(),
       null,
+      null,
       () => channel
     )
       .then(c => {

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -87,6 +87,11 @@ import {
   notificationFilterMinimumSeverityLevel,
   AuthTokenManager,
   AuthTokenAndExpiration,
+  ClientCertificate,
+  ClientCertificateProvider,
+  ClientCertificateProviders,
+  RotatingClientCertificateProvider,
+  clientCertificateProviders,
   types as coreTypes
 } from 'neo4j-driver-core'
 import {
@@ -283,6 +288,7 @@ declare const forExport: {
   notificationFilterDisabledCategory: typeof notificationFilterDisabledCategory
   notificationFilterMinimumSeverityLevel: typeof notificationFilterMinimumSeverityLevel
   logging: typeof logging
+  clientCertificateProviders: typeof clientCertificateProviders
 }
 
 export {
@@ -358,7 +364,8 @@ export {
   notificationSeverityLevel,
   notificationFilterDisabledCategory,
   notificationFilterMinimumSeverityLevel,
-  logging
+  logging,
+  clientCertificateProviders
 }
 
 export type {
@@ -376,7 +383,11 @@ export type {
   NotificationFilterDisabledCategory,
   NotificationFilterMinimumSeverityLevel,
   AuthTokenManager,
-  AuthTokenAndExpiration
+  AuthTokenAndExpiration,
+  ClientCertificate,
+  ClientCertificateProvider,
+  ClientCertificateProviders,
+  RotatingClientCertificateProvider
 }
 
 export default forExport

--- a/packages/testkit-backend/src/context.js
+++ b/packages/testkit-backend/src/context.js
@@ -19,6 +19,8 @@ export default class Context {
     this._basicAuthTokenProviderRequests = {}
     this._binder = binder
     this._environmentLogLevel = environmentLogLevel
+    this._clientCertificateProviders = {}
+    this._clientCertificateProviderRequests = {}
   }
 
   get binder () {
@@ -224,6 +226,32 @@ export default class Context {
 
   removeBasicAuthTokenProviderRequest (id) {
     delete this._basicAuthTokenProviderRequests[id]
+  }
+
+  addClientCertificate (clientCertificateFactory) {
+    this._id++
+    this._clientCertificateProviders[this._id] = clientCertificateFactory(this._id)
+    return this._id
+  }
+
+  getClientCertificate (id) {
+    return this._clientCertificateProviders[id]
+  }
+
+  removeClientCertificate (id) {
+    delete this._clientCertificateProviders[id]
+  }
+
+  addClientCertificateProviderRequest (resolve, reject) {
+    return this._add(this._clientCertificateProviderRequests, { resolve, reject })
+  }
+
+  getClientCertificateProviderRequest (id) {
+    return this._clientCertificateProviderRequests[id]
+  }
+
+  removeClientCertificateProviderRequest (id) {
+    delete this._clientCertificateProviderRequests[id]
   }
 
   _add (map, object) {

--- a/packages/testkit-backend/src/feature/common.js
+++ b/packages/testkit-backend/src/feature/common.js
@@ -7,6 +7,7 @@ const features = [
   'Feature:API:BookmarkManager',
   'Feature:API:RetryableExceptions',
   'Feature:API:Session:AuthConfig',
+  'Feature:API:SSLClientCertificate',
   'Feature:API:SSLConfig',
   'Feature:API:SSLSchemes',
   'Feature:API:Type.Temporal',

--- a/packages/testkit-backend/src/request-handlers-rx.js
+++ b/packages/testkit-backend/src/request-handlers-rx.js
@@ -33,6 +33,9 @@ export {
   BearerAuthTokenProviderCompleted,
   NewBasicAuthTokenManager,
   BasicAuthTokenProviderCompleted,
+  NewClientCertificateProvider,
+  ClientCertificateProviderClose,
+  ClientCertificateProviderCompleted,
   FakeTimeInstall,
   FakeTimeTick,
   FakeTimeUninstall

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -87,7 +87,7 @@ export function NewDriver ({ neo4j }, context, data, wire) {
   }
 
   if ('clientCertificate' in data) {
-    config.clientCertificate = data.clientCertificate
+    config.clientCertificate = data.clientCertificate.data
   }
 
   let driver

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -86,6 +86,10 @@ export function NewDriver ({ neo4j }, context, data, wire) {
     config.connectionLivenessCheckTimeout = data.livenessCheckTimeoutMs
   }
 
+  if ('clientCertificate' in data) {
+    config.clientCertificate = data.clientCertificate
+  }
+
   let driver
   try {
     driver = neo4j.driver(uri, parsedAuthToken, config)

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -86,7 +86,7 @@ export function NewDriver ({ neo4j }, context, data, wire) {
     config.connectionLivenessCheckTimeout = data.livenessCheckTimeoutMs
   }
 
-  if ('clientCertificate' in data) {
+  if (data.clientCertificate != null) {
     config.clientCertificate = data.clientCertificate.data
   }
 

--- a/packages/testkit-backend/src/responses.js
+++ b/packages/testkit-backend/src/responses.js
@@ -139,6 +139,14 @@ export function DriverIsAuthenticated ({ id, authenticated }) {
   return response('DriverIsAuthenticated', { id, authenticated })
 }
 
+export function ClientCertificateProvider ({ id }) {
+  return response('ClientCertificateProvider', { id })
+}
+
+export function ClientCertificateProviderRequest ({ id, clientCertificateProviderId }) {
+  return response('ClientCertificateProviderRequest', { id, clientCertificateProviderId })
+}
+
 // Testkit controller messages
 export function RunTest () {
   return response('RunTest', null)

--- a/packages/testkit-backend/src/skipped-tests/deno.js
+++ b/packages/testkit-backend/src/skipped-tests/deno.js
@@ -8,6 +8,9 @@ const skippedTests = [
     ifEndsWith('test_untrusted_ca_correct_hostname'),
     ifEndsWith('test_1_1')
   ),
+  skip('DenoJS does not support client certificates',
+    ifStartsWith('tls.test_client_certificate.')
+  ),
   skip('Trust All is not available as configuration',
     ifStartsWith('tls.test_self_signed_scheme.TestTrustAllCertsConfig.'),
     ifStartsWith('tls.test_self_signed_scheme.TestSelfSignedScheme.')


### PR DESCRIPTION
⚠️ This API is released as preview.
⚠️ This feature is NodeJS only. Browser should configure the client certificate in the system certificates. 

The ClientCertificate is a mechanism to support mutual TLS as a second factor for authentication. The driver's certificate will not be used to authenticate a user on the DBMS, but only to authenticate the driver as a trusted client to the DBMS. Another authentication mechanism is still required to authenticate the user.

The configuration is done by using the driver configuration, the property name is `clientCertificate` and this a object with the following properties:

* `certfile`: The path to client certificate file. This is can configured as list of paths.
* `keyfile`: The path to key file. This can also be configured as a list of paths, an object contain `path` and `password` or a list of objects contain `path` and `password`.
* `password` (optional): The client key password.

See [node documentation](https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions) for understanding how password, certs and keys work together. 

Configuration example:

```javascript
import neo4j from 'neo4j-driver'

const driver = neo4j.driver('neo4j+s://myhost:7687', MY_CREDENTIALS, {
   clientCertificate: {
      certfile: '/path/to/cert/file.cert',
      keyfile: '/path/to/cert/file.pem',
      password: 'the_key_password' // optional
   }
})

// then use your driver as usual. 
```

### Client Certificate Provider and Certificate Rotation

In case of the certificate needs to be changed, the driver offers an api for change client certificates without creating a new driver instance. The change is done by inform an `ClientCertificateProvider` instead of a `ClientCertificate` in the driver configuration. 

`ClientCertificateProvider` is a public interface which can be implemented by user. However, the driver offers an implementation of this interface for working with certificate rotation scenarios. 

```javascript
import neo4j from 'neo4j-driver'

const initialClientCertificate: {
  certfile: '/path/to/cert/file.cert',
  keyfile: '/path/to/cert/file.pem',
  password: 'the_key_password' // optional
}

const clientCertificateProvider = neo4j.clientCertificateProviders.rotating({
    initialCertificate: initialClientCertificate
})

const driver = neo4j.driver('neo4j+s://myhost:7687', MY_CREDENTIALS, {
   clientCertificate: clientCertificateProvider
})


// use the driver as usual

// then you have new certificate which will replace the old one
clientCertificateProvider.updateCertificate({
  certfile: '/path/to/cert/new_file.cert',
  keyfile: '/path/to/cert/new_file.pem',
  password: 'the_new_key_password' // optional
})

// New connections will be created using the new certificate.
// however, older connections will not be closed if they still working.
```

⚠️ This feature is NodeJS only. Browser should configure the client certificate in the system certificates. 
⚠️ This API is released as preview.




