### PR TITLE
Fix `DateTime.toString()` on missing offset

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.utc.transformer.js
@@ -28,11 +28,12 @@ import v4x4 from './bolt-protocol-v4x4.transformer'
 import {
   epochSecondAndNanoToLocalDateTime
 } from './temporal-factory'
-import { identity } from '../lang/functional'
 
 const {
   temporalUtil: {
-    localDateTimeToEpochSecond
+    localDateTimeToEpochSecond,
+    getTimeInZoneId,
+    getOffsetFromZoneId
   }
 } = internal
 
@@ -99,126 +100,6 @@ function createDateTimeWithZoneIdTransformer (config, logger) {
       return new structure.Structure(DATE_TIME_WITH_ZONE_ID, [utc, nano, timeZoneId])
     }
   })
-}
-
-/**
- * Returns the offset for a given timezone id
- *
- * Javascript doesn't have support for direct getting the timezone offset from a given
- * TimeZoneId and DateTime in the given TimeZoneId. For solving this issue,
- *
- * 1. The ZoneId is applied to the timestamp, so we could make the difference between the
- * given timestamp and the new calculated one. This is the offset for the timezone
- * in the utc is equal to epoch (some time in the future or past)
- * 2. The offset is subtracted from the timestamp, so we have an estimated utc timestamp.
- * 3. The ZoneId is applied to the new timestamp, se we could could make the difference
- * between the new timestamp and the calculated one. This is the offset for the given timezone.
- *
- * Example:
- *    Input: 2022-3-27 1:59:59 'Europe/Berlin'
- *    Apply 1, 2022-3-27 1:59:59 => 2022-3-27 3:59:59 'Europe/Berlin' +2:00
- *    Apply 2, 2022-3-27 1:59:59 - 2:00 => 2022-3-26 23:59:59
- *    Apply 3, 2022-3-26 23:59:59 => 2022-3-27 00:59:59 'Europe/Berlin' +1:00
- *  The offset is +1 hour.
- *
- * @param {string} timeZoneId The timezone id
- * @param {Integer} epochSecond The epoch second in the timezone id
- * @param {Integerable} nanosecond The nanoseconds in the timezone id
- * @returns The timezone offset
- */
-function getOffsetFromZoneId (timeZoneId, epochSecond, nanosecond) {
-  const dateTimeWithZoneAppliedTwice = getTimeInZoneId(timeZoneId, epochSecond, nanosecond)
-
-  // The wallclock form the current date time
-  const epochWithZoneAppliedTwice = localDateTimeToEpochSecond(
-    dateTimeWithZoneAppliedTwice.year,
-    dateTimeWithZoneAppliedTwice.month,
-    dateTimeWithZoneAppliedTwice.day,
-    dateTimeWithZoneAppliedTwice.hour,
-    dateTimeWithZoneAppliedTwice.minute,
-    dateTimeWithZoneAppliedTwice.second,
-    nanosecond)
-
-  const offsetOfZoneInTheFutureUtc = epochWithZoneAppliedTwice.subtract(epochSecond)
-  const guessedUtc = epochSecond.subtract(offsetOfZoneInTheFutureUtc)
-
-  const zonedDateTimeFromGuessedUtc = getTimeInZoneId(timeZoneId, guessedUtc, nanosecond)
-
-  const zonedEpochFromGuessedUtc = localDateTimeToEpochSecond(
-    zonedDateTimeFromGuessedUtc.year,
-    zonedDateTimeFromGuessedUtc.month,
-    zonedDateTimeFromGuessedUtc.day,
-    zonedDateTimeFromGuessedUtc.hour,
-    zonedDateTimeFromGuessedUtc.minute,
-    zonedDateTimeFromGuessedUtc.second,
-    nanosecond)
-
-  const offset = zonedEpochFromGuessedUtc.subtract(guessedUtc)
-  return offset
-}
-
-const dateTimeFormatCache = new Map()
-
-function getDateTimeFormatForZoneId (timeZoneId) {
-  if (!dateTimeFormatCache.has(timeZoneId)) {
-    const formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone: timeZoneId,
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric',
-      hour12: false,
-      era: 'narrow'
-    })
-
-    dateTimeFormatCache.set(timeZoneId, formatter)
-  }
-
-  return dateTimeFormatCache.get(timeZoneId)
-}
-
-function getTimeInZoneId (timeZoneId, epochSecond, nano) {
-  const formatter = getDateTimeFormatForZoneId(timeZoneId)
-
-  const utc = int(epochSecond)
-    .multiply(1000)
-    .add(int(nano).div(1_000_000))
-    .toNumber()
-
-  const formattedUtcParts = formatter.formatToParts(utc)
-
-  const localDateTime = formattedUtcParts.reduce((obj, currentValue) => {
-    if (currentValue.type === 'era') {
-      obj.adjustEra =
-        currentValue.value.toUpperCase() === 'B'
-          ? year => year.subtract(1).negate() // 1BC equals to year 0 in astronomical year numbering
-          : identity
-    } else if (currentValue.type === 'hour') {
-      obj.hour = int(currentValue.value).modulo(24)
-    } else if (currentValue.type !== 'literal') {
-      obj[currentValue.type] = int(currentValue.value)
-    }
-    return obj
-  }, {})
-
-  localDateTime.year = localDateTime.adjustEra(localDateTime.year)
-
-  const epochInTimeZone = localDateTimeToEpochSecond(
-    localDateTime.year,
-    localDateTime.month,
-    localDateTime.day,
-    localDateTime.hour,
-    localDateTime.minute,
-    localDateTime.second,
-    localDateTime.nanosecond
-  )
-
-  localDateTime.timeZoneOffsetSeconds = epochInTimeZone.subtract(epochSecond)
-  localDateTime.hour = localDateTime.hour.modulo(24)
-
-  return localDateTime
 }
 
 function createDateTimeWithOffsetTransformer (config) {

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -682,9 +682,23 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       this.nanosecond
     )
 
-    const timeOffset = this.timeZoneOffsetSeconds != null
-      ? util.timeZoneOffsetToIsoString(this.timeZoneOffsetSeconds ?? 0)
-      : ''
+    let offsetInSeconds: NumberOrInteger | undefined = this.timeZoneOffsetSeconds
+
+    if (offsetInSeconds == null) {
+      const epochSecond = util.localDateTimeToEpochSecond(
+        this.year,
+        this.month,
+        this.day,
+        this.hour,
+        this.minute,
+        this.second,
+        this.nanosecond
+      )
+
+      offsetInSeconds = util.getOffsetFromZoneId(this.timeZoneId ?? '', epochSecond, this.nanosecond)
+    }
+
+    const timeOffset = util.timeZoneOffsetToIsoString(offsetInSeconds)
 
     const timeZoneStr = this.timeZoneId != null
       ? `[${this.timeZoneId}]`

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -162,6 +162,38 @@ describe('DateTime', () => {
       )
     })
   })
+
+  describe('.toString()', () => {
+    it('should stringify to iso string (offset + zone id)', () => {
+      const datetime = new DateTime(2022, 6, 16, 11, 19, 25, 4000004, 2 * 60 * 60, 'Europe/Stockholm')
+
+      const stringified = datetime.toString()
+
+      expect(stringified).toEqual(
+        '2022-06-16T11:19:25.004000004+02:00[Europe/Stockholm]'
+      )
+    })
+
+    it('should stringify to iso string (offset)', () => {
+      const datetime = new DateTime(2020, 12, 15, 12, 2, 3, 4000000, 60 * 60)
+
+      const stringified = datetime.toString()
+
+      expect(stringified).toEqual(
+        '2020-12-15T12:02:03.004000000+01:00'
+      )
+    })
+
+    it('should stringify to iso string (zoneid)', () => {
+      const datetime = new DateTime(2020, 12, 15, 12, 2, 3, 4000000, undefined, 'Europe/Stockholm')
+
+      const stringified = datetime.toString()
+
+      expect(stringified).toEqual(
+        '2020-12-15T12:02:03.004000000+01:00[Europe/Stockholm]'
+      )
+    })
+  })
 })
 
 describe('isDuration', () => {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.utc.transformer.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.utc.transformer.js
@@ -28,11 +28,12 @@ import v4x4 from './bolt-protocol-v4x4.transformer.js'
 import {
   epochSecondAndNanoToLocalDateTime
 } from './temporal-factory.js'
-import { identity } from '../lang/functional.js'
 
 const {
   temporalUtil: {
-    localDateTimeToEpochSecond
+    localDateTimeToEpochSecond,
+    getTimeInZoneId,
+    getOffsetFromZoneId
   }
 } = internal
 
@@ -99,126 +100,6 @@ function createDateTimeWithZoneIdTransformer (config, logger) {
       return new structure.Structure(DATE_TIME_WITH_ZONE_ID, [utc, nano, timeZoneId])
     }
   })
-}
-
-/**
- * Returns the offset for a given timezone id
- *
- * Javascript doesn't have support for direct getting the timezone offset from a given
- * TimeZoneId and DateTime in the given TimeZoneId. For solving this issue,
- *
- * 1. The ZoneId is applied to the timestamp, so we could make the difference between the
- * given timestamp and the new calculated one. This is the offset for the timezone
- * in the utc is equal to epoch (some time in the future or past)
- * 2. The offset is subtracted from the timestamp, so we have an estimated utc timestamp.
- * 3. The ZoneId is applied to the new timestamp, se we could could make the difference
- * between the new timestamp and the calculated one. This is the offset for the given timezone.
- *
- * Example:
- *    Input: 2022-3-27 1:59:59 'Europe/Berlin'
- *    Apply 1, 2022-3-27 1:59:59 => 2022-3-27 3:59:59 'Europe/Berlin' +2:00
- *    Apply 2, 2022-3-27 1:59:59 - 2:00 => 2022-3-26 23:59:59
- *    Apply 3, 2022-3-26 23:59:59 => 2022-3-27 00:59:59 'Europe/Berlin' +1:00
- *  The offset is +1 hour.
- *
- * @param {string} timeZoneId The timezone id
- * @param {Integer} epochSecond The epoch second in the timezone id
- * @param {Integerable} nanosecond The nanoseconds in the timezone id
- * @returns The timezone offset
- */
-function getOffsetFromZoneId (timeZoneId, epochSecond, nanosecond) {
-  const dateTimeWithZoneAppliedTwice = getTimeInZoneId(timeZoneId, epochSecond, nanosecond)
-
-  // The wallclock form the current date time
-  const epochWithZoneAppliedTwice = localDateTimeToEpochSecond(
-    dateTimeWithZoneAppliedTwice.year,
-    dateTimeWithZoneAppliedTwice.month,
-    dateTimeWithZoneAppliedTwice.day,
-    dateTimeWithZoneAppliedTwice.hour,
-    dateTimeWithZoneAppliedTwice.minute,
-    dateTimeWithZoneAppliedTwice.second,
-    nanosecond)
-
-  const offsetOfZoneInTheFutureUtc = epochWithZoneAppliedTwice.subtract(epochSecond)
-  const guessedUtc = epochSecond.subtract(offsetOfZoneInTheFutureUtc)
-
-  const zonedDateTimeFromGuessedUtc = getTimeInZoneId(timeZoneId, guessedUtc, nanosecond)
-
-  const zonedEpochFromGuessedUtc = localDateTimeToEpochSecond(
-    zonedDateTimeFromGuessedUtc.year,
-    zonedDateTimeFromGuessedUtc.month,
-    zonedDateTimeFromGuessedUtc.day,
-    zonedDateTimeFromGuessedUtc.hour,
-    zonedDateTimeFromGuessedUtc.minute,
-    zonedDateTimeFromGuessedUtc.second,
-    nanosecond)
-
-  const offset = zonedEpochFromGuessedUtc.subtract(guessedUtc)
-  return offset
-}
-
-const dateTimeFormatCache = new Map()
-
-function getDateTimeFormatForZoneId (timeZoneId) {
-  if (!dateTimeFormatCache.has(timeZoneId)) {
-    const formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone: timeZoneId,
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric',
-      hour12: false,
-      era: 'narrow'
-    })
-
-    dateTimeFormatCache.set(timeZoneId, formatter)
-  }
-
-  return dateTimeFormatCache.get(timeZoneId)
-}
-
-function getTimeInZoneId (timeZoneId, epochSecond, nano) {
-  const formatter = getDateTimeFormatForZoneId(timeZoneId)
-
-  const utc = int(epochSecond)
-    .multiply(1000)
-    .add(int(nano).div(1_000_000))
-    .toNumber()
-
-  const formattedUtcParts = formatter.formatToParts(utc)
-
-  const localDateTime = formattedUtcParts.reduce((obj, currentValue) => {
-    if (currentValue.type === 'era') {
-      obj.adjustEra =
-        currentValue.value.toUpperCase() === 'B'
-          ? year => year.subtract(1).negate() // 1BC equals to year 0 in astronomical year numbering
-          : identity
-    } else if (currentValue.type === 'hour') {
-      obj.hour = int(currentValue.value).modulo(24)
-    } else if (currentValue.type !== 'literal') {
-      obj[currentValue.type] = int(currentValue.value)
-    }
-    return obj
-  }, {})
-
-  localDateTime.year = localDateTime.adjustEra(localDateTime.year)
-
-  const epochInTimeZone = localDateTimeToEpochSecond(
-    localDateTime.year,
-    localDateTime.month,
-    localDateTime.day,
-    localDateTime.hour,
-    localDateTime.minute,
-    localDateTime.second,
-    localDateTime.nanosecond
-  )
-
-  localDateTime.timeZoneOffsetSeconds = epochInTimeZone.subtract(epochSecond)
-  localDateTime.hour = localDateTime.hour.modulo(24)
-
-  return localDateTime
 }
 
 function createDateTimeWithOffsetTransformer (config) {

--- a/packages/neo4j-driver-deno/lib/core/internal/temporal-util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/temporal-util.ts
@@ -20,6 +20,9 @@ import { Neo4jError, newError } from '../error.ts'
 import { assertNumberOrInteger } from './util.ts'
 import { NumberOrInteger } from '../graph-types.ts'
 
+const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>()
+const timeZoneValidityCache = new Map<string, boolean>()
+
 /*
   Code in this util should be compatible with code in the database that uses JSR-310 java.time APIs.
 
@@ -428,7 +431,7 @@ export function assertValidNanosecond (
   )
 }
 
-const timeZoneValidityCache = new Map<string, boolean>()
+
 const newInvalidZoneIdError = (zoneId: string, fieldName: string): Neo4jError => newError(
   `${fieldName} is expected to be a valid ZoneId but was: "${zoneId}"`
 )
@@ -613,6 +616,124 @@ function formatYear (year: NumberOrInteger | string): string {
     return formatNumber(yearInteger, 6, { usePositiveSign: true })
   }
   return formatNumber(yearInteger, 4)
+}
+
+/**
+ * Returns the offset for a given timezone id
+ *
+ * Javascript doesn't have support for direct getting the timezone offset from a given
+ * TimeZoneId and DateTime in the given TimeZoneId. For solving this issue,
+ *
+ * 1. The ZoneId is applied to the timestamp, so we could make the difference between the
+ * given timestamp and the new calculated one. This is the offset for the timezone
+ * in the utc is equal to epoch (some time in the future or past)
+ * 2. The offset is subtracted from the timestamp, so we have an estimated utc timestamp.
+ * 3. The ZoneId is applied to the new timestamp, se we could could make the difference
+ * between the new timestamp and the calculated one. This is the offset for the given timezone.
+ *
+ * Example:
+ *    Input: 2022-3-27 1:59:59 'Europe/Berlin'
+ *    Apply 1, 2022-3-27 1:59:59 => 2022-3-27 3:59:59 'Europe/Berlin' +2:00
+ *    Apply 2, 2022-3-27 1:59:59 - 2:00 => 2022-3-26 23:59:59
+ *    Apply 3, 2022-3-26 23:59:59 => 2022-3-27 00:59:59 'Europe/Berlin' +1:00
+ *  The offset is +1 hour.
+ *
+ * @param {string} timeZoneId The timezone id
+ * @param {Integer} epochSecond The epoch second in the timezone id
+ * @param {Integerable} nanosecond The nanoseconds in the timezone id
+ * @returns The timezone offset
+ */
+export function getOffsetFromZoneId (timeZoneId: string, epochSecond: Integer, nanosecond: Integer | bigint | number): Integer {
+  const dateTimeWithZoneAppliedTwice = getTimeInZoneId(timeZoneId, epochSecond, nanosecond)
+
+  // The wallclock form the current date time
+  const epochWithZoneAppliedTwice = localDateTimeToEpochSecond(
+    dateTimeWithZoneAppliedTwice.year,
+    dateTimeWithZoneAppliedTwice.month,
+    dateTimeWithZoneAppliedTwice.day,
+    dateTimeWithZoneAppliedTwice.hour,
+    dateTimeWithZoneAppliedTwice.minute,
+    dateTimeWithZoneAppliedTwice.second,
+    nanosecond)
+
+  const offsetOfZoneInTheFutureUtc = epochWithZoneAppliedTwice.subtract(epochSecond)
+  const guessedUtc = epochSecond.subtract(offsetOfZoneInTheFutureUtc)
+
+  const zonedDateTimeFromGuessedUtc = getTimeInZoneId(timeZoneId, guessedUtc, nanosecond)
+
+  const zonedEpochFromGuessedUtc = localDateTimeToEpochSecond(
+    zonedDateTimeFromGuessedUtc.year,
+    zonedDateTimeFromGuessedUtc.month,
+    zonedDateTimeFromGuessedUtc.day,
+    zonedDateTimeFromGuessedUtc.hour,
+    zonedDateTimeFromGuessedUtc.minute,
+    zonedDateTimeFromGuessedUtc.second,
+    nanosecond)
+
+  const offset = zonedEpochFromGuessedUtc.subtract(guessedUtc)
+  return offset
+}
+
+export function getDateTimeFormatForZoneId (timeZoneId: string): Intl.DateTimeFormat {
+  let formatter = dateTimeFormatCache.get(timeZoneId) ?? new Intl.DateTimeFormat('en-US', {
+    timeZone: timeZoneId,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: false,
+    era: 'narrow'
+  })
+
+  if (!dateTimeFormatCache.has(timeZoneId)) {
+    dateTimeFormatCache.set(timeZoneId, formatter)
+  }
+
+  return formatter
+}
+
+export function getTimeInZoneId (timeZoneId: string, epochSecond: Integer, nano: bigint | Integer | number ): any {
+  const formatter = getDateTimeFormatForZoneId(timeZoneId)
+
+  const utc = int(epochSecond)
+    .multiply(1000)
+    .add(int(nano).div(1_000_000))
+    .toNumber()
+
+  const formattedUtcParts = formatter.formatToParts(utc)
+
+  const localDateTime = formattedUtcParts.reduce((obj, currentValue) => {
+    if (currentValue.type === 'era') {
+      obj.adjustEra =
+        currentValue.value.toUpperCase() === 'B'
+          ? (year: Integer) => year.subtract(1).negate() // 1BC equals to year 0 in astronomical year numbering
+          : (i: any) => i
+    } else if (currentValue.type === 'hour') {
+      obj.hour = int(currentValue.value).modulo(24)
+    } else if (currentValue.type !== 'literal') {
+      obj[currentValue.type] = int(currentValue.value)
+    }
+    return obj
+  }, {} as any)
+
+  localDateTime.year = localDateTime.adjustEra(localDateTime.year)
+
+  const epochInTimeZone = localDateTimeToEpochSecond(
+    localDateTime.year,
+    localDateTime.month,
+    localDateTime.day,
+    localDateTime.hour,
+    localDateTime.minute,
+    localDateTime.second,
+    localDateTime.nanosecond
+  )
+
+  localDateTime.timeZoneOffsetSeconds = epochInTimeZone.subtract(epochSecond)
+  localDateTime.hour = localDateTime.hour.modulo(24)
+
+  return localDateTime
 }
 
 /**

--- a/packages/neo4j-driver-deno/lib/core/internal/temporal-util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/temporal-util.ts
@@ -431,7 +431,6 @@ export function assertValidNanosecond (
   )
 }
 
-
 const newInvalidZoneIdError = (zoneId: string, fieldName: string): Neo4jError => newError(
   `${fieldName} is expected to be a valid ZoneId but was: "${zoneId}"`
 )
@@ -675,7 +674,7 @@ export function getOffsetFromZoneId (timeZoneId: string, epochSecond: Integer, n
 }
 
 export function getDateTimeFormatForZoneId (timeZoneId: string): Intl.DateTimeFormat {
-  let formatter = dateTimeFormatCache.get(timeZoneId) ?? new Intl.DateTimeFormat('en-US', {
+  const formatter = dateTimeFormatCache.get(timeZoneId) ?? new Intl.DateTimeFormat('en-US', {
     timeZone: timeZoneId,
     year: 'numeric',
     month: 'numeric',
@@ -694,7 +693,7 @@ export function getDateTimeFormatForZoneId (timeZoneId: string): Intl.DateTimeFo
   return formatter
 }
 
-export function getTimeInZoneId (timeZoneId: string, epochSecond: Integer, nano: bigint | Integer | number ): any {
+export function getTimeInZoneId (timeZoneId: string, epochSecond: Integer, nano: bigint | Integer | number): any {
   const formatter = getDateTimeFormatForZoneId(timeZoneId)
 
   const utc = int(epochSecond)
@@ -704,7 +703,7 @@ export function getTimeInZoneId (timeZoneId: string, epochSecond: Integer, nano:
 
   const formattedUtcParts = formatter.formatToParts(utc)
 
-  const localDateTime = formattedUtcParts.reduce((obj, currentValue) => {
+  const localDateTime = formattedUtcParts.reduce<any>((obj, currentValue) => {
     if (currentValue.type === 'era') {
       obj.adjustEra =
         currentValue.value.toUpperCase() === 'B'
@@ -716,7 +715,7 @@ export function getTimeInZoneId (timeZoneId: string, epochSecond: Integer, nano:
       obj[currentValue.type] = int(currentValue.value)
     }
     return obj
-  }, {} as any)
+  }, {})
 
   localDateTime.year = localDateTime.adjustEra(localDateTime.year)
 

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -682,9 +682,24 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       this.nanosecond
     )
 
-    const timeOffset = this.timeZoneOffsetSeconds != null
-      ? util.timeZoneOffsetToIsoString(this.timeZoneOffsetSeconds ?? 0)
-      : ''
+    let offsetInSeconds: NumberOrInteger | undefined = this.timeZoneOffsetSeconds
+
+    if (offsetInSeconds == null) {
+      const epochSecond = util.localDateTimeToEpochSecond(
+        this.year,
+        this.month,
+        this.day,
+        this.hour,
+        this.minute,
+        this.second,
+        this.nanosecond
+      )
+
+      offsetInSeconds = util.getOffsetFromZoneId(this.timeZoneId ?? '', epochSecond, this.nanosecond)
+    }
+      
+
+    const timeOffset = util.timeZoneOffsetToIsoString(offsetInSeconds)
 
     const timeZoneStr = this.timeZoneId != null
       ? `[${this.timeZoneId}]`

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -697,7 +697,6 @@ export class DateTime<T extends NumberOrInteger = Integer> {
 
       offsetInSeconds = util.getOffsetFromZoneId(this.timeZoneId ?? '', epochSecond, this.nanosecond)
     }
-      
 
     const timeOffset = util.timeZoneOffsetToIsoString(offsetInSeconds)
 

--- a/packages/neo4j-driver/test/temporal-types.test.js
+++ b/packages/neo4j-driver/test/temporal-types.test.js
@@ -627,7 +627,7 @@ describe('#integration temporal-types', () => {
         15000000,
         'Europe/Zaporozhye'
       ).toString()
-    ).toEqual('1949-10-07T06:10:15.015000000[Europe/Zaporozhye]')
+    ).toEqual('1949-10-07T06:10:15.015000000+03:00[Europe/Zaporozhye]')
     expect(
       dateTimeWithZoneId(
         -30455,
@@ -639,7 +639,7 @@ describe('#integration temporal-types', () => {
         123,
         'Asia/Yangon'
       ).toString()
-    ).toEqual('-030455-05-05T12:24:10.000000123[Asia/Yangon]')
+    ).toEqual('-030455-05-05T12:24:10.000000123+06:24:47[Asia/Yangon]')
   }, 90000)
 
   it('should expose local time components in time', () => {


### PR DESCRIPTION
When the offset is missing from the DateTime object, the object is stringified without the offset and so not compliant with the iso standard.

For example, `new DateTime(2020, 12, 15, 12, 2, 3, 4000000, undefined, 'Europe/Stockholm')` is stringified as
`2020-12-15T12:02:03.004000000[Europe/Stockholm]`, which is missing any offset information.

This PR solves this problem by using the offset calculator used for writing the `DateTime` in Bolt to calculate the offset when serialize. So, the previous example is stringified as
`2020-12-15T12:02:03.004000000+01:00[Europe/Stockholm]`.

## Development notes

The datetime helper functions defined in `bolt-connection` package, more specific on `bolt-protocol-v5x0.utc.transformer.js`, were move to `core` and now they are part of `temporal-utils.ts`. So, they can be shared across the driver.

<!--
    Thanks for making the effort to create a Pull Request!
    Please read the comment in its entirety fist.
    If you haven't already, please sign our Contributor License Agreement at
    https://neo4j.com/developer/cla/
    Commits from accounts that have not signed the CLA will fail the CI and
    will not be reviewed. If you are a first-time contributor and have just
    signed the CLA, please include a note about this in the PR comment as some
    manual steps from our side are required.
-->

<!--
    Title:
    PRs targeting the current default branch (nightly driver) don't follow a
    fixed naming scheme.
    If your PR is a backport, please link the original PR in the comments.
-->

<!--
    Description:
    Please include a summary of the changes in this PR and their purpose.
    Link any related issues or PRs.
-->
