### PR TITLE
Correct list of possible timeout error codes.

### DIFF
--- a/packages/neo4j-driver/test/bolt-v3.test.js
+++ b/packages/neo4j-driver/test/bolt-v3.test.js
@@ -92,7 +92,8 @@ describe('#integration Bolt V3 API', () => {
       if (
         e.code !== 'Neo.ClientError.Transaction.TransactionTimedOut' &&
         e.code !== 'Neo.TransientError.Transaction.LockClientStopped' &&
-        e.code !== 'Neo.ClientError.Transaction.LockClientStopped'
+        e.code !== 'Neo.ClientError.Transaction.LockClientStopped' &&
+        e.code !== 'Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration'
       ) {
         fail('Expected transaction timeout error but got: ' + e.code)
       }


### PR DESCRIPTION
The error code ```Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration``` was neglected when listing the possible transaction timeout error messages in one test, this causes some flakiness in integration tests as it is sometimes but not always the resulting error. It was previously correctly added to one test, but not another.