### PR TITLE
benchkit: Fix Node installation in Dockerimage

### DIFF
--- a/benchkit/Dockerfile
+++ b/benchkit/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y curl
 
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION:=10}.x | sh
+RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION:=10}.x | bash -
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
The new node script installer doesn't work with sh, only with bash.

<!--
    Thanks for making the effort to create a Pull Request!
    Please read the comment in its entirety fist.
    If you haven't already, please sign our Contributor License Agreement at
    https://neo4j.com/developer/cla/
    Commits from accounts that have not signed the CLA will fail the CI and
    will not be reviewed. If you are a first-time contributor and have just
    signed the CLA, please include a note about this in the PR comment as some
    manual steps from our side are required.
-->

<!--
    Title:
    PRs targeting the current default branch (nightly driver) don't follow a
    fixed naming scheme.
    If your PR is a backport, please link the original PR in the comments.
-->

<!--
    Description:
    Please include a summary of the changes in this PR and their purpose.
    Link any related issues or PRs.
-->
