### PR TITLE
Fix `Notification.description` polyfill from `GqlStatusObject`

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x5.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x5.js
@@ -147,7 +147,7 @@ export default class BoltProtocol extends BoltProtocolV5x4 {
       afterComplete,
       highRecordWatermark,
       lowRecordWatermark,
-      enrichMetadata: BoltProtocol._enrichMetadata
+      enrichMetadata: this._enrichMetadata
     })
 
     const flushRun = reactive
@@ -176,10 +176,11 @@ export default class BoltProtocol extends BoltProtocolV5x4 {
    * @param {object} metadata
    * @returns {object}
    */
-  static _enrichMetadata (metadata) {
+  _enrichMetadata (metadata) {
     if (Array.isArray(metadata.statuses)) {
       metadata.statuses = metadata.statuses.map(status => ({
         ...status,
+        description: status.neo4j_code != null ? status.status_description : status.description,
         diagnostic_record: status.diagnostic_record !== null ? { ...DEFAULT_DIAGNOSTIC_RECORD, ...status.diagnostic_record } : null
       }))
     }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x5.transformer.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x5.transformer.js
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import v5x3 from './bolt-protocol-v5x3.transformer'
+import v5x4 from './bolt-protocol-v5x4.transformer'
 
 export default {
-  ...v5x3
+  ...v5x4
 }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x6.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x6.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import BoltProtocolV5x5 from './bolt-protocol-v5x5'
+
+import transformersFactories from './bolt-protocol-v5x5.transformer'
+import Transformer from './transformer'
+
+import { internal } from 'neo4j-driver-core'
+
+const {
+  constants: { BOLT_PROTOCOL_V5_6 }
+} = internal
+
+const DEFAULT_DIAGNOSTIC_RECORD = Object.freeze({
+  OPERATION: '',
+  OPERATION_CODE: '0',
+  CURRENT_SCHEMA: '/'
+})
+
+export default class BoltProtocol extends BoltProtocolV5x5 {
+  get version () {
+    return BOLT_PROTOCOL_V5_6
+  }
+
+  get transformer () {
+    if (this._transformer === undefined) {
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+    }
+    return this._transformer
+  }
+
+  /**
+   *
+   * @param {object} metadata
+   * @returns {object}
+   */
+  _enrichMetadata (metadata) {
+    if (Array.isArray(metadata.statuses)) {
+      metadata.statuses = metadata.statuses.map(status => ({
+        ...status,
+        diagnostic_record: status.diagnostic_record !== null ? { ...DEFAULT_DIAGNOSTIC_RECORD, ...status.diagnostic_record } : null
+      }))
+    }
+
+    return metadata
+  }
+}

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x6.transformer.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x6.transformer.js
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import v5x4 from './bolt-protocol-v5x4.transformer.js'
+import v5x5 from './bolt-protocol-v5x5.transformer'
 
 export default {
-  ...v5x4
+  ...v5x5
 }

--- a/packages/bolt-connection/src/bolt/create.js
+++ b/packages/bolt-connection/src/bolt/create.js
@@ -30,6 +30,7 @@ import BoltProtocolV5x2 from './bolt-protocol-v5x2'
 import BoltProtocolV5x3 from './bolt-protocol-v5x3'
 import BoltProtocolV5x4 from './bolt-protocol-v5x4'
 import BoltProtocolV5x5 from './bolt-protocol-v5x5'
+import BoltProtocolV5x6 from './bolt-protocol-v5x6'
 // eslint-disable-next-line no-unused-vars
 import { Chunker, Dechunker } from '../channel'
 import ResponseHandler from './response-handler'
@@ -232,6 +233,14 @@ function createProtocol (
         serversideRouting)
     case 5.5:
       return new BoltProtocolV5x5(server,
+        chunker,
+        packingConfig,
+        createResponseHandler,
+        log,
+        onProtocolError,
+        serversideRouting)
+    case 5.6:
+      return new BoltProtocolV5x6(server,
         chunker,
         packingConfig,
         createResponseHandler,

--- a/packages/bolt-connection/src/bolt/handshake.js
+++ b/packages/bolt-connection/src/bolt/handshake.js
@@ -76,7 +76,7 @@ function parseNegotiatedResponse (buffer, log) {
  */
 function newHandshakeBuffer () {
   return createHandshakeMessage([
-    [version(5, 5), version(5, 0)],
+    [version(5, 6), version(5, 0)],
     [version(4, 4), version(4, 2)],
     version(4, 1),
     version(3, 0)

--- a/packages/bolt-connection/test/bolt/__snapshots__/bolt-protocol-v5x6.test.js.snap
+++ b/packages/bolt-connection/test/bolt/__snapshots__/bolt-protocol-v5x6.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#unit BoltProtocolV5x6 .packable() should resultant function not pack graph types (Node) 1`] = `"It is not allowed to pass nodes in query parameters, given: (c:a {a:"b"})"`;
+
+exports[`#unit BoltProtocolV5x6 .packable() should resultant function not pack graph types (Path) 1`] = `"It is not allowed to pass paths in query parameters, given: [object Object]"`;
+
+exports[`#unit BoltProtocolV5x6 .packable() should resultant function not pack graph types (Relationship) 1`] = `"It is not allowed to pass relationships in query parameters, given: (e)-[:a {b:"c"}]->(f)"`;
+
+exports[`#unit BoltProtocolV5x6 .packable() should resultant function not pack graph types (UnboundRelationship) 1`] = `"It is not allowed to pass unbound relationships in query parameters, given: -[:a {b:"c"}]->"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Date with less fields) 1`] = `"Wrong struct size for Date, expected 1 but was 0"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Date with more fields) 1`] = `"Wrong struct size for Date, expected 1 but was 2"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (DateTimeWithZoneId with less fields) 1`] = `"Wrong struct size for DateTimeWithZoneId, expected 3 but was 2"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (DateTimeWithZoneId with more fields) 1`] = `"Wrong struct size for DateTimeWithZoneId, expected 3 but was 4"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (DateTimeWithZoneOffset with less fields) 1`] = `"Wrong struct size for DateTimeWithZoneOffset, expected 3 but was 2"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (DateTimeWithZoneOffset with more fields) 1`] = `"Wrong struct size for DateTimeWithZoneOffset, expected 3 but was 4"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Duration with less fields) 1`] = `"Wrong struct size for Duration, expected 4 but was 3"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Duration with more fields) 1`] = `"Wrong struct size for Duration, expected 4 but was 5"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (LocalDateTime with less fields) 1`] = `"Wrong struct size for LocalDateTime, expected 2 but was 1"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (LocalDateTime with more fields) 1`] = `"Wrong struct size for LocalDateTime, expected 2 but was 3"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (LocalTime with less fields) 1`] = `"Wrong struct size for LocalTime, expected 1 but was 0"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (LocalTime with more fields) 1`] = `"Wrong struct size for LocalTime, expected 1 but was 2"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Node with less fields) 1`] = `"Wrong struct size for Node, expected 4 but was 3"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Node with more fields) 1`] = `"Wrong struct size for Node, expected 4 but was 5"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Path with less fields) 1`] = `"Wrong struct size for Path, expected 3 but was 2"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Path with more fields) 1`] = `"Wrong struct size for Path, expected 3 but was 4"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Point with less fields) 1`] = `"Wrong struct size for Point2D, expected 3 but was 2"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Point with more fields) 1`] = `"Wrong struct size for Point2D, expected 3 but was 4"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Point3D with less fields) 1`] = `"Wrong struct size for Point3D, expected 4 but was 3"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Point3D with more fields) 1`] = `"Wrong struct size for Point3D, expected 4 but was 5"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Relationship with less fields) 1`] = `"Wrong struct size for Relationship, expected 8 but was 5"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Relationship with more fields) 1`] = `"Wrong struct size for Relationship, expected 8 but was 9"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Time with less fields) 1`] = `"Wrong struct size for Time, expected 2 but was 1"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (Time with more fileds) 1`] = `"Wrong struct size for Time, expected 2 but was 3"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (UnboundRelationship with less fields) 1`] = `"Wrong struct size for UnboundRelationship, expected 4 but was 3"`;
+
+exports[`#unit BoltProtocolV5x6 .unpack() should not unpack with wrong size (UnboundRelationship with more fields) 1`] = `"Wrong struct size for UnboundRelationship, expected 4 but was 5"`;

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v5x6.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v5x6.test.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import BoltProtocolV5x5 from '../../src/bolt/bolt-protocol-v5x5'
+import BoltProtocolV5x6 from '../../src/bolt/bolt-protocol-v5x6'
 import RequestMessage from '../../src/bolt/request-message'
 import { v2, structure } from '../../src/packstream'
 import utils from '../test-utils'
@@ -49,7 +49,7 @@ const {
   temporalUtil
 } = internal
 
-describe('#unit BoltProtocolV5x5', () => {
+describe('#unit BoltProtocolV5x6', () => {
   beforeEach(() => {
     expect.extend(utils.matchers)
   })
@@ -58,7 +58,7 @@ describe('#unit BoltProtocolV5x5', () => {
 
   it('should request routing information', () => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
     const routingContext = { someContextParam: 'value' }
     const databaseName = 'name'
@@ -79,7 +79,7 @@ describe('#unit BoltProtocolV5x5', () => {
 
   it('should request routing information sending bookmarks', () => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
     const routingContext = { someContextParam: 'value' }
     const listOfBookmarks = ['a', 'b', 'c']
@@ -112,7 +112,7 @@ describe('#unit BoltProtocolV5x5', () => {
       metadata: { x: 1, y: 'something' }
     })
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const query = 'RETURN $x, $y'
@@ -152,7 +152,7 @@ describe('#unit BoltProtocolV5x5', () => {
       metadata: { x: 1, y: 'something' }
     })
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const query = 'RETURN $x, $y'
@@ -193,7 +193,7 @@ describe('#unit BoltProtocolV5x5', () => {
       metadata: { x: 1, y: 'something' }
     })
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const observer = protocol.beginTransaction({
@@ -223,7 +223,7 @@ describe('#unit BoltProtocolV5x5', () => {
       metadata: { x: 1, y: 'something' }
     })
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const observer = protocol.beginTransaction({
@@ -243,14 +243,14 @@ describe('#unit BoltProtocolV5x5', () => {
   })
 
   it('should return correct bolt version number', () => {
-    const protocol = new BoltProtocolV5x5(null, null, false)
+    const protocol = new BoltProtocolV5x6(null, null, false)
 
-    expect(protocol.version).toBe(5.5)
+    expect(protocol.version).toBe(5.6)
   })
 
   it('should update metadata', () => {
     const metadata = { t_first: 1, t_last: 2, db_hits: 3, some_other_key: 4 }
-    const protocol = new BoltProtocolV5x5(null, null, false)
+    const protocol = new BoltProtocolV5x6(null, null, false)
 
     const transformedMetadata = protocol.transformMetadata(metadata)
 
@@ -264,7 +264,7 @@ describe('#unit BoltProtocolV5x5', () => {
 
   it('should initialize connection', () => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const clientName = 'js-driver/1.2.3'
@@ -301,13 +301,13 @@ describe('#unit BoltProtocolV5x5', () => {
   })
 
   it.each([
-    'javascript-driver/5.5.0',
+    'javascript-driver/5.6.0',
     '',
     undefined,
     null
   ])('should always use the user agent set by the user', (userAgent) => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const boltAgent = {
@@ -346,7 +346,7 @@ describe('#unit BoltProtocolV5x5', () => {
     [true, false]
   )('should logon to the server [flush=%s]', (flush) => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const authToken = { username: 'neo4j', password: 'secret' }
@@ -367,7 +367,7 @@ describe('#unit BoltProtocolV5x5', () => {
     [true, false]
   )('should logoff from the server [flush=%s]', (flush) => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const observer = protocol.logoff({ flush })
@@ -392,7 +392,7 @@ describe('#unit BoltProtocolV5x5', () => {
       metadata: { x: 1, y: 'something' }
     })
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const observer = protocol.beginTransaction({
@@ -411,7 +411,7 @@ describe('#unit BoltProtocolV5x5', () => {
 
   it('should commit', () => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const observer = protocol.commitTransaction()
@@ -424,7 +424,7 @@ describe('#unit BoltProtocolV5x5', () => {
 
   it('should rollback', () => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
     utils.spyProtocolWrite(protocol)
 
     const observer = protocol.rollbackTransaction()
@@ -437,7 +437,7 @@ describe('#unit BoltProtocolV5x5', () => {
 
   it('should support logoff', () => {
     const recorder = new utils.MessageRecordingConnection()
-    const protocol = new BoltProtocolV5x5(recorder, null, false)
+    const protocol = new BoltProtocolV5x6(recorder, null, false)
 
     expect(protocol.supportsReAuth).toBe(true)
   })
@@ -451,7 +451,7 @@ describe('#unit BoltProtocolV5x5', () => {
     ])(
       'should create unpacker with disableLosslessIntegers=%p and useBigInt=%p',
       (disableLosslessIntegers, useBigInt) => {
-        const protocol = new BoltProtocolV5x5(null, null, {
+        const protocol = new BoltProtocolV5x6(null, null, {
           disableLosslessIntegers,
           useBigInt
         })
@@ -473,7 +473,7 @@ describe('#unit BoltProtocolV5x5', () => {
     it('.run() should configure watermarks', () => {
       const recorder = new utils.MessageRecordingConnection()
       const protocol = utils.spyProtocolWrite(
-        new BoltProtocolV5x5(recorder, null, false)
+        new BoltProtocolV5x6(recorder, null, false)
       )
 
       const query = 'RETURN $x, $y'
@@ -492,12 +492,12 @@ describe('#unit BoltProtocolV5x5', () => {
 
   describe('packstream', () => {
     it('should configure v2 packer', () => {
-      const protocol = new BoltProtocolV5x5(null, null, false)
+      const protocol = new BoltProtocolV5x6(null, null, false)
       expect(protocol.packer()).toBeInstanceOf(v2.Packer)
     })
 
     it('should configure v2 unpacker', () => {
-      const protocol = new BoltProtocolV5x5(null, null, false)
+      const protocol = new BoltProtocolV5x6(null, null, false)
       expect(protocol.unpacker()).toBeInstanceOf(v2.Unpacker)
     })
   })
@@ -509,7 +509,7 @@ describe('#unit BoltProtocolV5x5', () => {
       ['UnboundRelationship', new UnboundRelationship(1, 'a', { b: 'c' }, '1')],
       ['Path', new Path(new Node(1, [], {}), new Node(2, [], {}), [])]
     ])('should resultant function not pack graph types (%s)', (_, graphType) => {
-      const protocol = new BoltProtocolV5x5(
+      const protocol = new BoltProtocolV5x6(
         new utils.MessageRecordingConnection(),
         null,
         false
@@ -546,7 +546,7 @@ describe('#unit BoltProtocolV5x5', () => {
       ['Point3D', new Point(1, 1, 1, 1)]
     ])('should pack spatial types and temporal types (%s)', (_, object) => {
       const buffer = alloc(256)
-      const protocol = new BoltProtocolV5x5(
+      const protocol = new BoltProtocolV5x6(
         new utils.MessageRecordingConnection(),
         buffer,
         {
@@ -665,7 +665,7 @@ describe('#unit BoltProtocolV5x5', () => {
     ])('should pack and unpack DateTimeWithZoneId and without offset (%s)', (_, object) => {
       const buffer = alloc(256)
       const loggerFunction = jest.fn()
-      const protocol = new BoltProtocolV5x5(
+      const protocol = new BoltProtocolV5x6(
         new utils.MessageRecordingConnection(),
         buffer,
         {
@@ -728,7 +728,7 @@ describe('#unit BoltProtocolV5x5', () => {
             )
             const buffer = alloc(256)
             const loggerFunction = jest.fn()
-            const protocol = new BoltProtocolV5x5(
+            const protocol = new BoltProtocolV5x6(
               new utils.MessageRecordingConnection(),
               buffer,
               {
@@ -776,7 +776,7 @@ describe('#unit BoltProtocolV5x5', () => {
           const object = DateTime.fromStandardDate(date)
           const buffer = alloc(256)
           const loggerFunction = jest.fn()
-          const protocol = new BoltProtocolV5x5(
+          const protocol = new BoltProtocolV5x6(
             new utils.MessageRecordingConnection(),
             buffer,
             {
@@ -855,7 +855,7 @@ describe('#unit BoltProtocolV5x5', () => {
       ]
     ])('should unpack graph types (%s)', (_, struct, graphObject) => {
       const buffer = alloc(256)
-      const protocol = new BoltProtocolV5x5(
+      const protocol = new BoltProtocolV5x6(
         new utils.MessageRecordingConnection(),
         buffer,
         false
@@ -1007,7 +1007,7 @@ describe('#unit BoltProtocolV5x5', () => {
       ]
     ])('should not unpack with wrong size (%s)', (_, struct) => {
       const buffer = alloc(256)
-      const protocol = new BoltProtocolV5x5(
+      const protocol = new BoltProtocolV5x6(
         new utils.MessageRecordingConnection(),
         buffer,
         false
@@ -1103,7 +1103,7 @@ describe('#unit BoltProtocolV5x5', () => {
       ]
     ])('should unpack spatial types and temporal types (%s)', (_, struct, object) => {
       const buffer = alloc(256)
-      const protocol = new BoltProtocolV5x5(
+      const protocol = new BoltProtocolV5x6(
         new utils.MessageRecordingConnection(),
         buffer,
         {
@@ -1132,7 +1132,7 @@ describe('#unit BoltProtocolV5x5', () => {
       ]
     ])('should unpack deprecated temporal types as unknown structs (%s)', (_, struct) => {
       const buffer = alloc(256)
-      const protocol = new BoltProtocolV5x5(
+      const protocol = new BoltProtocolV5x6(
         new utils.MessageRecordingConnection(),
         buffer,
         {
@@ -1152,7 +1152,7 @@ describe('#unit BoltProtocolV5x5', () => {
   })
 
   describe('result metadata enrichment', () => {
-    it('run should configure BoltProtocolV5x5._enrichMetadata as enrichMetadata', () => {
+    it('run should configure BoltProtocolV5x6._enrichMetadata as enrichMetadata', () => {
       const database = 'testdb'
       const bookmarks = new Bookmarks([
         'neo4j:bookmark:v1:tx1',
@@ -1163,7 +1163,7 @@ describe('#unit BoltProtocolV5x5', () => {
         metadata: { x: 1, y: 'something' }
       })
       const recorder = new utils.MessageRecordingConnection()
-      const protocol = new BoltProtocolV5x5(recorder, null, false)
+      const protocol = new BoltProtocolV5x6(recorder, null, false)
       utils.spyProtocolWrite(protocol)
 
       const query = 'RETURN $x, $y'
@@ -1179,7 +1179,7 @@ describe('#unit BoltProtocolV5x5', () => {
       expect(observer._enrichMetadata).toBe(protocol._enrichMetadata)
     })
 
-    describe('BoltProtocolV5x5._enrichMetadata', () => {
+    describe('BoltProtocolV5x6._enrichMetadata', () => {
       const protocol = newProtocol()
 
       it('should handle empty metadata', () => {
@@ -1483,7 +1483,6 @@ describe('#unit BoltProtocolV5x5', () => {
           [{
             gql_status: '03N33',
             status_description: 'info: description',
-            description: 'info: description',
             neo4j_code: 'Neo.Info.My.Code',
             title: 'Mitt title',
             diagnostic_record: {
@@ -1492,6 +1491,50 @@ describe('#unit BoltProtocolV5x5', () => {
               CURRENT_SCHEMA: '/',
               _classification: 'SOME',
               _severity: 'INFORMATION'
+            }
+          }]
+        ],
+        [
+          [{
+            gql_status: '03N33',
+            status_description: 'info: description',
+            neo4j_code: 'Neo.Info.My.Code',
+            description: 'description',
+            title: 'Mitt title',
+            diagnostic_record: {
+              _classification: 'SOME',
+              _severity: 'INFORMATION'
+            }
+          }],
+          [{
+            gql_status: '03N33',
+            status_description: 'info: description',
+            neo4j_code: 'Neo.Info.My.Code',
+            title: 'Mitt title',
+            description: 'description',
+            diagnostic_record: {
+              OPERATION: '',
+              OPERATION_CODE: '0',
+              CURRENT_SCHEMA: '/',
+              _classification: 'SOME',
+              _severity: 'INFORMATION'
+            }
+          }]
+        ],
+        [
+          [{
+            gql_status: '03N33',
+            status_description: 'info: description',
+            description: 'description'
+          }],
+          [{
+            gql_status: '03N33',
+            status_description: 'info: description',
+            description: 'description',
+            diagnostic_record: {
+              OPERATION: '',
+              OPERATION_CODE: '0',
+              CURRENT_SCHEMA: '/'
             }
           }]
         ]
@@ -1522,6 +1565,6 @@ describe('#unit BoltProtocolV5x5', () => {
   })
 
   function newProtocol (recorder) {
-    return new BoltProtocolV5x5(recorder, null, false, undefined, undefined, () => {})
+    return new BoltProtocolV5x6(recorder, null, false, undefined, undefined, () => {})
   }
 })

--- a/packages/bolt-connection/test/bolt/index.test.js
+++ b/packages/bolt-connection/test/bolt/index.test.js
@@ -34,6 +34,7 @@ import BoltProtocolV5x2 from '../../src/bolt/bolt-protocol-v5x2'
 import BoltProtocolV5x3 from '../../src/bolt/bolt-protocol-v5x3'
 import BoltProtocolV5x4 from '../../src/bolt/bolt-protocol-v5x4'
 import BoltProtocolV5x5 from '../../src/bolt/bolt-protocol-v5x5'
+import BoltProtocolV5x6 from '../../src/bolt/bolt-protocol-v5x6'
 
 const {
   logger: { Logger }
@@ -47,13 +48,13 @@ describe('#unit Bolt', () => {
       const writtenBuffer = channel.written[0]
 
       const boltMagicPreamble = '60 60 b0 17'
-      const protocolVersion5x5to5x0 = '00 05 05 05'
+      const protocolVersion5x6to5x0 = '00 06 06 05'
       const protocolVersion4x4to4x2 = '00 02 04 04'
       const protocolVersion4x1 = '00 00 01 04'
       const protocolVersion3 = '00 00 00 03'
 
       expect(writtenBuffer.toHex()).toEqual(
-        `${boltMagicPreamble} ${protocolVersion5x5to5x0} ${protocolVersion4x4to4x2} ${protocolVersion4x1} ${protocolVersion3}`
+        `${boltMagicPreamble} ${protocolVersion5x6to5x0} ${protocolVersion4x4to4x2} ${protocolVersion4x1} ${protocolVersion3}`
       )
     })
 
@@ -392,7 +393,8 @@ describe('#unit Bolt', () => {
         v(5.2, BoltProtocolV5x2),
         v(5.3, BoltProtocolV5x3),
         v(5.4, BoltProtocolV5x4),
-        v(5.5, BoltProtocolV5x5)
+        v(5.5, BoltProtocolV5x5),
+        v(5.6, BoltProtocolV5x6)
       ]
 
       availableProtocols.forEach(lambda)

--- a/packages/core/src/internal/constants.ts
+++ b/packages/core/src/internal/constants.ts
@@ -37,6 +37,7 @@ const BOLT_PROTOCOL_V5_2: number = 5.2
 const BOLT_PROTOCOL_V5_3: number = 5.3
 const BOLT_PROTOCOL_V5_4: number = 5.4
 const BOLT_PROTOCOL_V5_5: number = 5.5
+const BOLT_PROTOCOL_V5_6: number = 5.6
 
 const TELEMETRY_APIS = {
   MANAGED_TRANSACTION: 0,
@@ -70,5 +71,6 @@ export {
   BOLT_PROTOCOL_V5_3,
   BOLT_PROTOCOL_V5_4,
   BOLT_PROTOCOL_V5_5,
+  BOLT_PROTOCOL_V5_6,
   TELEMETRY_APIS
 }

--- a/packages/core/src/notification.ts
+++ b/packages/core/src/notification.ts
@@ -405,7 +405,7 @@ function polyfillNotification (status: any): Notification | undefined {
   return new Notification({
     code: status.neo4j_code,
     title: status.title,
-    description: status.status_description,
+    description: status.description,
     severity: status.diagnostic_record?._severity,
     category: status.diagnostic_record?._classification,
     position: status.diagnostic_record?._position

--- a/packages/core/test/notification.test.ts
+++ b/packages/core/test/notification.test.ts
@@ -108,6 +108,7 @@ describe('Notification', () => {
         neo4j_code: 'Neo.Notification.Warning.Code',
         gql_status: '01N42',
         status_description: 'Description',
+        description: 'the notification description',
         title: 'Notification Title',
         diagnostic_record: {
           OPERATION: '',
@@ -129,7 +130,7 @@ describe('Notification', () => {
       expect(notification).toEqual(new Notification({
         code: 'Neo.Notification.Warning.Code',
         title: 'Notification Title',
-        description: 'Description',
+        description: 'the notification description',
         severity: 'WARNING',
         position: {
           offset: 0,
@@ -146,6 +147,7 @@ describe('Notification', () => {
         gql_status: '03N42',
         title: 'Notification Title',
         status_description: 'Description',
+        description: 'the notification description',
         diagnostic_record: {
           OPERATION: '',
           OPERATION_CODE: '0',
@@ -166,7 +168,7 @@ describe('Notification', () => {
       expect(notification).toEqual(new Notification({
         code: 'Neo.Notification.Warning.Code',
         title: 'Notification Title',
-        description: 'Description',
+        description: 'the notification description',
         severity: 'INFORMATION',
         position: {
           offset: 0,
@@ -189,6 +191,7 @@ describe('Notification', () => {
         gql_status: '03N42',
         title: 'Notification Title',
         status_description: 'Description',
+        description: 'the notification description',
         diagnostic_record: {
           OPERATION: '',
           OPERATION_CODE: '0',
@@ -209,7 +212,7 @@ describe('Notification', () => {
       expect(notification).toEqual(new Notification({
         code: 'Neo.Notification.Warning.Code',
         title: 'Notification Title',
-        description: 'Description',
+        description: 'the notification description',
         severity,
         position: {
           offset: 1,
@@ -225,7 +228,8 @@ describe('Notification', () => {
         neo4j_code: 'Neo.Notification.Warning.Code',
         gql_status: '03N42',
         title: 'Notification Title',
-        status_description: 'Description'
+        status_description: 'Description',
+        description: 'the notification description'
       }
 
       const notification = polyfillNotification(status)
@@ -233,7 +237,7 @@ describe('Notification', () => {
       expect(notification).toEqual(new Notification({
         code: 'Neo.Notification.Warning.Code',
         title: 'Notification Title',
-        description: 'Description'
+        description: 'the notification description'
       }))
     })
   })

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x5.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x5.js
@@ -147,7 +147,7 @@ export default class BoltProtocol extends BoltProtocolV5x4 {
       afterComplete,
       highRecordWatermark,
       lowRecordWatermark,
-      enrichMetadata: BoltProtocol._enrichMetadata
+      enrichMetadata: this._enrichMetadata
     })
 
     const flushRun = reactive
@@ -176,10 +176,11 @@ export default class BoltProtocol extends BoltProtocolV5x4 {
    * @param {object} metadata
    * @returns {object}
    */
-  static _enrichMetadata (metadata) {
+  _enrichMetadata (metadata) {
     if (Array.isArray(metadata.statuses)) {
       metadata.statuses = metadata.statuses.map(status => ({
         ...status,
+        description: status.neo4j_code != null ? status.status_description : status.description,
         diagnostic_record: status.diagnostic_record !== null ? { ...DEFAULT_DIAGNOSTIC_RECORD, ...status.diagnostic_record } : null
       }))
     }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x6.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x6.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import BoltProtocolV5x5 from './bolt-protocol-v5x5.js'
+
+import transformersFactories from './bolt-protocol-v5x5.transformer.js'
+import Transformer from './transformer.js'
+
+import { internal } from '../../core/index.ts'
+
+const {
+  constants: { BOLT_PROTOCOL_V5_6 }
+} = internal
+
+const DEFAULT_DIAGNOSTIC_RECORD = Object.freeze({
+  OPERATION: '',
+  OPERATION_CODE: '0',
+  CURRENT_SCHEMA: '/'
+})
+
+export default class BoltProtocol extends BoltProtocolV5x5 {
+  get version () {
+    return BOLT_PROTOCOL_V5_6
+  }
+
+  get transformer () {
+    if (this._transformer === undefined) {
+      this._transformer = new Transformer(Object.values(transformersFactories).map(create => create(this._config, this._log)))
+    }
+    return this._transformer
+  }
+
+  /**
+   *
+   * @param {object} metadata
+   * @returns {object}
+   */
+  _enrichMetadata (metadata) {
+    if (Array.isArray(metadata.statuses)) {
+      metadata.statuses = metadata.statuses.map(status => ({
+        ...status,
+        diagnostic_record: status.diagnostic_record !== null ? { ...DEFAULT_DIAGNOSTIC_RECORD, ...status.diagnostic_record } : null
+      }))
+    }
+
+    return metadata
+  }
+}

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x6.transformer.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x6.transformer.js
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import v5x4 from './bolt-protocol-v5x4.transformer.js'
+import v5x5 from './bolt-protocol-v5x5.transformer.js'
 
 export default {
-  ...v5x4
+  ...v5x5
 }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/create.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/create.js
@@ -30,6 +30,7 @@ import BoltProtocolV5x2 from './bolt-protocol-v5x2.js'
 import BoltProtocolV5x3 from './bolt-protocol-v5x3.js'
 import BoltProtocolV5x4 from './bolt-protocol-v5x4.js'
 import BoltProtocolV5x5 from './bolt-protocol-v5x5.js'
+import BoltProtocolV5x6 from './bolt-protocol-v5x6.js'
 // eslint-disable-next-line no-unused-vars
 import { Chunker, Dechunker } from '../channel/index.js'
 import ResponseHandler from './response-handler.js'
@@ -232,6 +233,14 @@ function createProtocol (
         serversideRouting)
     case 5.5:
       return new BoltProtocolV5x5(server,
+        chunker,
+        packingConfig,
+        createResponseHandler,
+        log,
+        onProtocolError,
+        serversideRouting)
+    case 5.6:
+      return new BoltProtocolV5x6(server,
         chunker,
         packingConfig,
         createResponseHandler,

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/handshake.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/handshake.js
@@ -76,7 +76,7 @@ function parseNegotiatedResponse (buffer, log) {
  */
 function newHandshakeBuffer () {
   return createHandshakeMessage([
-    [version(5, 5), version(5, 0)],
+    [version(5, 6), version(5, 0)],
     [version(4, 4), version(4, 2)],
     version(4, 1),
     version(3, 0)

--- a/packages/neo4j-driver-deno/lib/core/internal/constants.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/constants.ts
@@ -37,6 +37,7 @@ const BOLT_PROTOCOL_V5_2: number = 5.2
 const BOLT_PROTOCOL_V5_3: number = 5.3
 const BOLT_PROTOCOL_V5_4: number = 5.4
 const BOLT_PROTOCOL_V5_5: number = 5.5
+const BOLT_PROTOCOL_V5_6: number = 5.6
 
 const TELEMETRY_APIS = {
   MANAGED_TRANSACTION: 0,
@@ -70,5 +71,6 @@ export {
   BOLT_PROTOCOL_V5_3,
   BOLT_PROTOCOL_V5_4,
   BOLT_PROTOCOL_V5_5,
+  BOLT_PROTOCOL_V5_6,
   TELEMETRY_APIS
 }

--- a/packages/neo4j-driver-deno/lib/core/notification.ts
+++ b/packages/neo4j-driver-deno/lib/core/notification.ts
@@ -405,7 +405,7 @@ function polyfillNotification (status: any): Notification | undefined {
   return new Notification({
     code: status.neo4j_code,
     title: status.title,
-    description: status.status_description,
+    description: status.description,
     severity: status.diagnostic_record?._severity,
     category: status.diagnostic_record?._classification,
     position: status.diagnostic_record?._position

--- a/packages/testkit-backend/src/feature/common.js
+++ b/packages/testkit-backend/src/feature/common.js
@@ -25,6 +25,7 @@ const features = [
   'Feature:Bolt:5.3',
   'Feature:Bolt:5.4',
   'Feature:Bolt:5.5',
+  'Feature:Bolt:5.6',
   'Feature:Bolt:Patch:UTC',
   'Feature:API:ConnectionAcquisitionTimeout',
   'Feature:API:Driver.ExecuteQuery',


### PR DESCRIPTION
Bolt 5.6 introduces the original notification description back in the protocol level. This avoids the `Notification.description` changes when connected to GQL aware servers.

This issues was detected during homologation, so the problem won't happen with any released server since the bolt version which miss information will not be released.