### PR TITLE
Fix checks for deno v2

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -80,7 +80,8 @@ const auth = {
       try {
         stringify(parameters)
       } catch (e) {
-        // @ts-expect-error
+        // eslint-disable-next-line
+        // @ts-ignore
         throw newError('Circular references in custom auth token parameters', undefined, e)
       }
       output.parameters = parameters

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -80,6 +80,7 @@ const auth = {
       try {
         stringify(parameters)
       } catch (e) {
+        // @ts-expect-error
         throw newError('Circular references in custom auth token parameters', undefined, e)
       }
       output.parameters = parameters

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -617,6 +617,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
           buffer.unshift(element)
           return element
         } catch (error) {
+          // @ts-expect-error
           buffer.unshift(error)
           throw error
         } finally {

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -617,7 +617,8 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
           buffer.unshift(element)
           return element
         } catch (error) {
-          // @ts-expect-error
+          // eslint-disable-next-line
+          // @ts-ignore
           buffer.unshift(error)
           throw error
         } finally {

--- a/packages/neo4j-driver-deno/deno.json
+++ b/packages/neo4j-driver-deno/deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "noImplicitOverride": false
+  }
+}

--- a/packages/neo4j-driver-deno/lib/core/auth.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth.ts
@@ -80,6 +80,7 @@ const auth = {
       try {
         stringify(parameters)
       } catch (e) {
+        // eslint-disable-next-line
         // @ts-ignore
         throw newError('Circular references in custom auth token parameters', undefined, e)
       }

--- a/packages/neo4j-driver-deno/lib/core/auth.ts
+++ b/packages/neo4j-driver-deno/lib/core/auth.ts
@@ -80,6 +80,7 @@ const auth = {
       try {
         stringify(parameters)
       } catch (e) {
+        // @ts-ignore
         throw newError('Circular references in custom auth token parameters', undefined, e)
       }
       output.parameters = parameters

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -617,6 +617,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
           buffer.unshift(element)
           return element
         } catch (error) {
+          // eslint-disable-next-line
           // @ts-ignore
           buffer.unshift(error)
           throw error

--- a/packages/neo4j-driver-deno/lib/core/result.ts
+++ b/packages/neo4j-driver-deno/lib/core/result.ts
@@ -617,6 +617,7 @@ class Result<R extends RecordShape = RecordShape> implements Promise<QueryResult
           buffer.unshift(element)
           return element
         } catch (error) {
+          // @ts-ignore
           buffer.unshift(error)
           throw error
         } finally {


### PR DESCRIPTION
Bumping the build dockerfile to use docker v2 enabled a few checks by default, this ignores two lines where violation is unavoidable, and disables another check that would involve a larger rework that is not a priority at this time.