### PR TITLE
Removal of duplicate error listener on socket

### DIFF
--- a/packages/bolt-connection/src/channel/node/node-channel.js
+++ b/packages/bolt-connection/src/channel/node/node-channel.js
@@ -268,8 +268,6 @@ export default class NodeChannel {
             self.onmessage(new ChannelBuffer(buffer))
           }
         })
-
-        self._conn.on('error', self._handleConnectionError)
         self._conn.on('end', self._handleConnectionTerminated)
 
         // Drain all pending messages

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
@@ -268,8 +268,6 @@ export default class NodeChannel {
             self.onmessage(new ChannelBuffer(buffer))
           }
         })
-
-        self._conn.on('error', self._handleConnectionError)
         self._conn.on('end', self._handleConnectionTerminated)
 
         // Drain all pending messages


### PR DESCRIPTION
The socket adds a listener for 'error' events twice, this results in the same error messages being handled twice, causing confusing logs and potentially unwanted behaviors.

This PR removes one of the listeners, resulting in just one listener on the socket.
