### PR TITLE
Add todo to point stringer for 7.0 update

### DIFF
--- a/packages/core/src/spatial-types.ts
+++ b/packages/core/src/spatial-types.ts
@@ -65,6 +65,7 @@ export class Point<T extends NumberOrInteger = Integer> {
    * @ignore
    */
   toString (): string {
+    // Update this in 7.0 to be copy-pasteable into cypher (currently missing parenthesis)
     return this.z != null && !isNaN(this.z)
       ? `Point{srid=${formatAsFloat(this.srid)}, x=${formatAsFloat(
           this.x

--- a/packages/core/src/spatial-types.ts
+++ b/packages/core/src/spatial-types.ts
@@ -65,7 +65,7 @@ export class Point<T extends NumberOrInteger = Integer> {
    * @ignore
    */
   toString (): string {
-    // Update this in 7.0 to be copy-pasteable into cypher (currently missing parenthesis)
+    // TODO 7.0: Update this in 7.0 to be copy-pasteable into cypher (currently missing parenthesis)
     return this.z != null && !isNaN(this.z)
       ? `Point{srid=${formatAsFloat(this.srid)}, x=${formatAsFloat(
           this.x

--- a/packages/neo4j-driver-deno/lib/core/spatial-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/spatial-types.ts
@@ -65,6 +65,7 @@ export class Point<T extends NumberOrInteger = Integer> {
    * @ignore
    */
   toString (): string {
+    // Update this in 7.0 to be copy-pasteable into cypher (currently missing parenthesis)
     return this.z != null && !isNaN(this.z)
       ? `Point{srid=${formatAsFloat(this.srid)}, x=${formatAsFloat(
           this.x

--- a/packages/neo4j-driver-deno/lib/core/spatial-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/spatial-types.ts
@@ -65,7 +65,7 @@ export class Point<T extends NumberOrInteger = Integer> {
    * @ignore
    */
   toString (): string {
-    // Update this in 7.0 to be copy-pasteable into cypher (currently missing parenthesis)
+    // TODO 7.0: Update this in 7.0 to be copy-pasteable into cypher (currently missing parenthesis)
     return this.z != null && !isNaN(this.z)
       ? `Point{srid=${formatAsFloat(this.srid)}, x=${formatAsFloat(
           this.x


### PR DESCRIPTION
closes DRIVERS-231
The toString of the Point object is almost correctly formatted for it to be copy-pasteable into a cypher query. Given that the Vector object stringer was designed to allow it to be copy-pasted, it would make sense to make the same true for Points.