### PR TITLE
Fix handshake manifest parsing of future bolt versions

### DIFF
--- a/packages/bolt-connection/src/bolt/handshake.js
+++ b/packages/bolt-connection/src/bolt/handshake.js
@@ -19,7 +19,7 @@ import { alloc } from '../channel'
 import { newError } from 'neo4j-driver-core'
 
 const BOLT_MAGIC_PREAMBLE = 0x6060b017
-const AVAILABLE_BOLT_PROTOCOLS = [5.8, 5.7, 5.6, 5.4, 5.3, 5.2, 5.1, 5.0, 4.4, 4.3, 4.2, 3.0] // bolt protocols the client will accept, ordered by preference
+const AVAILABLE_BOLT_PROTOCOLS = ['5.8', '5.7', '5.6', '5.4', '5.3', '5.2', '5.1', '5.0', '4.4', '4.3', '4.2', '3.0'] // bolt protocols the client will accept, ordered by preference
 const DESIRED_CAPABILITES = 0
 
 function version (major, minor) {
@@ -98,7 +98,7 @@ function handshakeNegotiationV2 (channel, buffer, log) {
   })
   for (let i = 0; i < versions.length; i++) {
     const version = versions[i]
-    if (AVAILABLE_BOLT_PROTOCOLS.includes(Number(version.major + '.' + version.minor))) {
+    if (AVAILABLE_BOLT_PROTOCOLS.includes(version.major + '.' + version.minor)) {
       major = version.major
       minor = version.minor
       break

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/handshake.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/handshake.js
@@ -19,7 +19,7 @@ import { alloc } from '../channel/index.js'
 import { newError } from '../../core/index.ts'
 
 const BOLT_MAGIC_PREAMBLE = 0x6060b017
-const AVAILABLE_BOLT_PROTOCOLS = [5.8, 5.7, 5.6, 5.4, 5.3, 5.2, 5.1, 5.0, 4.4, 4.3, 4.2, 3.0] // bolt protocols the client will accept, ordered by preference
+const AVAILABLE_BOLT_PROTOCOLS = ['5.8', '5.7', '5.6', '5.4', '5.3', '5.2', '5.1', '5.0', '4.4', '4.3', '4.2', '3.0'] // bolt protocols the client will accept, ordered by preference
 const DESIRED_CAPABILITES = 0
 
 function version (major, minor) {
@@ -98,7 +98,7 @@ function handshakeNegotiationV2 (channel, buffer, log) {
   })
   for (let i = 0; i < versions.length; i++) {
     const version = versions[i]
-    if (AVAILABLE_BOLT_PROTOCOLS.includes(Number(version.major + '.' + version.minor))) {
+    if (AVAILABLE_BOLT_PROTOCOLS.includes(version.major + '.' + version.minor)) {
       major = version.major
       minor = version.minor
       break


### PR DESCRIPTION
When checking the whitelist of available bolt protocols, the versions are parsed as floats, which leads to the future version 5.10 being marked as "available" since it is seen as the same as 5.1.

The fix is simple and makes the code simpler, treating them as strings in this step instead.