### PR TITLE
Fix Firefox preferences to let WebSockets have a carefree childhood

### DIFF
--- a/testkit/firefox_profile/prefs.js
+++ b/testkit/firefox_profile/prefs.js
@@ -1,3 +1,5 @@
 /* global user_pref */
 user_pref('network.dnsCacheExpiration', 0);
 user_pref('network.dnsCacheExpirationGracePeriod', 0);
+user_pref('network.websocket.delay-failed-reconnects', false);
+user_pref('network.websocket.max-connections', 10000);


### PR DESCRIPTION
Disable FF's implementation of RFC 6455 (WebSockets) section 7.2.3 (backoff when recovering from abnormal closure):
https://www.rfc-editor.org/rfc/rfc6455.html#section-7.2.3

While this is a good thing in the wild, during testing we want to test the driver and not the browser, so it should get out of the way. Further, the tests often expect/enforce failures and we don't want those tests to pollute the environment for following tests.

While at it, also bump the browser's WS limit so that we hit the driver's max pool size before ever hitting the browser's limit.

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=711793