### PR TITLE
Don't prevent NodeJS from closing to run acquisition timeout error

### DIFF
--- a/packages/bolt-connection/src/pool/pool.js
+++ b/packages/bolt-connection/src/pool/pool.js
@@ -113,6 +113,7 @@ class Pool {
           )
         }
       }, this._acquisitionTimeout)
+      typeof timeoutId === 'object' && timeoutId.unref()
 
       request = new PendingRequest(key, acquisitionContext, config, resolve, reject, timeoutId, this._log)
       allRequests[key].push(request)

--- a/packages/neo4j-driver-deno/lib/bolt-connection/pool/pool.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/pool/pool.js
@@ -113,6 +113,7 @@ class Pool {
           )
         }
       }, this._acquisitionTimeout)
+      typeof timeoutId === 'object' && timeoutId.unref()
 
       request = new PendingRequest(key, acquisitionContext, config, resolve, reject, timeoutId, this._log)
       allRequests[key].push(request)


### PR DESCRIPTION
Currently my node process will wait 60 seconds (I know it's configurable) to close because this timeout is waiting to fire a timeout error. This stops referencing counting this callback, so it won't prevent the process from closing. This will still process if there are other executions in the event loop, so all this affects if node is waiting on a timeout that will never be needed.

---

Digging more into this the wait time happens because the socket never emits the logon success.
60% of the time I see
```
C: LOGON { ... }
```
But no bytes are ever read / the [data event](https://github.com/neo4j/neo4j-javascript-driver/blob/5.0/packages/bolt-connection/src/channel/node/node-channel.js#L266) is never fired.
This just "hangs" waiting for logon response, until the timeout is fired. I'm not sure why this happens. I haven't indicated to node in any way of my intention to close the process. Yet somehow I suspect it is aware of this.

The other 40% the logon / connection init process works fine:
```
C: LOGON { ... }
NodeChannel._conn.data <Buffer 00 56 b1 70 a3 86 73 65 72 76 65 72 8c 4e 65 6f 34 6a 2f 35 2e 32 30 2e 30 8d 63 6f 6e 6e 65 63 74 69 6f 6e 5f 69 64 87 62 6f 6c 74 2d 32 37 85 68 69 ... 47 more bytes>
S: SUCCESS {"signature":112,"fields":[{"server":"Neo4j/5.20.0","connection_id":"bolt-27","hints":{"connection.recv_timeout_seconds":{"low":120,"high":0}}}]}
```
In these cases the process cleans up rapidly.