### PR TITLE
Export Vector type and vector/isVector functions in TypeScript definitions

### DIFF
--- a/packages/neo4j-driver/test/types/export.test.ts
+++ b/packages/neo4j-driver/test/types/export.test.ts
@@ -27,7 +27,9 @@ import driver, {
   RxResult,
   Session,
   Record,
-  types
+  types,
+  Vector,
+  vector
 } from '../../'
 
 const {
@@ -97,6 +99,7 @@ const instanceOfLocalDateTime: boolean = dummy instanceof types.LocalDateTime
 const instanceOfLocalTime: boolean = dummy instanceof types.LocalTime
 const instanceOfTime: boolean = dummy instanceof types.Time
 const instanceOfInteger: boolean = dummy instanceof types.Integer
+const instanceOfVector: boolean = dummy instanceof types.Vector
 const instanceOfResult: boolean = dummy instanceof types.Result
 const instanceOfResultSummary: boolean = dummy instanceof types.ResultSummary
 const instanceOfRecord: boolean = dummy instanceof types.Record
@@ -136,6 +139,7 @@ const instanceOfDriverRxSession: boolean = dummy instanceof driver.RxSession
 const instanceOfDriverRxTransaction: boolean = dummy instanceof driver.RxTransaction
 const instanceOfDriverRxManagedTransaction: boolean = dummy instanceof driver.RxManagedTransaction
 const instanceOfDriverRxResult: boolean = dummy instanceof driver.RxResult
+const instanceOfDriverVector: boolean = dummy instanceof driver.Vector
 
 const recordShape: RecordShape = {
   a: 1234,

--- a/packages/neo4j-driver/types/index.d.ts
+++ b/packages/neo4j-driver/types/index.d.ts
@@ -106,6 +106,9 @@ import {
   StandardCase,
   MappedQueryResult,
   types as coreTypes,
+  Vector,
+  VectorType,
+  vector,
   isVector
 } from 'neo4j-driver-core'
 import {
@@ -181,6 +184,7 @@ declare const types: {
   LocalDateTime: typeof LocalDateTime
   DateTime: typeof DateTime
   Integer: typeof Integer
+  Vector: typeof Vector
   RxSession: typeof RxSession
   RxTransaction: typeof RxTransaction
   RxManagedTransaction: typeof RxManagedTransaction
@@ -308,6 +312,8 @@ declare const forExport: {
   notificationFilterMinimumSeverityLevel: typeof notificationFilterMinimumSeverityLevel
   logging: typeof logging
   clientCertificateProviders: typeof clientCertificateProviders
+  Vector: typeof Vector
+  vector: typeof vector
   isVector: typeof isVector
 }
 
@@ -391,6 +397,8 @@ export {
   notificationFilterMinimumSeverityLevel,
   logging,
   clientCertificateProviders,
+  Vector,
+  vector,
   isVector
 }
 
@@ -416,6 +424,7 @@ export type {
   ClientCertificateProvider,
   ClientCertificateProviders,
   RotatingClientCertificateProvider,
+  VectorType,
   Rule,
   Rules,
   rule,


### PR DESCRIPTION
# Export Vector type and vector/isVector functions in TypeScript definitions

## Problem

The Vector functionality was added in v6.0.0 for optimized vector storage (as documented in the README), but the TypeScript definitions in `packages/neo4j-driver/types/index.d.ts` were not updated to export the `Vector` class, `vector()` constructor function, `VectorType` type, and related functionality.

This causes TypeScript compilation errors when trying to use the Vector API:

```typescript
import { Vector, vector } from 'neo4j-driver';
// Error: 'neo4j-driver' has no exported member named 'Vector'
// Error: 'neo4j-driver' has no exported member named 'vector'
```

## Solution

This PR adds the missing exports to `packages/neo4j-driver/types/index.d.ts`:

1. **Import from neo4j-driver-core**: Added `Vector`, `VectorType`, and `vector` to the imports from `neo4j-driver-core`
2. **Added to types object**: Added `Vector: typeof Vector` to the `types` declaration
3. **Added to forExport**: Added `Vector` and `vector` to the default export object
4. **Added to named exports**: Added `Vector` and `vector` to the named exports
5. **Added to type exports**: Added `VectorType` to the type-only exports

## Changes Made

- Modified: `packages/neo4j-driver/types/index.d.ts`
  - Added Vector, VectorType, vector imports (lines 109-111)
  - Added Vector to types object (line 187)
  - Added Vector and vector to forExport (lines 315-316)
  - Added Vector and vector to named exports (lines 400-401)
  - Added VectorType to type exports (line 427)

## Additional Notes

- This is a non-breaking change - it only adds missing type exports
- The Vector functionality already exists in the runtime code
- The documentation already describes how to use Vectors, but TypeScript users couldn't actually import the types
- No tests needed as this only affects type definitions (no runtime changes)