### PR TITLE
Stabilize mTLS feature

### DIFF
--- a/packages/core/src/client-certificate.ts
+++ b/packages/core/src/client-certificate.ts
@@ -39,8 +39,7 @@ type KeyFile = string | { path: string, password?: string }
  *
  * @interface
  * @see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 export default class ClientCertificate {
   public readonly certfile: string | string[]
@@ -87,8 +86,7 @@ export default class ClientCertificate {
  * Should fetching the certificate be particularly slow, it might be necessary to increase the timeout.
  *
  * @interface
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 export class ClientCertificateProvider {
   /**
@@ -116,8 +114,7 @@ export class ClientCertificateProvider {
 /**
  * Interface for  {@link ClientCertificateProvider} which provides update certificate function.
  * @interface
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 export class RotatingClientCertificateProvider extends ClientCertificateProvider {
   /**
@@ -136,8 +133,7 @@ export class RotatingClientCertificateProvider extends ClientCertificateProvider
 /**
  * Defines the object which holds the common {@link ClientCertificateProviders} used in the Driver
  *
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 class ClientCertificateProviders {
   /**
@@ -161,8 +157,7 @@ class ClientCertificateProviders {
 /**
  * Holds the common {@link ClientCertificateProviders} used in the Driver.
  *
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 const clientCertificateProviders: ClientCertificateProviders = new ClientCertificateProviders()
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -350,8 +350,7 @@ export class Config {
      * where the {@link ClientCertificate} might change over time.
      *
      * @type {ClientCertificate|ClientCertificateProvider|undefined}
-     * @experimental Exposed as preview feature.
-     * @since 5.19
+     * @since 5.27
      */
     this.clientCertificate = undefined
   }

--- a/packages/neo4j-driver-deno/lib/core/client-certificate.ts
+++ b/packages/neo4j-driver-deno/lib/core/client-certificate.ts
@@ -39,8 +39,7 @@ type KeyFile = string | { path: string, password?: string }
  *
  * @interface
  * @see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 export default class ClientCertificate {
   public readonly certfile: string | string[]
@@ -87,8 +86,7 @@ export default class ClientCertificate {
  * Should fetching the certificate be particularly slow, it might be necessary to increase the timeout.
  *
  * @interface
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 export class ClientCertificateProvider {
   /**
@@ -116,8 +114,7 @@ export class ClientCertificateProvider {
 /**
  * Interface for  {@link ClientCertificateProvider} which provides update certificate function.
  * @interface
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 export class RotatingClientCertificateProvider extends ClientCertificateProvider {
   /**
@@ -136,8 +133,7 @@ export class RotatingClientCertificateProvider extends ClientCertificateProvider
 /**
  * Defines the object which holds the common {@link ClientCertificateProviders} used in the Driver
  *
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 class ClientCertificateProviders {
   /**
@@ -161,8 +157,7 @@ class ClientCertificateProviders {
 /**
  * Holds the common {@link ClientCertificateProviders} used in the Driver.
  *
- * @experimental Exposed as preview feature.
- * @since 5.19
+ * @since 5.27
  */
 const clientCertificateProviders: ClientCertificateProviders = new ClientCertificateProviders()
 

--- a/packages/neo4j-driver-deno/lib/core/types.ts
+++ b/packages/neo4j-driver-deno/lib/core/types.ts
@@ -350,8 +350,7 @@ export class Config {
      * where the {@link ClientCertificate} might change over time.
      *
      * @type {ClientCertificate|ClientCertificateProvider|undefined}
-     * @experimental Exposed as preview feature.
-     * @since 5.19
+     * @since 5.27
      */
     this.clientCertificate = undefined
   }


### PR DESCRIPTION
The mTLS feature has been marked as preview since 5.19, and the decision has been made to officially stabilize the feature