### PR TITLE
Fix acquisition timeout unification

### DIFF
--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -161,7 +161,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         () => new RoutingTable({ database: homeDb })
       )
       if (currentRoutingTable && !currentRoutingTable.isStaleFor(accessMode)) {
-        conn = await this.getConnectionFromRoutingTable(currentRoutingTable, auth, accessMode, databaseSpecificErrorHandler)
+        conn = await this._getConnectionFromRoutingTable(currentRoutingTable, auth, accessMode, databaseSpecificErrorHandler)
         if (this.SSREnabled()) {
           return conn
         }
@@ -181,10 +181,10 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         }
       }
     })
-    return this.getConnectionFromRoutingTable(routingTable, auth, accessMode, databaseSpecificErrorHandler)
+    return this._getConnectionFromRoutingTable(routingTable, auth, accessMode, databaseSpecificErrorHandler)
   }
 
-  async getConnectionFromRoutingTable (routingTable, auth, accessMode, databaseSpecificErrorHandler) {
+  async _getConnectionFromRoutingTable (routingTable, auth, accessMode, databaseSpecificErrorHandler) {
     let name
     let address
     // select a target server based on specified access mode
@@ -290,6 +290,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
   }
 
   async verifyAuthentication ({ database, accessMode, auth }) {
+    this._startTime = new Date().getTime()
     return this._verifyAuthentication({
       auth,
       getAddress: async () => {
@@ -320,6 +321,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
 
   async verifyConnectivityAndGetServerInfo ({ database, accessMode }) {
     const context = { database: database || DEFAULT_DB_NAME }
+    this._startTime = new Date().getTime()
 
     const routingTable = await this._freshRoutingTable({
       accessMode,

--- a/packages/core/src/internal/pool/pool.ts
+++ b/packages/core/src/internal/pool/pool.ts
@@ -16,7 +16,7 @@
  */
 
 import PoolConfig from './pool-config'
-import { newError } from '../../error'
+import { Neo4jError, newError } from '../../error'
 import { Logger } from '../logger'
 import { ServerAddress } from '../server-address'
 
@@ -119,6 +119,10 @@ class Pool<R extends unknown = unknown> {
     const allRequests = this._acquireRequests
     const requests = allRequests[key]
     const elapsedTime = (acquisitionContext.startTime != null && acquisitionContext.startTime !== 0) ? new Date().getTime() - acquisitionContext.startTime : 0
+    if (elapsedTime >= this._acquisitionTimeout) {
+      throw this.getAcquisitionTimeoutError(address)
+    }
+
     if (requests == null) {
       allRequests[key] = []
     }
@@ -137,12 +141,8 @@ class Pool<R extends unknown = unknown> {
           // request already resolved/rejected by the release operation; nothing to do
         } else {
           // request is still pending and needs to be failed
-          const activeCount = this.activeResourceCount(address)
-          const idleCount = this.has(address) ? this._pools[key].length : 0
           request.reject(
-            newError(
-              `Connection acquisition timed out in ${this._acquisitionTimeout} ms. Pool status: Active conn count = ${activeCount}, Idle conn count = ${idleCount}.`
-            )
+            this.getAcquisitionTimeoutError(address)
           )
         }
       }, this._acquisitionTimeout - elapsedTime)
@@ -157,6 +157,15 @@ class Pool<R extends unknown = unknown> {
       allRequests[key].push(request)
       this._processPendingAcquireRequests(address)
     })
+  }
+
+  getAcquisitionTimeoutError (address: ServerAddress): Neo4jError {
+    const key = address.asKey()
+    const activeCount = this.activeResourceCount(address)
+    const idleCount = this.has(address) ? this._pools[key].length : 0
+    return newError(
+        `Connection acquisition timed out in ${this._acquisitionTimeout} ms. Pool status: Active conn count = ${activeCount}, Idle conn count = ${idleCount}.`
+    )
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -161,7 +161,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         () => new RoutingTable({ database: homeDb })
       )
       if (currentRoutingTable && !currentRoutingTable.isStaleFor(accessMode)) {
-        conn = await this.getConnectionFromRoutingTable(currentRoutingTable, auth, accessMode, databaseSpecificErrorHandler)
+        conn = await this._getConnectionFromRoutingTable(currentRoutingTable, auth, accessMode, databaseSpecificErrorHandler)
         if (this.SSREnabled()) {
           return conn
         }
@@ -181,10 +181,10 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
         }
       }
     })
-    return this.getConnectionFromRoutingTable(routingTable, auth, accessMode, databaseSpecificErrorHandler)
+    return this._getConnectionFromRoutingTable(routingTable, auth, accessMode, databaseSpecificErrorHandler)
   }
 
-  async getConnectionFromRoutingTable (routingTable, auth, accessMode, databaseSpecificErrorHandler) {
+  async _getConnectionFromRoutingTable (routingTable, auth, accessMode, databaseSpecificErrorHandler) {
     let name
     let address
     // select a target server based on specified access mode
@@ -290,6 +290,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
   }
 
   async verifyAuthentication ({ database, accessMode, auth }) {
+    this._startTime = new Date().getTime()
     return this._verifyAuthentication({
       auth,
       getAddress: async () => {
@@ -320,6 +321,7 @@ export default class RoutingConnectionProvider extends PooledConnectionProvider 
 
   async verifyConnectivityAndGetServerInfo ({ database, accessMode }) {
     const context = { database: database || DEFAULT_DB_NAME }
+    this._startTime = new Date().getTime()
 
     const routingTable = await this._freshRoutingTable({
       accessMode,

--- a/packages/neo4j-driver-deno/lib/core/internal/pool/pool.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/pool/pool.ts
@@ -122,7 +122,7 @@ class Pool<R extends unknown = unknown> {
     if (elapsedTime >= this._acquisitionTimeout) {
       throw this.getAcquisitionTimeoutError(address)
     }
-    
+
     if (requests == null) {
       allRequests[key] = []
     }
@@ -159,13 +159,13 @@ class Pool<R extends unknown = unknown> {
     })
   }
 
-  getAcquisitionTimeoutError(address: ServerAddress): Neo4jError  {
+  getAcquisitionTimeoutError (address: ServerAddress): Neo4jError {
     const key = address.asKey()
     const activeCount = this.activeResourceCount(address)
     const idleCount = this.has(address) ? this._pools[key].length : 0
     return newError(
         `Connection acquisition timed out in ${this._acquisitionTimeout} ms. Pool status: Active conn count = ${activeCount}, Idle conn count = ${idleCount}.`
-      )
+    )
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/internal/pool/pool.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/pool/pool.ts
@@ -16,7 +16,7 @@
  */
 
 import PoolConfig from './pool-config.ts'
-import { newError } from '../../error.ts'
+import { Neo4jError, newError } from '../../error.ts'
 import { Logger } from '../logger.ts'
 import { ServerAddress } from '../server-address.ts'
 
@@ -119,6 +119,10 @@ class Pool<R extends unknown = unknown> {
     const allRequests = this._acquireRequests
     const requests = allRequests[key]
     const elapsedTime = (acquisitionContext.startTime != null && acquisitionContext.startTime !== 0) ? new Date().getTime() - acquisitionContext.startTime : 0
+    if (elapsedTime >= this._acquisitionTimeout) {
+      throw this.getAcquisitionTimeoutError(address)
+    }
+    
     if (requests == null) {
       allRequests[key] = []
     }
@@ -137,12 +141,8 @@ class Pool<R extends unknown = unknown> {
           // request already resolved/rejected by the release operation; nothing to do
         } else {
           // request is still pending and needs to be failed
-          const activeCount = this.activeResourceCount(address)
-          const idleCount = this.has(address) ? this._pools[key].length : 0
           request.reject(
-            newError(
-              `Connection acquisition timed out in ${this._acquisitionTimeout} ms. Pool status: Active conn count = ${activeCount}, Idle conn count = ${idleCount}.`
-            )
+            this.getAcquisitionTimeoutError(address)
           )
         }
       }, this._acquisitionTimeout - elapsedTime)
@@ -157,6 +157,15 @@ class Pool<R extends unknown = unknown> {
       allRequests[key].push(request)
       this._processPendingAcquireRequests(address)
     })
+  }
+
+  getAcquisitionTimeoutError(address: ServerAddress): Neo4jError  {
+    const key = address.asKey()
+    const activeCount = this.activeResourceCount(address)
+    const idleCount = this.has(address) ? this._pools[key].length : 0
+    return newError(
+        `Connection acquisition timed out in ${this._acquisitionTimeout} ms. Pool status: Active conn count = ${activeCount}, Idle conn count = ${idleCount}.`
+      )
   }
 
   /**

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "correct-acquisition-timeout-unification-test"
+    "ref": "6.x"
   }
 }

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "6.x"
+    "ref": "correct-acquisition-timeout-unification-test"
   }
 }


### PR DESCRIPTION
The original solution would still allow minor pieces of work to slip through before a timeout fired.