### PR TITLE
Fix Integration Vector Tests for Browser Test Environment

### DIFF
--- a/packages/neo4j-driver/package.json
+++ b/packages/neo4j-driver/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --fix --ext .js ./",
     "test": "gulp test",
     "test::unit": "gulp test-nodejs-unit && gulp run-ts-declaration-tests",
-    "test::browser": "jest -c jest.browser.config.ts",
+    "test::browser": "jest -c jest.browser.config.ts --runInBand",
     "test::integration": "gulp test-nodejs-integration",
     "test::stress": "gulp run-stress-tests-without-jasmine",
     "build": "gulp all",

--- a/packages/neo4j-driver/test/vector-type.test.js
+++ b/packages/neo4j-driver/test/vector-type.test.js
@@ -49,24 +49,21 @@ describe('#integration vector type', () => {
   it('write and read vectors', async () => {
     if (protocolVersion.isGreaterOrEqualTo({ major: 6, minor: 0 }) && edition === 'enterprise') {
       const driver = driverGlobal
-
+      const session = driver.session()
       const bufferWriter = Uint8Array.from([1, 1])
-      const write = await driver.executeQuery('CREATE (p:Product) SET p.vector_from_array = $vector_from_array, p.vector_from_buffer = $vector_from_buffer', {
-        vector_from_array: neo4j.vector(Float32Array.from([1, 2, 3, 4])), // Typed arrays can be created from a regular list of Numbers
-        vector_from_buffer: neo4j.vector(new Int8Array(bufferWriter.buffer)) // Or from a bytebuffer
+      const res = await session.executeWrite(async (tx) => {
+        await tx.run('CREATE (p:Product) SET p.vector_from_array = $vector_from_array, p.vector_from_buffer = $vector_from_buffer', {
+          vector_from_array: neo4j.vector(Float32Array.from([1, 2, 3, 4])), // Typed arrays can be created from a regular list of Numbers
+          vector_from_buffer: neo4j.vector(new Int8Array(bufferWriter.buffer)) // Or from a bytebuffer
+        })
+        return await tx.run('MATCH (p:Product) RETURN p.vector_from_array as arrayVector, p.vector_from_buffer as bufferVector')
       })
-
-      console.error(write)
-
-      const read = await driver.executeQuery('MATCH (p:Product) RETURN p.vector_from_array as arrayVector, p.vector_from_buffer as bufferVector')
-
-      console.error(JSON.stringify(read))
-
-      const arrayVec = read.records[0].get('arrayVector').asTypedArray()
-      const bufferVec = read.records[0].get('bufferVector').asTypedArray()
+      const arrayVec = res.records[0].get('arrayVector').asTypedArray()
+      const bufferVec = res.records[0].get('bufferVector').asTypedArray()
 
       expect(arrayVec[0]).toBe(1)
       expect(bufferVec[1]).toBe(1)
+      session.close()
     }
   })
 })

--- a/packages/neo4j-driver/test/vector-type.test.js
+++ b/packages/neo4j-driver/test/vector-type.test.js
@@ -37,7 +37,7 @@ describe('#integration vector type', () => {
 
   beforeEach(async () => {
     const driver = driverGlobal
-    const session = driver.session({ bookmarkManager: driver.executeQueryBookmarkManager })
+    const session = driver.session()
     await session.run('MATCH (n) DETACH DELETE n')
     await session.close()
   })

--- a/packages/neo4j-driver/test/vector-type.test.js
+++ b/packages/neo4j-driver/test/vector-type.test.js
@@ -35,12 +35,11 @@ describe('#integration vector type', () => {
     await tmpDriver.close()
   })
 
-  beforeEach(async done => {
+  beforeEach(async () => {
     const driver = driverGlobal
     const session = driver.session()
     await session.run('MATCH (n) DETACH DELETE n')
-    await session.close()
-    done()
+    return session.close()
   })
 
   afterAll(async () => {

--- a/packages/neo4j-driver/test/vector-type.test.js
+++ b/packages/neo4j-driver/test/vector-type.test.js
@@ -49,21 +49,19 @@ describe('#integration vector type', () => {
   it('write and read vectors', async () => {
     if (protocolVersion.isGreaterOrEqualTo({ major: 6, minor: 0 }) && edition === 'enterprise') {
       const driver = driverGlobal
-      const session = driver.session()
+
       const bufferWriter = Uint8Array.from([1, 1])
-      const res = await session.executeWrite(async (tx) => {
-        await tx.run('CREATE (p:Product) SET p.vector_from_array = $vector_from_array, p.vector_from_buffer = $vector_from_buffer', {
-          vector_from_array: neo4j.vector(Float32Array.from([1, 2, 3, 4])), // Typed arrays can be created from a regular list of Numbers
-          vector_from_buffer: neo4j.vector(new Int8Array(bufferWriter.buffer)) // Or from a bytebuffer
-        })
-        return await tx.run('MATCH (p:Product) RETURN p.vector_from_array as arrayVector, p.vector_from_buffer as bufferVector')
+      await driver.executeQuery('CREATE (p:Product) SET p.vector_from_array = $vector_from_array, p.vector_from_buffer = $vector_from_buffer', {
+        vector_from_array: neo4j.vector(Float32Array.from([1, 2, 3, 4])), // Typed arrays can be created from a regular list of Numbers
+        vector_from_buffer: neo4j.vector(new Int8Array(bufferWriter.buffer)) // Or from a bytebuffer
       })
+      const res = await driver.executeQuery('MATCH (p:Product) RETURN p.vector_from_array as arrayVector, p.vector_from_buffer as bufferVector')
+
       const arrayVec = res.records[0].get('arrayVector').asTypedArray()
       const bufferVec = res.records[0].get('bufferVector').asTypedArray()
 
       expect(arrayVec[0]).toBe(1)
       expect(bufferVec[1]).toBe(1)
-      session.close()
     }
   })
 })

--- a/packages/neo4j-driver/test/vector-type.test.js
+++ b/packages/neo4j-driver/test/vector-type.test.js
@@ -37,9 +37,9 @@ describe('#integration vector type', () => {
 
   beforeEach(async () => {
     const driver = driverGlobal
-    const session = driver.session()
+    const session = driver.session({ bookmarkManager: driver.executeQueryBookmarkManager })
     await session.run('MATCH (n) DETACH DELETE n')
-    return session.close()
+    await session.close()
   })
 
   afterAll(async () => {

--- a/packages/neo4j-driver/test/vector-type.test.js
+++ b/packages/neo4j-driver/test/vector-type.test.js
@@ -35,11 +35,12 @@ describe('#integration vector type', () => {
     await tmpDriver.close()
   })
 
-  beforeEach(async () => {
+  beforeEach(async done => {
     const driver = driverGlobal
     const session = driver.session()
     await session.run('MATCH (n) DETACH DELETE n')
     await session.close()
+    done()
   })
 
   afterAll(async () => {

--- a/packages/neo4j-driver/test/vector-type.test.js
+++ b/packages/neo4j-driver/test/vector-type.test.js
@@ -51,14 +51,19 @@ describe('#integration vector type', () => {
       const driver = driverGlobal
 
       const bufferWriter = Uint8Array.from([1, 1])
-      await driver.executeQuery('CREATE (p:Product) SET p.vector_from_array = $vector_from_array, p.vector_from_buffer = $vector_from_buffer', {
+      const write = await driver.executeQuery('CREATE (p:Product) SET p.vector_from_array = $vector_from_array, p.vector_from_buffer = $vector_from_buffer', {
         vector_from_array: neo4j.vector(Float32Array.from([1, 2, 3, 4])), // Typed arrays can be created from a regular list of Numbers
         vector_from_buffer: neo4j.vector(new Int8Array(bufferWriter.buffer)) // Or from a bytebuffer
       })
-      const res = await driver.executeQuery('MATCH (p:Product) RETURN p.vector_from_array as arrayVector, p.vector_from_buffer as bufferVector')
 
-      const arrayVec = res.records[0].get('arrayVector').asTypedArray()
-      const bufferVec = res.records[0].get('bufferVector').asTypedArray()
+      console.error(write)
+
+      const read = await driver.executeQuery('MATCH (p:Product) RETURN p.vector_from_array as arrayVector, p.vector_from_buffer as bufferVector')
+
+      console.error(JSON.stringify(read))
+
+      const arrayVec = read.records[0].get('arrayVector').asTypedArray()
+      const bufferVec = read.records[0].get('bufferVector').asTypedArray()
 
       expect(arrayVec[0]).toBe(1)
       expect(bufferVec[1]).toBe(1)


### PR DESCRIPTION
The new framework for browser integration tests runs beforeEach calls in the middle of running other tests, this leads to some suites that run "MATCH (n) DETACH DELETE n" to clear out nodes that are being used by other tests.