### PR TITLE
Handle getting summary in Testkit Backend when a Record Iterator exists

### DIFF
--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -241,6 +241,15 @@ export function ResultConsume (_, context, data, wire) {
   const { resultId } = data
   const result = context.getResult(resultId)
 
+  if (('recordIt' in result)) {
+    return result.recordIt.return().then(summary => {
+      if (summary.value) {
+        summary = summary.value
+      }
+      console.error(summary)
+      wire.writeResponse(responses.Summary({ summary }, { binder: context.binder }))
+    }).catch(e => wire.writeError(e))
+  }
   return result.summary().then(summary => {
     wire.writeResponse(responses.Summary({ summary }, { binder: context.binder }))
   }).catch(e => wire.writeError(e))

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -246,7 +246,6 @@ export function ResultConsume (_, context, data, wire) {
       if (summary.value) {
         summary = summary.value
       }
-      console.error(summary)
       wire.writeResponse(responses.Summary({ summary }, { binder: context.binder }))
     }).catch(e => wire.writeError(e))
   }

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -241,15 +241,10 @@ export function ResultConsume (_, context, data, wire) {
   const { resultId } = data
   const result = context.getResult(resultId)
 
-  if (('recordIt' in result)) {
-    return result.recordIt.return().then(summary => {
-      if (summary.value) {
-        summary = summary.value
-      }
-      wire.writeResponse(responses.Summary({ summary }, { binder: context.binder }))
-    }).catch(e => wire.writeError(e))
-  }
-  return result.summary().then(summary => {
+  let summaryPromise = 'recordIt' in result
+    ? (async () => {return (await result.recordIt.return()).value})()
+    : result.summary()
+  return summaryPromise.then(summary => {
     wire.writeResponse(responses.Summary({ summary }, { binder: context.binder }))
   }).catch(e => wire.writeError(e))
 }

--- a/packages/testkit-backend/src/skipped-tests/common.js
+++ b/packages/testkit-backend/src/skipped-tests/common.js
@@ -56,6 +56,7 @@ const skippedTests = [
   skip(
     'ResultSummary.notifications defaults to empty array instead of return null/undefined',
     ifEquals('stub.summary.test_summary.TestSummaryNotifications4x4.test_no_notifications'),
+    ifEquals('stub.summary.test_summary.TestSummaryNotifications4x4Discard.test_no_notifications'),
     ifEquals('neo4j.test_summary.TestSummary.test_no_notification_info')
   ),
   skip(


### PR DESCRIPTION
Handling some errors which were found when adding tests in https://github.com/neo4j-drivers/testkit/pull/653

The testkit backend would at times mix incompatible bits of the API, this is an issue which no tests have run into before.