### PR TITLE
Introduce `resultTransformer.summary`

### DIFF
--- a/packages/core/src/result-transformers.ts
+++ b/packages/core/src/result-transformers.ts
@@ -20,6 +20,8 @@ import Result from './result'
 import EagerResult from './result-eager'
 import ResultSummary from './result-summary'
 import { newError } from './error'
+import { NumberOrInteger } from './graph-types'
+import Integer from './integer'
 
 type ResultTransformer<T> = (result: Result) => Promise<T>
 /**
@@ -181,6 +183,24 @@ class ResultTransformers {
   first<Entries extends RecordShape = RecordShape>(): ResultTransformer<Record<Entries> | undefined> {
     return first
   }
+
+  /**
+   * Creates a {@link ResultTransformer} which consumes the result and returns the {@link ResultSummary}.
+   *
+   * This result transformer is a shortcut to `(result) => result.summary()`.
+   *
+   * @example
+   * const summary = await driver.executeQuery('CREATE (p:Person{ name: $name }) RETURN p', { name: 'Person1'}, {
+   *   resultTransformer: neo4j.resultTransformers.summary()
+   * })
+   *
+   * @returns {ResultTransformer<ResultSummary<T>>} The result transformer
+   * @see {@link Driver#executeQuery}
+   * @experimental This is a preview feature
+   */
+  summary <T extends NumberOrInteger = Integer> (): ResultTransformer<ResultSummary<T>> {
+    return summary
+  }
 }
 
 /**
@@ -220,4 +240,8 @@ async function first<Entries extends RecordShape> (result: Result): Promise<Reco
       await it.return()
     }
   }
+}
+
+async function summary<T extends NumberOrInteger = Integer> (result: Result): Promise<ResultSummary<T>> {
+  return await result.summary()
 }

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -23,6 +23,7 @@ import { Query, PeekableAsyncIterator } from './types'
 import { observer, util, connectionHolder } from './internal'
 import { newError, PROTOCOL_ERROR } from './error'
 import { NumberOrInteger } from './graph-types'
+import Integer from './integer'
 
 const { EMPTY_CONNECTION_HOLDER } = connectionHolder
 
@@ -182,12 +183,14 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
    * *Should not be combined with {@link Result#subscribe} function.*
    *
    * @public
-   * @returns {Promise<ResultSummary>} - Result summary.
+   * @returns {Promise<ResultSummary<T>>} - Result summary.
    *
    */
-  summary (): Promise<ResultSummary> {
+  summary<T extends NumberOrInteger = Integer> (): Promise<ResultSummary<T>> {
     if (this._summary !== null) {
-      return Promise.resolve(this._summary)
+      // This type casting is needed since we are defining the number type of
+      // summary in Result template
+      return Promise.resolve(this._summary as unknown as ResultSummary<T>)
     } else if (this._error !== null) {
       return Promise.reject(this._error)
     }
@@ -196,7 +199,9 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
         .then(o => {
           o.cancel()
           o.subscribe(this._decorateObserver({
-            onCompleted: summary => resolve(summary),
+            // This type casting is needed since we are defining the number type of
+            // summary in Result template
+            onCompleted: summary => resolve(summary as unknown as ResultSummary<T>),
             onError: err => reject(err)
           }))
         })

--- a/packages/core/test/result-transformers.test.ts
+++ b/packages/core/test/result-transformers.test.ts
@@ -270,7 +270,7 @@ describe('resultTransformers', () => {
 
   describe('.summary()', () => {
     describe('with a valid result', () => {
-      it('it should return an ResultSummary', async () => {
+      it('should return a ResultSummary', async () => {
         const resultStreamObserverMock = new ResultStreamObserverMock()
         const query = 'Query'
         const params = { a: 1 }
@@ -291,7 +291,7 @@ describe('resultTransformers', () => {
         )
       })
 
-      it('it should cancel stream', async () => {
+      it('should cancel stream', async () => {
         const meta = { db: 'adb' }
         const resultStreamObserverMock = new ResultStreamObserverMock()
         const cancelSpy = jest.spyOn(resultStreamObserverMock, 'cancel')
@@ -314,7 +314,7 @@ describe('resultTransformers', () => {
         )
       })
 
-      it('it should return a ResultSummary<number>', async () => {
+      it('should return a ResultSummary<number>', async () => {
         const resultStreamObserverMock = new ResultStreamObserverMock()
         const query = 'Query'
         const params = { a: 1 }
@@ -344,7 +344,7 @@ describe('resultTransformers', () => {
         )
       })
 
-      it('it should return a ResultSummary<bigint>', async () => {
+      it('should return a ResultSummary<bigint>', async () => {
         const resultStreamObserverMock = new ResultStreamObserverMock()
         const query = 'Query'
         const params = { a: 1 }
@@ -374,7 +374,7 @@ describe('resultTransformers', () => {
         )
       })
 
-      it('it should return a ResultSummary<Integer>', async () => {
+      it('should return a ResultSummary<Integer>', async () => {
         const resultStreamObserverMock = new ResultStreamObserverMock()
         const query = 'Query'
         const params = { a: 1 }
@@ -410,7 +410,7 @@ describe('resultTransformers', () => {
         const expectedError = newError('expected error')
         const result = new Result(Promise.reject(expectedError), 'query')
 
-        await expect(resultTransformers.eagerResultTransformer()(result)).rejects.toThrow(expectedError)
+        await expect(resultTransformers.summary()(result)).rejects.toThrow(expectedError)
       })
     })
   })

--- a/packages/core/test/result-transformers.test.ts
+++ b/packages/core/test/result-transformers.test.ts
@@ -330,10 +330,15 @@ describe('resultTransformers', () => {
         resultStreamObserverMock.onCompleted(meta)
         const summary = await resultTransformers.summary<number>()(result)
 
+        const typeAssertionNumber: ResultSummary<number> = summary
         // @ts-expect-error
         const typeAssertionInteger: ResultSummary<Integer> = summary
         // @ts-expect-error
         const typeAssertionBigInt: ResultSummary<bigint> = summary
+
+        expect(typeAssertionNumber).toEqual(
+          new ResultSummary<Integer>(query, params, meta)
+        )
 
         expect(typeAssertionInteger).toEqual(
           new ResultSummary<Integer>(query, params, meta)
@@ -360,6 +365,7 @@ describe('resultTransformers', () => {
         resultStreamObserverMock.onCompleted(meta)
         const summary = await resultTransformers.summary<bigint>()(result)
 
+        const typeAssertionBigInt: ResultSummary<bigint> = summary
         // @ts-expect-error
         const typeAssertionNumber: ResultSummary<number> = summary
         // @ts-expect-error
@@ -370,6 +376,10 @@ describe('resultTransformers', () => {
         )
 
         expect(typeAssertionInteger).toEqual(
+          new ResultSummary<Integer>(query, params, meta)
+        )
+
+        expect(typeAssertionBigInt).toEqual(
           new ResultSummary<Integer>(query, params, meta)
         )
       })
@@ -390,10 +400,15 @@ describe('resultTransformers', () => {
         resultStreamObserverMock.onCompleted(meta)
         const summary = await resultTransformers.summary<Integer>()(result)
 
+        const typeAssertionInteger: ResultSummary<Integer> = summary
         // @ts-expect-error
         const typeAssertionNumber: ResultSummary<number> = summary
         // @ts-expect-error
         const typeAssertionBigInt: ResultSummary<bigint> = summary
+
+        expect(typeAssertionInteger).toEqual(
+          new ResultSummary<Integer>(query, params, meta)
+        )
 
         expect(typeAssertionNumber).toEqual(
           new ResultSummary<Integer>(query, params, meta)

--- a/packages/core/test/result.test.ts
+++ b/packages/core/test/result.test.ts
@@ -240,7 +240,7 @@ describe('Result', () => {
           await expect(result.summary()).rejects.toThrow(expectedError)
         })
 
-        it('should resolve summary pushe afterwards', done => {
+        it('should resolve summary push afterwards', done => {
           const metadata = {
             resultConsumedAfter: 20,
             resultAvailableAfter: 124,

--- a/packages/neo4j-driver-deno/lib/core/result-transformers.ts
+++ b/packages/neo4j-driver-deno/lib/core/result-transformers.ts
@@ -20,6 +20,8 @@ import Result from './result.ts'
 import EagerResult from './result-eager.ts'
 import ResultSummary from './result-summary.ts'
 import { newError } from './error.ts'
+import { NumberOrInteger } from './graph-types.ts'
+import Integer from './integer.ts'
 
 type ResultTransformer<T> = (result: Result) => Promise<T>
 /**
@@ -181,6 +183,24 @@ class ResultTransformers {
   first<Entries extends RecordShape = RecordShape>(): ResultTransformer<Record<Entries> | undefined> {
     return first
   }
+
+  /**
+   * Creates a {@link ResultTransformer} which consumes the result and returns the {@link ResultSummary}.
+   *
+   * This result transformer is a shortcut to `(result) => result.summary()`.
+   *
+   * @example
+   * const summary = await driver.executeQuery('CREATE (p:Person{ name: $name }) RETURN p', { name: 'Person1'}, {
+   *   resultTransformer: neo4j.resultTransformers.summary()
+   * })
+   *
+   * @returns {ResultTransformer<ResultSummary<T>>} The result transformer
+   * @see {@link Driver#executeQuery}
+   * @experimental This is a preview feature
+   */
+  summary <T extends NumberOrInteger = Integer> (): ResultTransformer<ResultSummary<T>> {
+    return summary
+  }
 }
 
 /**
@@ -220,4 +240,8 @@ async function first<Entries extends RecordShape> (result: Result): Promise<Reco
       await it.return()
     }
   }
+}
+
+async function summary<T extends NumberOrInteger = Integer> (result: Result): Promise<ResultSummary<T>> {
+  return await result.summary()
 }

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -189,7 +189,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
   summary<T extends NumberOrInteger = Integer> (): Promise<ResultSummary<T>> {
     if (this._summary !== null) {
       // This type casting is needed since we are defining the number type of
-      // summary in Result template 
+      // summary in Result template
       return Promise.resolve(this._summary as unknown as ResultSummary<T>)
     } else if (this._error !== null) {
       return Promise.reject(this._error)
@@ -200,7 +200,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
           o.cancel()
           o.subscribe(this._decorateObserver({
             // This type casting is needed since we are defining the number type of
-            // summary in Result template 
+            // summary in Result template
             onCompleted: summary => resolve(summary as unknown as ResultSummary<T>),
             onError: err => reject(err)
           }))

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -23,6 +23,7 @@ import { Query, PeekableAsyncIterator } from './types.ts'
 import { observer, util, connectionHolder } from './internal/index.ts'
 import { newError, PROTOCOL_ERROR } from './error.ts'
 import { NumberOrInteger } from './graph-types.ts'
+import Integer from './integer.ts'
 
 const { EMPTY_CONNECTION_HOLDER } = connectionHolder
 
@@ -182,12 +183,14 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
    * *Should not be combined with {@link Result#subscribe} function.*
    *
    * @public
-   * @returns {Promise<ResultSummary>} - Result summary.
+   * @returns {Promise<ResultSummary<T>>} - Result summary.
    *
    */
-  summary (): Promise<ResultSummary> {
+  summary<T extends NumberOrInteger = Integer> (): Promise<ResultSummary<T>> {
     if (this._summary !== null) {
-      return Promise.resolve(this._summary)
+      // This type casting is needed since we are defining the number type of
+      // summary in Result template 
+      return Promise.resolve(this._summary as unknown as ResultSummary<T>)
     } else if (this._error !== null) {
       return Promise.reject(this._error)
     }
@@ -196,7 +199,9 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
         .then(o => {
           o.cancel()
           o.subscribe(this._decorateObserver({
-            onCompleted: summary => resolve(summary),
+            // This type casting is needed since we are defining the number type of
+            // summary in Result template 
+            onCompleted: summary => resolve(summary as unknown as ResultSummary<T>),
             onError: err => reject(err)
           }))
         })


### PR DESCRIPTION
**⚠️ This API is released as preview.**
This function enables fetching only the summary of the Result. The result will be consumed and records won't be streamed.

Examples:

```javascript
// using in the execute query
const summary = await driver.executeQuery('MATCH (p:Person{ age: $age }) RETURN p.name as name', { age: 25 }, {
    database: 'neo4j,
    resultTransformer: neo4j.resultTransformers.summary()
})
```

**⚠️ This API is released as preview.**

<!--
    Thanks for making the effort to create a Pull Request!
    Please read the comment in its entirety fist.
    If you haven't already, please sign our Contributor License Agreement at
    https://neo4j.com/developer/cla/
    Commits from accounts that have not signed the CLA will fail the CI and
    will not be reviewed. If you are a first-time contributor and have just
    signed the CLA, please include a note about this in the PR comment as some
    manual steps from our side are required.
-->

<!--
    Title:
    PRs targeting the current default branch (nightly driver) don't follow a
    fixed naming scheme.
    If your PR is a backport, please link the original PR in the comments.
-->

<!--
    Description:
    Please include a summary of the changes in this PR and their purpose.
    Link any related issues or PRs.
-->
