### PR TITLE
[4.4] Fix logging of driver errors containing bigints in testkit backend

### DIFF
--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -3,7 +3,7 @@ import ResultObserver from './result-observer.js'
 import { cypherToNative, nativeToCypher } from './cypher-native-binders.js'
 import { nativeToTestkitSummary } from './summary-binder.js'
 import tls from 'tls'
-import { stringify } from './stringify.js'
+import stringify from './stringify.js'
 
 const SUPPORTED_TLS = (() => {
   if (tls.DEFAULT_MAX_VERSION) {

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -3,6 +3,7 @@ import ResultObserver from './result-observer.js'
 import { cypherToNative, nativeToCypher } from './cypher-native-binders.js'
 import { nativeToTestkitSummary } from './summary-binder.js'
 import tls from 'tls'
+import { stringify } from './stringify.js'
 
 const SUPPORTED_TLS = (() => {
   if (tls.DEFAULT_MAX_VERSION) {
@@ -180,7 +181,7 @@ export function ResultNext (context, data, wire) {
       }
     })
     .catch(e => {
-      console.log('got some err: ' + JSON.stringify(e))
+      console.log('got some err: ' + stringify(e))
       wire.writeError(e)
     })
 }
@@ -272,7 +273,7 @@ export function TransactionCommit (context, data, wire) {
   tx.commit()
     .then(() => wire.writeResponse('Transaction', { id }))
     .catch(e => {
-      console.log('got some err: ' + JSON.stringify(e))
+      console.log('got some err: ' + stringify(e))
       wire.writeError(e)
     })
 }


### PR DESCRIPTION
The JavaScript driver testkit backend handles all ints as bigints, when these end up in some errors (as in syntax errors on 2025.x servers) they cause the backend to crash. This PR solves the issue by using a replacer function.