### PR TITLE
configure timeout example test has too short timeout

### DIFF
--- a/packages/neo4j-driver/test/examples.test.js
+++ b/packages/neo4j-driver/test/examples.test.js
@@ -853,7 +853,7 @@ describe('#integration examples', () => {
     try {
       const result = await session.executeWrite(
         tx => addPerson(tx, personName),
-        { timeout: 10 }
+        { timeout: 100 }
       )
 
       const singleRecord = result.records[0]


### PR DESCRIPTION
Configure Timeout example sets the transaction timeout to 10ms, this causes flakiness because it's too low of a value.