### PR TITLE
Skip new summary tests on RX session

### DIFF
--- a/packages/testkit-backend/src/skipped-tests/rx.js
+++ b/packages/testkit-backend/src/skipped-tests/rx.js
@@ -1,9 +1,13 @@
-import { skip, ifEquals } from './skip.js'
+import { skip, ifEquals, ifStartsWith } from './skip.js'
 
 const skippedTests = [
   skip(
     'Throws after run insted of the first next because of the backend implementation',
     ifEquals('stub.disconnects.test_disconnects.TestDisconnects.test_disconnect_on_tx_begin')
+  ),
+  skip(
+    'Reactive driver does not send DISCARD on consume if records stream has been subscribed to',
+    ifStartsWith('stub.summary.test_summary')
   )
 ]
 

--- a/packages/testkit-backend/src/skipped-tests/rx.js
+++ b/packages/testkit-backend/src/skipped-tests/rx.js
@@ -7,7 +7,13 @@ const skippedTests = [
   ),
   skip(
     'Reactive driver does not send DISCARD on consume if records stream has been subscribed to',
-    ifStartsWith('stub.summary.test_summary')
+    ifStartsWith('stub.summary.test_summary.TestSummaryPlanDiscard'),
+    ifStartsWith('stub.summary.test_summary.TestSummaryCountersDiscard'),
+    ifStartsWith('stub.summary.test_summary.TestSummaryBasicInfoDiscard'),
+    ifStartsWith('stub.summary.test_summary.TestSummaryGqlStatusObjects4x4Discard'),
+    ifStartsWith('stub.summary.test_summary.TestSummaryGqlStatusObjects5x6Discard'),
+    ifStartsWith('stub.summary.test_summary.TestSummaryNotifications4x4Discard'),
+    ifStartsWith('stub.summary.test_summary.TestSummaryNotifications5x6Discard')
   )
 ]
 

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "5.0"
+    "ref": "summary-test-discard-and-pull"
   }
 }

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "summary-test-discard-and-pull"
+    "ref": "5.0"
   }
 }


### PR DESCRIPTION
The RX session handles sending DISCARDS slightly differently than other drivers, which breaks some new tests being added to testkit. This skips those new tests on the rx driver until a more elegant solution is found