### PR TITLE
Fix typo in API docs.

### DIFF
--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -240,7 +240,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
   /**
    * Provides a async iterator over the records in the result.
    *
-   * *Should not be combined with {@link Result#subscribe} or ${@link Result#then} functions.*
+   * *Should not be combined with {@link Result#subscribe} or {@link Result#then} functions.*
    *
    * @public
    * @returns {PeekableAsyncIterator<Record<R>, ResultSummary>} The async iterator for the Results

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -240,7 +240,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
   /**
    * Provides a async iterator over the records in the result.
    *
-   * *Should not be combined with {@link Result#subscribe} or ${@link Result#then} functions.*
+   * *Should not be combined with {@link Result#subscribe} or {@link Result#then} functions.*
    *
    * @public
    * @returns {PeekableAsyncIterator<Record<R>, ResultSummary>} The async iterator for the Results


### PR DESCRIPTION
Fixes this nasty, _nasty_ visual bug.

![Screenshot from 2025-03-06 07-28-19](https://github.com/user-attachments/assets/0a210bf8-6f3d-423e-9850-cfcb486a75da)

I've raised this to `5.0` as it is still the default branch. I assume it needs to be cherry-picked forward too.