### PR TITLE
Close channels on destroying errors

### DIFF
--- a/packages/bolt-connection/src/channel/node/node-channel.js
+++ b/packages/bolt-connection/src/channel/node/node-channel.js
@@ -290,6 +290,9 @@ export default class NodeChannel {
       'and that you have compatible encryption settings both on Neo4j server and driver. ' +
       'Note that the default encryption setting has changed in Neo4j 4.0.'
     if (err.message) msg += ' Caused by: ' + err.message
+    if (this._conn.destroyed) {
+      this._open = false
+    }
     this._error = newError(msg, this._connectionErrorCode)
     if (this.onerror) {
       this.onerror(this._error)

--- a/packages/bolt-connection/test/channel/node/node-channel.test.js
+++ b/packages/bolt-connection/test/channel/node/node-channel.test.js
@@ -222,6 +222,32 @@ describe('NodeChannel', () => {
       })
     })
   })
+
+  describe('._HandleConnectionError()', () => {
+    it('should set open false if connection error on destroyed socket', () => {
+      const address = ServerAddress.fromUrl('bolt://localhost:9999')
+      const channelConfig = new ChannelConfig(address, {}, SERVICE_UNAVAILABLE)
+      const channel = new NodeChannel(channelConfig)
+
+      channel._handleConnectionError(newError('mock error',
+        SERVICE_UNAVAILABLE))
+
+      return expect(channel._open).toBe(true)
+    })
+
+    it('should not set open false if connection error on not destroyed socket', () => {
+      const address = ServerAddress.fromUrl('bolt://localhost:9999')
+      const channelConfig = new ChannelConfig(address, {}, SERVICE_UNAVAILABLE)
+      const channel = new NodeChannel(channelConfig)
+
+      channel._conn.destroyed = true
+
+      channel._handleConnectionError(newError('mock error',
+        SERVICE_UNAVAILABLE))
+
+      return expect(channel._open).toBe(false)
+    })
+  })
 })
 
 function createMockedChannel (connected, config = { connectionTimeout: 30000 }) {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/node/node-channel.js
@@ -290,6 +290,9 @@ export default class NodeChannel {
       'and that you have compatible encryption settings both on Neo4j server and driver. ' +
       'Note that the default encryption setting has changed in Neo4j 4.0.'
     if (err.message) msg += ' Caused by: ' + err.message
+    if (this._conn.destroyed) {
+      this._open = false
+    }
     this._error = newError(msg, this._connectionErrorCode)
     if (this.onerror) {
       this.onerror(this._error)


### PR DESCRIPTION
Set channels to close when connections are destroyed by errors. This fixes an issue where sessions would not retry if they were closed by a connection error rather than a connection termination.

includes unit tests for both destroying and non-destroying errors, ensuring that channels are closed and kept open respectively.
