### PR TITLE
Move channel timeout to after packing the struct

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -499,17 +499,16 @@ export default class BoltProtocol {
    * @param {boolean} flush `true` if flush should happen after the message is written to the buffer.
    */
   write (message, observer, flush) {
+    this._lastMessageSignature = message.signature
+    const messageStruct = new structure.Structure(message.signature, message.fields)
+
+    this.packable(messageStruct)()
     const queued = this.queueObserverIfProtocolIsNotBroken(observer)
 
     if (queued) {
       if (this._log.isDebugEnabled()) {
         this._log.debug(`C: ${message}`)
       }
-
-      this._lastMessageSignature = message.signature
-      const messageStruct = new structure.Structure(message.signature, message.fields)
-
-      this.packable(messageStruct)()
 
       this._chunker.messageBoundary()
       if (flush) {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v1.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v1.js
@@ -499,17 +499,16 @@ export default class BoltProtocol {
    * @param {boolean} flush `true` if flush should happen after the message is written to the buffer.
    */
   write (message, observer, flush) {
+    this._lastMessageSignature = message.signature
+    const messageStruct = new structure.Structure(message.signature, message.fields)
+
+    this.packable(messageStruct)()
     const queued = this.queueObserverIfProtocolIsNotBroken(observer)
 
     if (queued) {
       if (this._log.isDebugEnabled()) {
         this._log.debug(`C: ${message}`)
       }
-
-      this._lastMessageSignature = message.signature
-      const messageStruct = new structure.Structure(message.signature, message.fields)
-
-      this.packable(messageStruct)()
 
       this._chunker.messageBoundary()
       if (flush) {


### PR DESCRIPTION
This prevents channel timeout from triggering if the driver were to get stuck in the packing of a struct.

Also solves an issue regarding the timing of when the errors in packaging get surfaced to the user