### PR TITLE
add quick return in toStructure() for primitive values

### DIFF
--- a/packages/bolt-connection/src/bolt/transformer.js
+++ b/packages/bolt-connection/src/bolt/transformer.js
@@ -61,6 +61,11 @@ export default class Transformer {
    * @returns {<T>|structure.Structure} The structure or the object, if any transformer was found
    */
   toStructure (type) {
+    const valueType = typeof type
+    // captures 'string' | 'boolean' | 'bigint' | 'number' | 'undefined' | null
+    if ((valueType !== 'object' && valueType !== 'function' && valueType !== 'symbol') || type === null) {
+      return type
+    }
     const transformer = this._transformers.find(({ isTypeInstance }) => isTypeInstance(type))
     if (transformer !== undefined) {
       return transformer.toStructure(type)

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/transformer.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/transformer.js
@@ -61,6 +61,11 @@ export default class Transformer {
    * @returns {<T>|structure.Structure} The structure or the object, if any transformer was found
    */
   toStructure (type) {
+    const valueType = typeof type
+    // captures 'string' | 'boolean' | 'bigint' | 'number' | 'undefined' | null
+    if ((valueType !== 'object' && valueType !== 'function' && valueType !== 'symbol') || type === null) {
+      return type
+    }
     const transformer = this._transformers.find(({ isTypeInstance }) => isTypeInstance(type))
     if (transformer !== undefined) {
       return transformer.toStructure(type)


### PR DESCRIPTION
The toStructure function is run on every element being sent over bolt, which loops over all available typeTransformers and checks if they're valid for transforming what is being sent to a structure. This is rather wasteful for things like strings and numbers, which we do not have any transformers for.

Based on a suggestion in  #1351, the improvement will only work for as long as we do not have any transformers for primitive types, but there are currently no plans which would require that.