### PR TITLE
Introduce `AbortSignal` to `Driver.executeQuery`

### DIFF
--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -358,6 +358,7 @@ class QueryConfig<T = EagerResult> {
   resultTransformer?: ResultTransformer<T>
   transactionConfig?: TransactionConfig
   auth?: AuthToken
+  signal?: AbortSignal
 
   /**
    * @constructor
@@ -429,6 +430,23 @@ class QueryConfig<T = EagerResult> {
      * @see {@link driver}
      */
     this.auth = undefined
+
+    /**
+     * The {@link AbortSignal} for aborting query execution.
+     *
+     * When aborted, the signal triggers the result consumption cancelation and
+     * transactions are reset. However, due to race conditions,
+     * there is no warranty the transaction will be rolled back.
+     * Equivalent to {@link Session.close}
+     *
+     * **Warning**: This option is only available in runtime which supports AbortSignal.addEventListener.
+     *
+     * @since 5.22.0
+     * @type {AbortSignal|undefined}
+     * @experimental
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+     */
+    this.signal = undefined
   }
 }
 
@@ -595,7 +613,8 @@ class Driver {
       database: config.database,
       impersonatedUser: config.impersonatedUser,
       transactionConfig: config.transactionConfig,
-      auth: config.auth
+      auth: config.auth,
+      signal: config.signal
     }, query, parameters)
   }
 

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -436,7 +436,7 @@ class QueryConfig<T = EagerResult> {
      *
      * When aborted, the signal triggers the result consumption cancelation and
      * transactions are reset. However, due to race conditions,
-     * there is no warranty the transaction will be rolled back.
+     * there is no guarantee the transaction will be rolled back.
      * Equivalent to {@link Session.close}
      *
      * **Warning**: This option is only available in runtime which supports AbortSignal.addEventListener.

--- a/packages/core/src/internal/query-executor.ts
+++ b/packages/core/src/internal/query-executor.ts
@@ -50,8 +50,11 @@ export default class QueryExecutor {
       auth: config.auth
     })
 
-    // @ts-expect-error AbortSignal doesn't implements EventTarget on this TS Config.
-    const listenerHandle = installEventListenerWhenPossible(config.signal, 'abort', async () => await session.close())
+    const listenerHandle = installEventListenerWhenPossible(
+      // Solving linter and types definitions issue
+      config.signal as unknown as EventTarget,
+      'abort',
+      async () => await session.close())
 
     // @ts-expect-error The method is private for external users
     session._configureTransactionExecutor(true, TELEMETRY_APIS.EXECUTE_QUERY)

--- a/packages/core/src/internal/query-executor.ts
+++ b/packages/core/src/internal/query-executor.ts
@@ -33,6 +33,7 @@ interface ExecutionConfig<T> {
   bookmarkManager?: BookmarkManager
   transactionConfig?: TransactionConfig
   auth?: AuthToken
+  signal?: AbortSignal
   resultTransformer: (result: Result) => Promise<T>
 }
 
@@ -49,6 +50,9 @@ export default class QueryExecutor {
       auth: config.auth
     })
 
+    // @ts-expect-error AbortSignal doesn't implements EventTarget on this TS Config.
+    const listenerHandle = installEventListenerWhenPossible(config.signal, 'abort', async () => await session.close())
+
     // @ts-expect-error The method is private for external users
     session._configureTransactionExecutor(true, TELEMETRY_APIS.EXECUTE_QUERY)
 
@@ -62,7 +66,29 @@ export default class QueryExecutor {
         return await config.resultTransformer(result)
       }, config.transactionConfig)
     } finally {
+      listenerHandle.uninstall()
       await session.close()
+    }
+  }
+}
+
+type Listener = (event: unknown) => unknown
+
+interface EventTarget {
+  addEventListener?: (type: string, listener: Listener) => unknown
+  removeEventListener?: (type: string, listener: Listener) => unknown
+}
+
+function installEventListenerWhenPossible (target: EventTarget | undefined, event: string, listener: () => unknown): { uninstall: () => void } {
+  if (typeof target?.addEventListener === 'function') {
+    target.addEventListener(event, listener)
+  }
+
+  return {
+    uninstall: () => {
+      if (typeof target?.removeEventListener === 'function') {
+        target.removeEventListener(event, listener)
+      }
     }
   }
 }

--- a/packages/core/test/driver.test.ts
+++ b/packages/core/test/driver.test.ts
@@ -473,6 +473,8 @@ describe('Driver', () => {
           key: 'value'
         }
       }
+      const aAbortController = new AbortController()
+
       async function aTransformer (result: Result): Promise<string> {
         const summary = await result.summary()
         return summary.database.name ?? 'no-db-set'
@@ -488,7 +490,8 @@ describe('Driver', () => {
         ['config.bookmarkManager=null', 'q', {}, { bookmarkManager: null }, extendsDefaultWith({ bookmarkManager: undefined })],
         ['config.bookmarkManager set to non-null/empty', 'q', {}, { bookmarkManager: theBookmarkManager }, extendsDefaultWith({ bookmarkManager: theBookmarkManager })],
         ['config.resultTransformer set', 'q', {}, { resultTransformer: aTransformer }, extendsDefaultWith({ resultTransformer: aTransformer })],
-        ['config.transactionConfig set', 'q', {}, { transactionConfig: aTransactionConfig }, extendsDefaultWith({ transactionConfig: aTransactionConfig })]
+        ['config.transactionConfig set', 'q', {}, { transactionConfig: aTransactionConfig }, extendsDefaultWith({ transactionConfig: aTransactionConfig })],
+        ['config.signal set', 'q', {}, { signal: aAbortController.signal }, extendsDefaultWith({ signal: aAbortController.signal })]
       ])('should handle the params for %s', async (_, query, params, config, buildExpectedConfig) => {
         const spiedExecute = jest.spyOn(queryExecutor, 'execute')
 

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -432,15 +432,15 @@ class QueryConfig<T = EagerResult> {
     this.auth = undefined
 
     /**
-     * The {@link AbortSignal} for aborting query execution. 
-     * 
+     * The {@link AbortSignal} for aborting query execution.
+     *
      * When aborted, the signal triggers the result consumption cancelation and
      * transactions are reset. However, due to race conditions,
      * there is no warranty the transaction will be rolled back.
      * Equivalent to {@link Session.close}
-     * 
-     * **Warning**: This option is only available in runtime which supports AbortSignal.addEventListener. 
-     * 
+     *
+     * **Warning**: This option is only available in runtime which supports AbortSignal.addEventListener.
+     *
      * @since 5.22.0
      * @type {AbortSignal|undefined}
      * @experimental

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -436,7 +436,7 @@ class QueryConfig<T = EagerResult> {
      *
      * When aborted, the signal triggers the result consumption cancelation and
      * transactions are reset. However, due to race conditions,
-     * there is no warranty the transaction will be rolled back.
+     * there is no guarantee the transaction will be rolled back.
      * Equivalent to {@link Session.close}
      *
      * **Warning**: This option is only available in runtime which supports AbortSignal.addEventListener.

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -358,6 +358,7 @@ class QueryConfig<T = EagerResult> {
   resultTransformer?: ResultTransformer<T>
   transactionConfig?: TransactionConfig
   auth?: AuthToken
+  signal?: AbortSignal
 
   /**
    * @constructor
@@ -429,6 +430,23 @@ class QueryConfig<T = EagerResult> {
      * @see {@link driver}
      */
     this.auth = undefined
+
+    /**
+     * The {@link AbortSignal} for aborting query execution. 
+     * 
+     * When aborted, the signal triggers the result consumption cancelation and
+     * transactions are reset. However, due to race conditions,
+     * there is no warranty the transaction will be rolled back.
+     * Equivalent to {@link Session.close}
+     * 
+     * **Warning**: This option is only available in runtime which supports AbortSignal.addEventListener. 
+     * 
+     * @since 5.22.0
+     * @type {AbortSignal|undefined}
+     * @experimental
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+     */
+    this.signal = undefined
   }
 }
 
@@ -595,7 +613,8 @@ class Driver {
       database: config.database,
       impersonatedUser: config.impersonatedUser,
       transactionConfig: config.transactionConfig,
-      auth: config.auth
+      auth: config.auth,
+      signal: config.signal
     }, query, parameters)
   }
 

--- a/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
@@ -50,11 +50,10 @@ export default class QueryExecutor {
       auth: config.auth
     })
 
-    
     const listenerHandle = installEventListenerWhenPossible(
       // Solving linter and types definitions issue
-      config.signal as unknown as EventTarget, 
-      'abort', 
+      config.signal as unknown as EventTarget,
+      'abort',
       async () => await session.close())
 
     // @ts-expect-error The method is private for external users

--- a/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
@@ -51,7 +51,7 @@ export default class QueryExecutor {
     })
 
     // @ts-expect-error AbortSignal doesn't implements EventTarget on this TS Config.
-    const listenerHandle = installEventListenerWhenPossible(config.signal, 'abort',  async () => await session.close())
+    const listenerHandle = installEventListenerWhenPossible(config.signal, 'abort', async () => await session.close())
 
     // @ts-expect-error The method is private for external users
     session._configureTransactionExecutor(true, TELEMETRY_APIS.EXECUTE_QUERY)
@@ -72,13 +72,11 @@ export default class QueryExecutor {
   }
 }
 
-interface Listener {
-  (event: unknown): unknown
-}
+type Listener = (event: unknown) => unknown
 
 interface EventTarget {
-  addEventListener?: (type:string, listener: Listener) => unknown
-  removeEventListener?: (type:string, listener: Listener) => unknown
+  addEventListener?: (type: string, listener: Listener) => unknown
+  removeEventListener?: (type: string, listener: Listener) => unknown
 }
 
 function installEventListenerWhenPossible (target: EventTarget | undefined, event: string, listener: () => unknown): { uninstall: () => void } {

--- a/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
@@ -50,8 +50,12 @@ export default class QueryExecutor {
       auth: config.auth
     })
 
-    // @ts-expect-error AbortSignal doesn't implements EventTarget on this TS Config.
-    const listenerHandle = installEventListenerWhenPossible(config.signal, 'abort', async () => await session.close())
+    
+    const listenerHandle = installEventListenerWhenPossible(
+      // Solving linter and types definitions issue
+      config.signal as unknown as EventTarget, 
+      'abort', 
+      async () => await session.close())
 
     // @ts-expect-error The method is private for external users
     session._configureTransactionExecutor(true, TELEMETRY_APIS.EXECUTE_QUERY)


### PR DESCRIPTION
**⚠️ This API is released as preview.**
This configuration property enables the cancellation of ongoing queries which was previous not possible when using `Driver.executeQuery`.

The cancellation is done by closing the session used internally by the driver when execute the query. This means the cancellation is not safe and transaction might be commit apart of the execution being aborted. The cancellation might also triggers errors on the `Driver.executeQuery` execution.

Example:

```javascript
const abortController = new AbortController()

// Some event which cancels the query
process.on('SIGINT', () => abortController.abort() )

const result = await driver.executeQuery(query, params, {
    database: 'neo4j',
    signal: abortController.signal
})
```

**⚠️ This API is released as preview.**

<!--
    Thanks for making the effort to create a Pull Request!
    Please read the comment in its entirety fist.
    If you haven't already, please sign our Contributor License Agreement at
    https://neo4j.com/developer/cla/
    Commits from accounts that have not signed the CLA will fail the CI and
    will not be reviewed. If you are a first-time contributor and have just
    signed the CLA, please include a note about this in the PR comment as some
    manual steps from our side are required.
-->

<!--
    Title:
    PRs targeting the current default branch (nightly driver) don't follow a
    fixed naming scheme.
    If your PR is a backport, please link the original PR in the comments.
-->

<!--
    Description:
    Please include a summary of the changes in this PR and their purpose.
    Link any related issues or PRs.
-->
