### PR TITLE
Fix failures on the pipelines due to memory issues

### DIFF
--- a/packages/testkit-backend/deno/controller.ts
+++ b/packages/testkit-backend/deno/controller.ts
@@ -64,12 +64,14 @@ export function createHandler(
   ) {
     const context = newContext();
     const wire = newWire(context, (response) => {
-      console.log("response:", response);
+      console.log("response:", response.name);
+      console.debug(response.data);
       return reply(response);
     });
 
     for await (const request of requests()) {
-      console.log("request:", request);
+      console.log("request:", request.name);
+      console.debug(request.data);
       const { data, name } = request;
       if (!(name in requestHandlers)) {
         console.log("Unknown request: " + name);

--- a/packages/testkit-backend/deno/deps.ts
+++ b/packages/testkit-backend/deno/deps.ts
@@ -6,3 +6,4 @@ export { default as neo4j } from "../../neo4j-driver-deno/lib/mod.ts";
 export { createGetFeatures } from "../src/feature/index.js";
 export * as handlers from "../src/request-handlers.js";
 export { default as CypherNativeBinders } from "../src/cypher-native-binders.js";
+export { default as configurableConsole } from "../src/console.configurable.js";

--- a/packages/testkit-backend/deno/index.ts
+++ b/packages/testkit-backend/deno/index.ts
@@ -1,4 +1,5 @@
 import {
+  configurableConsole,
   Context,
   createGetFeatures,
   CypherNativeBinders,
@@ -29,6 +30,7 @@ const logLevel = Deno.env.get("TEST_LOG_LEVEL");
 const createContext = () =>
   new Context(shouldRunTest, getFeatures, binder, logLevel);
 
+configurableConsole.install(logLevel);
 const listener = channel.listen(9876);
 const handle = controller.createHandler(neo4j, createContext, requestHandlers);
 

--- a/packages/testkit-backend/src/channel/testkit-protocol.js
+++ b/packages/testkit-backend/src/channel/testkit-protocol.js
@@ -62,14 +62,16 @@ export default class Protocol extends EventEmitter {
 
   serializeResponse (response) {
     const responseStr = stringify(response)
-    console.log('> writing response', responseStr)
+    console.log('> writing response', response.name)
+    console.debug(responseStr)
     return ['#response begin', responseStr, '#response end'].join('\n') + '\n'
   }
 
   _emitRequest () {
     const request = JSON.parse(this._request)
     const { name, data } = request
-    console.log('> Got request ' + name, data)
+    console.log('> Got request ' + name)
+    console.debug(data)
     this.emit('request', { name, data })
   }
 }

--- a/packages/testkit-backend/src/console.configurable.js
+++ b/packages/testkit-backend/src/console.configurable.js
@@ -1,0 +1,42 @@
+const originalConsole = console
+
+const config = {
+  level: 'info',
+  canRun: (method) => {
+    if (config.level === 'debug') {
+      return true
+    } else if (config.level === 'info') {
+      return method !== 'debug'
+    } else if (config.level === 'warn') {
+      return method !== 'debug' &&
+               method !== 'log'
+    } else if (config.level === 'error') {
+      return method !== 'debug' &&
+                method !== 'log' &&
+                method !== 'warn'
+    }
+    return true
+  }
+}
+
+export default {
+  install (level = 'info') {
+    this.setLevel(level)
+    // eslint-disable-next-line no-global-assign
+    console = new Proxy({}, {
+      get: (_, method) => (...args) => {
+        if (config.canRun(method)) {
+          originalConsole[method].apply(originalConsole, args)
+        }
+      }
+    })
+  },
+  setLevel (level) {
+    config.level = (level || 'info').toLowerCase()
+  },
+  uninstall () {
+    config.level = 'info'
+    // eslint-disable-next-line no-global-assign
+    console = originalConsole
+  }
+}

--- a/packages/testkit-backend/src/index.js
+++ b/packages/testkit-backend/src/index.js
@@ -8,6 +8,7 @@ import { createGetFeatures } from './feature'
 import * as REQUEST_HANDLERS from './request-handlers.js'
 import * as RX_REQUEST_HANDLERS from './request-handlers-rx.js'
 import remoteConsole from './console.remote.js'
+import configurableConsole from './console.configurable.js'
 
 const SUPPORTED_TLS = (() => {
   if (tls.DEFAULT_MAX_VERSION) {
@@ -38,6 +39,8 @@ function main () {
 
   const shouldRunTest = getShouldRunTest([...driverDescriptorList, sessionTypeDescriptor])
   const getFeatures = createGetFeatures([sessionTypeDescriptor], SUPPORTED_TLS)
+
+  configurableConsole.install(process.env.TEST_LOG_LEVEL || 'info')
 
   const newChannel = () => {
     if (channelType.toUpperCase() === 'WEBSOCKET') {

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -1,4 +1,5 @@
 import * as responses from './responses.js'
+import configurableConsole from './console.configurable.js'
 
 export function throwFrontendError () {
   throw new Error('TestKit FrontendError')
@@ -376,6 +377,9 @@ export function StartTest (_, context, { testName }, wire) {
   } else {
     context.logLevel = null
   }
+
+  configurableConsole.setLevel(context.logLevel || context.environmentLogLevel)
+
   const shouldRunTest = context.getShouldRunTestFunction()
   shouldRunTest(testName, {
     onRun: () => {


### PR DESCRIPTION
The testkit pipelines are failing given the log size generated from the testkit tests.

This PR enables the configuration of log levels for testkit backend ('info' by default) and downgrades the message parameters messages to 'debug' for saving space on logs.

<!--
    Thanks for making the effort to create a Pull Request!
    Please read the comment in its entirety fist.
    If you haven't already, please sign our Contributor License Agreement at
    https://neo4j.com/developer/cla/
    Commits from accounts that have not signed the CLA will fail the CI and
    will not be reviewed. If you are a first-time contributor and have just
    signed the CLA, please include a note about this in the PR comment as some
    manual steps from our side are required.
-->

<!--
    Title:
    PRs targeting the current default branch (nightly driver) don't follow a
    fixed naming scheme.
    If your PR is a backport, please link the original PR in the comments.
-->

<!--
    Description:
    Please include a summary of the changes in this PR and their purpose.
    Link any related issues or PRs.
-->
