### PR TITLE
[5.0] Fix logging of driver errors containing bigints in testkit backend

### DIFF
--- a/packages/testkit-backend/src/request-handlers-rx.js
+++ b/packages/testkit-backend/src/request-handlers-rx.js
@@ -1,5 +1,6 @@
 import * as responses from './responses.js'
 import { from } from 'rxjs'
+import stringify from './stringify.js'
 
 // Handlers which didn't change depending
 export {
@@ -108,7 +109,7 @@ export function SessionRun (_, context, data, wire) {
   try {
     rxResult = session.run(cypher, params, { metadata, timeout })
   } catch (e) {
-    console.log('got some err: ' + JSON.stringify(e))
+    console.log('got some err: ' + stringify(e))
     wire.writeError(e)
     return
   }
@@ -150,11 +151,11 @@ export function SessionBeginTransaction (_, context, data, wire) {
         const id = context.addTx(tx, sessionId)
         wire.writeResponse(responses.Transaction({ id }))
       }).catch(e => {
-        console.log('got some err: ' + JSON.stringify(e))
+        console.log('got some err: ' + stringify(e))
         wire.writeError(e)
       })
   } catch (e) {
-    console.log('got some err: ' + JSON.stringify(e))
+    console.log('got some err: ' + stringify(e))
     wire.writeError(e)
   }
 }
@@ -189,7 +190,7 @@ export function TransactionRollback (_, context, data, wire) {
     .toPromise()
     .then(() => wire.writeResponse(responses.Transaction({ id })))
     .catch(e => {
-      console.log('got some err: ' + JSON.stringify(e))
+      console.log('got some err: ' + stringify(e))
       wire.writeError(e)
     })
 }
@@ -201,7 +202,7 @@ export function TransactionCommit (_, context, data, wire) {
     .toPromise()
     .then(() => wire.writeResponse(responses.Transaction({ id })))
     .catch(e => {
-      console.log('got some err: ' + JSON.stringify(e))
+      console.log('got some err: ' + stringify(e))
       wire.writeError(e)
     })
 }

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -191,7 +191,7 @@ export function SessionRun (_, context, data, wire) {
   try {
     result = session.run(cypher, params, { metadata, timeout })
   } catch (e) {
-    console.log('got some err: ' + JSON.stringify(e))
+    console.log('got some err: ' + stringify(e))
     wire.writeError(e)
     return
   }
@@ -214,7 +214,7 @@ export function ResultNext (_, context, data, wire) {
       wire.writeResponse(responses.Record({ record: value }, { binder: context.binder }))
     }
   }).catch(e => {
-    console.log('got some err: ' + JSON.stringify(e))
+    console.log('got some err: ' + stringify(e))
     wire.writeError(e)
   })
 }
@@ -232,7 +232,7 @@ export function ResultPeek (_, context, data, wire) {
       wire.writeResponse(responses.Record({ record: value }, { binder: context.binder }))
     }
   }).catch(e => {
-    console.log('got some err: ' + JSON.stringify(e))
+    console.log('got some err: ' + stringify(e))
     wire.writeError(e)
   })
 }
@@ -241,8 +241,8 @@ export function ResultConsume (_, context, data, wire) {
   const { resultId } = data
   const result = context.getResult(resultId)
 
-  let summaryPromise = 'recordIt' in result
-    ? (async () => {return (await result.recordIt.return()).value})()
+  const summaryPromise = 'recordIt' in result
+    ? (async () => { return (await result.recordIt.return()).value })()
     : result.summary()
   return summaryPromise.then(summary => {
     wire.writeResponse(responses.Summary({ summary }, { binder: context.binder }))
@@ -317,11 +317,11 @@ export function SessionBeginTransaction (_, context, data, wire) {
         const id = context.addTx(tx, sessionId)
         wire.writeResponse(responses.Transaction({ id }))
       }).catch(e => {
-        console.log('got some err: ' + JSON.stringify(e))
+        console.log('got some err: ' + stringify(e))
         wire.writeError(e)
       })
   } catch (e) {
-    console.log('got some err: ' + JSON.stringify(e))
+    console.log('got some err: ' + stringify(e))
     wire.writeError(e)
   }
 }
@@ -332,7 +332,7 @@ export function TransactionCommit (_, context, data, wire) {
   return tx.commit()
     .then(() => wire.writeResponse(responses.Transaction({ id })))
     .catch(e => {
-      console.log('got some err: ' + JSON.stringify(e))
+      console.log('got some err: ' + stringify(e))
       wire.writeError(e)
     })
 }
@@ -801,4 +801,13 @@ export function FakeTimeUninstall (_, context, _data, wire) {
   context.clock.restore()
   delete context.clock
   wire.writeResponse(responses.FakeTimeAck())
+}
+
+export function stringify (val) {
+  return stringify(val, (_, value) => {
+    if (typeof value === 'bigint') {
+      return `${value}n`
+    }
+    return value
+  })
 }

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -1,5 +1,6 @@
 import * as responses from './responses.js'
 import configurableConsole from './console.configurable.js'
+import stringify from './stringify.js'
 
 export function throwFrontendError () {
   throw new Error('TestKit FrontendError')
@@ -801,13 +802,4 @@ export function FakeTimeUninstall (_, context, _data, wire) {
   context.clock.restore()
   delete context.clock
   wire.writeResponse(responses.FakeTimeAck())
-}
-
-export function stringify (val) {
-  return stringify(val, (_, value) => {
-    if (typeof value === 'bigint') {
-      return `${value}n`
-    }
-    return value
-  })
 }


### PR DESCRIPTION
The JavaScript driver testkit backend handles all ints as bigints, when these end up in some errors (as in syntax errors on 2025.x servers) they cause the backend to crash. This PR solves the issue by using a replacer function.