### PR TITLE
Introduce `resultTransformer.first`

### DIFF
--- a/packages/neo4j-driver-deno/lib/core/result-transformers.ts
+++ b/packages/neo4j-driver-deno/lib/core/result-transformers.ts
@@ -21,12 +21,6 @@ import EagerResult from './result-eager.ts'
 import ResultSummary from './result-summary.ts'
 import { newError } from './error.ts'
 
-async function createEagerResultFromResult<Entries extends RecordShape> (result: Result): Promise<EagerResult<Entries>> {
-  const { summary, records } = await result
-  const keys = await result.keys()
-  return new EagerResult<Entries>(keys, records, summary)
-}
-
 type ResultTransformer<T> = (result: Result) => Promise<T>
 /**
  * Protocol for transforming {@link Result}.
@@ -162,6 +156,31 @@ class ResultTransformers {
       })
     }
   }
+
+  /**
+   * Creates a {@link ResultTransformer} which collects the first record {@link Record} of {@link Result}
+   * and discard the rest of the records, if existent.
+   *
+   * @example
+   * // Using in executeQuery
+   * const maybeFirstRecord = await driver.executeQuery('MATCH (p:Person{ age: $age }) RETURN p.name as name', { age: 25 }, {
+   *   resultTransformer: neo4j.resultTransformers.first()
+   * })
+   *
+   * @example
+   * // Using in other results
+   * const record = await neo4j.resultTransformers.first()(result)
+   *
+   *
+   * @template Entries The shape of the record.
+   * @returns {ResultTransformer<Record<Entries>|undefined>} The result transformer
+   * @see {@link Driver#executeQuery}
+   * @experimental This is a preview feature.
+   * @since 5.22.0
+   */
+  first<Entries extends RecordShape = RecordShape>(): ResultTransformer<Record<Entries> | undefined> {
+    return first
+  }
 }
 
 /**
@@ -175,4 +194,30 @@ export default resultTransformers
 
 export type {
   ResultTransformer
+}
+
+async function createEagerResultFromResult<Entries extends RecordShape> (result: Result): Promise<EagerResult<Entries>> {
+  const { summary, records } = await result
+  const keys = await result.keys()
+  return new EagerResult<Entries>(keys, records, summary)
+}
+
+async function first<Entries extends RecordShape> (result: Result): Promise<Record<Entries> | undefined> {
+  // The async iterator is not used in the for await fashion
+  // because the transpiler is generating a code which
+  // doesn't call it.return when break the loop
+  // causing the method hanging when fetchSize > recordNumber.
+  const it = result[Symbol.asyncIterator]()
+  const { value, done } = await it.next()
+
+  try {
+    if (done === true) {
+      return undefined
+    }
+    return value
+  } finally {
+    if (it.return != null) {
+      await it.return()
+    }
+  }
 }


### PR DESCRIPTION
**⚠️ This API is released as preview.**
This function enables fetching only the first record in the Result. If any other record is present, it will be discarded and network optimization might be applied.

Examples:

```javascript
// using in the execute query
const maybeFirstRecord = await driver.executeQuery('MATCH (p:Person{ age: $age }) RETURN p.name as name', { age: 25 }, {
    database: 'neo4j,
    resultTransformer: neo4j.resultTransformers.first()
})
```

```javascript
// using in other a result

const maybeFirstRecord = await session.executeRead(tx => {
    // do not `await` or `resolve` the result before send it to the transformer
    const result = tx.run('MATCH (p:Person{ age: $age }) RETURN p.name as name', { age: 25 })
    return  neo4j.resultTransformers.first()(result)
})
```

**⚠️ This API is released as preview.**

<!--
    Thanks for making the effort to create a Pull Request!
    Please read the comment in its entirety fist.
    If you haven't already, please sign our Contributor License Agreement at
    https://neo4j.com/developer/cla/
    Commits from accounts that have not signed the CLA will fail the CI and
    will not be reviewed. If you are a first-time contributor and have just
    signed the CLA, please include a note about this in the PR comment as some
    manual steps from our side are required.
-->

<!--
    Title:
    PRs targeting the current default branch (nightly driver) don't follow a
    fixed naming scheme.
    If your PR is a backport, please link the original PR in the comments.
-->

<!--
    Description:
    Please include a summary of the changes in this PR and their purpose.
    Link any related issues or PRs.
-->
