### PR TITLE
Disable missbehaving esdocs plugin

### DIFF
--- a/packages/core/esdoc.json
+++ b/packages/core/esdoc.json
@@ -40,6 +40,10 @@
           "repository": "https://github.com/neo4j/neo4j-javascript-driver"
         }
       }
+    },
+    {
+      "name": "esdoc-type-inference-plugin", 
+      "option": {"enable": false}
     }
   ]
 }

--- a/packages/neo4j-driver-lite/esdoc.json
+++ b/packages/neo4j-driver-lite/esdoc.json
@@ -47,6 +47,10 @@
         "enabled": true,
         "path": "../core/docs"
       }
+    },
+    {
+      "name": "esdoc-type-inference-plugin", 
+      "option": {"enable": false}
     }
   ]
 }

--- a/packages/neo4j-driver/esdoc.json
+++ b/packages/neo4j-driver/esdoc.json
@@ -47,6 +47,10 @@
         "enabled": true,
         "path": "../core/docs"
       }
+    },
+    {
+      "name": "esdoc-type-inference-plugin", 
+      "option": {"enable": false}
     }
   ]
 }


### PR DESCRIPTION
esdoc-type-inference-plugin is a proof of concept plugin causing an error when building docs of the new version. disabling it solves the issue