### PR TITLE
make isUnboundRelationship private

### DIFF
--- a/packages/core/src/graph-types.ts
+++ b/packages/core/src/graph-types.ts
@@ -349,6 +349,7 @@ Object.defineProperty(
  * Test if given object is an instance of {@link UnboundRelationship} class.
  * @param {Object} obj the object to test.
  * @return {boolean} `true` if given object is a {@link UnboundRelationship}, `false` otherwise.
+ * @access private
  */
 function isUnboundRelationship<
     T extends NumberOrInteger = Integer,

--- a/packages/neo4j-driver-deno/lib/core/graph-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/graph-types.ts
@@ -349,6 +349,7 @@ Object.defineProperty(
  * Test if given object is an instance of {@link UnboundRelationship} class.
  * @param {Object} obj the object to test.
  * @return {boolean} `true` if given object is a {@link UnboundRelationship}, `false` otherwise.
+ * @access private
  */
 function isUnboundRelationship<
     T extends NumberOrInteger = Integer,


### PR DESCRIPTION
UnboundRelationship is a class that is used internally in the driver, and we do not need to document functions related to it to the users.
