### PR TITLE
TestKit: skip one of the newly added summary tests

### DIFF
--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -56,6 +56,7 @@ const skippedTests = [
   skip(
     'ResultSummary.notifications defaults to empty array instead of return null/undefined',
     ifEquals('stub.summary.test_summary.TestSummaryNotifications4x4.test_no_notifications'),
+    ifEquals('stub.summary.test_summary.TestSummaryNotifications4x4Discard.test_no_notifications'),
     ifEquals('neo4j.test_summary.TestSummary.test_no_notification_info')
   ),
   skip(


### PR DESCRIPTION
Skips one of the newly introduced tests from
 * https://github.com/neo4j-drivers/testkit/pull/653