### PR TITLE
Throw error from validation failure

### DIFF
--- a/packages/core/src/internal/pool/pool.ts
+++ b/packages/core/src/internal/pool/pool.ts
@@ -262,10 +262,10 @@ class Pool<R extends unknown = unknown> {
         try {
           valid = await this._validateOnAcquire(acquisitionContext, resource)
         } catch (e) {
-          if (this._log.isErrorEnabled()) {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            this._log.error(`Failure on validate ${resource}. This is a bug, please report it. Caused by: ${e.message}`)
-          }
+          resourceReleased(key, this._activeResourceCounts)
+          pool.removeInUse(resource)
+          await this._destroy(resource)
+          throw e
         }
 
         if (valid) {

--- a/packages/neo4j-driver-deno/lib/core/internal/pool/pool.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/pool/pool.ts
@@ -262,10 +262,10 @@ class Pool<R extends unknown = unknown> {
         try {
           valid = await this._validateOnAcquire(acquisitionContext, resource)
         } catch (e) {
-          if (this._log.isErrorEnabled()) {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            this._log.error(`Failure on validate ${resource}. This is a bug, please report it. Caused by: ${e.message}`)
-          }
+          resourceReleased(key, this._activeResourceCounts)
+          pool.removeInUse(resource)
+          await this._destroy(resource)
+          throw e
         }
 
         if (valid) {


### PR DESCRIPTION
Changes the connection pool behavior on errors during validation, these would be unintended behavior and as such the driver should throw an error if it occurs, rather than simply logging as was the case in the 5.24.1 patch release fix.

Also updates the test to control for this behavior.