### PR TITLE
Bump deno to 6.0.0-alpha02 (previous PR did not make alpha01 cutoff)

### DIFF
--- a/packages/neo4j-driver-deno/current.version.ts
+++ b/packages/neo4j-driver-deno/current.version.ts
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export default "6.0.0-alpha01" // Specified using --version when running generate.ts
+export default "6.0.0-alpha02" // Specified using --version when running generate.ts

--- a/packages/neo4j-driver-deno/lib/version.ts
+++ b/packages/neo4j-driver-deno/lib/version.ts
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export default "6.0.0-alpha01" // Specified using --version when running generate.ts
+export default "6.0.0-alpha02" // Specified using --version when running generate.ts


### PR DESCRIPTION
The parenthesis in the PR title is due to the fact that deno bumps are often a quick way to check when work on the next version started.