### PR TITLE
Require Node 18 for drivers 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Resources to get you started:
 
 ### In Node.js application
 
+The node version of the driver requires node 18 or later.
+
 Stable channel:
 
 ```shell

--- a/packages/neo4j-driver-lite/README.md
+++ b/packages/neo4j-driver-lite/README.md
@@ -25,6 +25,8 @@ Resources to get you started:
 
 ### In Node.js application
 
+The node version of the driver requires node 18 or later.
+
 Stable channel:
 
 ```shell

--- a/packages/neo4j-driver-lite/package.json
+++ b/packages/neo4j-driver-lite/package.json
@@ -34,6 +34,9 @@
     "neo4j",
     "driver"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "author": "Neo4j",
   "license": "Apache-2.0",
   "bugs": {

--- a/packages/neo4j-driver/package.json
+++ b/packages/neo4j-driver/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git://github.com/neo4j/neo4j-javascript-driver.git"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "lint": "eslint --fix --ext .js ./",
     "test": "gulp test",


### PR DESCRIPTION
This will permit the merging of the queryAPI wrapper into the main driver repo without a sudden breaking change in the middle of 6.x