### PR TITLE
[5.0] FailFastSecurityError check bug

### DIFF
--- a/packages/bolt-connection/src/channel/browser/browser-channel.js
+++ b/packages/bolt-connection/src/channel/browser/browser-channel.js
@@ -151,7 +151,7 @@ export default class WebSocketChannel {
           this._handleConnectionError()
         } else {
           // Some other error occured
-          throw error
+          throw newError('unexpected failure to write.', undefined, error)
         }
       }
     } else {

--- a/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
+++ b/packages/bolt-connection/src/connection-provider/connection-provider-routing.js
@@ -813,7 +813,7 @@ function _isFailFastError (error) {
 }
 
 function _isFailFastSecurityError (error) {
-  return error.code.startsWith('Neo.ClientError.Security.') &&
+  return error.code?.startsWith('Neo.ClientError.Security.') &&
     ![
       AUTHORIZATION_EXPIRED_CODE
     ].includes(error.code)

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/browser/browser-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/browser/browser-channel.js
@@ -151,7 +151,7 @@ export default class WebSocketChannel {
           this._handleConnectionError()
         } else {
           // Some other error occured
-          throw error
+          throw newError('unexpected failure to write.', undefined, error)
         }
       }
     } else {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/connection-provider-routing.js
@@ -813,7 +813,7 @@ function _isFailFastError (error) {
 }
 
 function _isFailFastSecurityError (error) {
-  return error.code.startsWith('Neo.ClientError.Security.') &&
+  return error.code?.startsWith('Neo.ClientError.Security.') &&
     ![
       AUTHORIZATION_EXPIRED_CODE
     ].includes(error.code)


### PR DESCRIPTION
The _isFailFastSecurityError() check checks if the error code starts with `Neo.ClientError.Security.` which causes a crash if a non neo4j error surfaces. This PR fixes that issue.