### PR TITLE
Better error handling for circular references in custom auth tokens

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+import { newError } from './error'
+import { stringify } from './json'
+
 /**
  * @property {function(username: string, password: string, realm: ?string)} basic the function to create a
  * basic authentication token.
@@ -74,6 +77,11 @@ const auth = {
       output.realm = realm
     }
     if (isNotEmpty(parameters)) {
+      try {
+        stringify(parameters)
+      } catch (e) {
+        throw newError('Circular references in custom auth token parameters', undefined, e)
+      }
       output.parameters = parameters
     }
     return output

--- a/packages/core/test/auth.test.ts
+++ b/packages/core/test/auth.test.ts
@@ -17,6 +17,12 @@
 import auth from '../src/auth'
 
 describe('auth', () => {
+  test('.custom() should crash with circular references in parameters', () => {
+    const params = { a: '', b: {} }
+    params.b = params
+    expect(() => auth.custom('test', 'pass', 'realm', 'scheme', params)).toThrow('Circular references in custom auth token parameters')
+  })
+
   test('.bearer()', () => {
     expect(auth.bearer('==Qyahiadakkda')).toEqual({ scheme: 'bearer', credentials: '==Qyahiadakkda' })
   })

--- a/packages/neo4j-driver-deno/lib/core/auth.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth.ts
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+import { newError } from './error.ts'
+import { stringify } from './json.ts'
+
 /**
  * @property {function(username: string, password: string, realm: ?string)} basic the function to create a
  * basic authentication token.
@@ -74,6 +77,11 @@ const auth = {
       output.realm = realm
     }
     if (isNotEmpty(parameters)) {
+      try{
+        stringify(parameters)
+      } catch (e) {
+        throw newError("Circular references in custom auth token parameters", undefined, e)
+      }
       output.parameters = parameters
     }
     return output

--- a/packages/neo4j-driver-deno/lib/core/auth.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth.ts
@@ -77,10 +77,10 @@ const auth = {
       output.realm = realm
     }
     if (isNotEmpty(parameters)) {
-      try{
+      try {
         stringify(parameters)
       } catch (e) {
-        throw newError("Circular references in custom auth token parameters", undefined, e)
+        throw newError('Circular references in custom auth token parameters', undefined, e)
       }
       output.parameters = parameters
     }


### PR DESCRIPTION
It is quite easy for a user to provide an object with a circular reference in the parameters of a custom auth token, despite this being impossible to send over Bolt. The current handling for this error is not very clear, this PR ensures an understandable error is thrown