### PR TITLE
TestKit: add NumberIsNumber feature flag

### DIFF
--- a/packages/testkit-backend/src/feature/common.js
+++ b/packages/testkit-backend/src/feature/common.js
@@ -44,7 +44,8 @@ const features = [
   'Optimization:ImplicitDefaultArguments',
   'Optimization:MinimalBookmarksSet',
   'Optimization:MinimalResets',
-  'Optimization:AuthPipelining'
+  'Optimization:AuthPipelining',
+  'Detail:NumberIsNumber'
 ]
 
 export default features

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "5.0"
+    "ref": "number-type-indifference-as-feature-flag"
   }
 }

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "number-type-indifference-as-feature-flag"
+    "ref": "5.0"
   }
 }


### PR DESCRIPTION
This implementation detail flag signals that the driver is not (fully) capable of differentiating integer and floating point types.

See also:
 * https://github.com/neo4j-drivers/testkit/pull/632