### PR TITLE
Update firefox install in testkit docker

### DIFF
--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -22,10 +22,23 @@ RUN apt-get update && \
         curl \
         python3 \
         nodejs \
-        firefox \
         nodejs \
+        wget \
         unzip \
     && rm -rf /var/lib/apt/lists/*
+
+RUN install -d -m 0755 /etc/apt/keyrings && \
+    wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg -O- | tee /etc/apt/keyrings/packages.mozilla.org.asc > /dev/null && \
+    gpg -n -q --import --import-options import-show /etc/apt/keyrings/packages.mozilla.org.asc | awk '/pub/{getline; gsub(/^ +| +$/,""); if($0 == "35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3") print "\nThe key fingerprint matches ("$0").\n"; else {exit 1}}' && \
+    echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" | tee -a /etc/apt/sources.list.d/mozilla.list > /dev/null && \
+    echo 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000' | tee /etc/apt/preferences.d/mozilla && \
+    apt-get update && apt-get install -y \
+        libpci-dev \
+        libcanberra-gtk3-module \
+        libgles2-mesa-dev \
+        dbus-x11 \
+        firefox && \
+    apt-get clean
 
 RUN /bin/bash -c "hash -d npm"
 


### PR DESCRIPTION
Newer version of ubuntu install a snap-dependent version of firefox via apt-get. This gets a Docker-compatible version from firefox.