### PR TITLE
Extent timeout on lite driver tests

### DIFF
--- a/packages/neo4j-driver-lite/test/integration/driver.test.ts
+++ b/packages/neo4j-driver-lite/test/integration/driver.test.ts
@@ -44,7 +44,7 @@ describe('neo4j-driver-lite', () => {
     expect(result.records.length).toEqual(1)
     expect(result.records[0].length).toEqual(1)
     result.records[0].forEach(val => expect(val).toEqual(int(2)))
-  })
+  }, 10000)
 
   test('hasReachableServer success', async () => {
     await expect(neo4j.hasReachableServer(`${Config.scheme}://${Config.hostname}:${Config.boltPort}`)).resolves.toBe(true)


### PR DESCRIPTION
A test on the lite driver is intermittently timing out with the default 5 second timeout, this PR doubles the timeout.