### PR TITLE
Expand Record Object Mapping to allow Parameter Mapping

### DIFF
--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -607,7 +607,7 @@ class Driver {
    * }
    *
    * @public
-   * @param {string | {text: string, parameters?: object}} query - Cypher query to execute
+   * @param {string | {text: string, parameters?: object, parameterRules?: Rules}} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in the query
    * @param {QueryConfig<T>} config - The query configuration
    * @returns {Promise<T>}

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -49,6 +49,7 @@ import NotificationFilter from './notification-filter'
 import HomeDatabaseCache from './internal/homedb-cache'
 import { cacheKey } from './internal/auth-util'
 import { ProtocolVersion } from './protocol-version'
+import { Rules } from './mapping.highlevel'
 
 const DEFAULT_MAX_CONNECTION_LIFETIME: number = 60 * 60 * 1000 // 1 hour
 
@@ -368,6 +369,7 @@ class QueryConfig<T = EagerResult> {
   transactionConfig?: TransactionConfig
   auth?: AuthToken
   signal?: AbortSignal
+  parameterRules?: Rules
 
   /**
    * @constructor
@@ -630,7 +632,7 @@ class Driver {
       transactionConfig: config.transactionConfig,
       auth: config.auth,
       signal: config.signal
-    }, query, parameters)
+    }, query, parameters, config.parameterRules)
   }
 
   /**

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -369,7 +369,6 @@ class QueryConfig<T = EagerResult> {
   transactionConfig?: TransactionConfig
   auth?: AuthToken
   signal?: AbortSignal
-  parameterRules?: Rules
 
   /**
    * @constructor
@@ -610,11 +609,12 @@ class Driver {
    * @param {string | {text: string, parameters?: object, parameterRules?: Rules}} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in the query
    * @param {QueryConfig<T>} config - The query configuration
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @returns {Promise<T>}
    *
    * @see {@link resultTransformers} for provided result transformers.
    */
-  async executeQuery<T = EagerResult> (query: Query, parameters?: any, config: QueryConfig<T> = {}): Promise<T> {
+  async executeQuery<T = EagerResult> (query: Query, parameters?: any, config: QueryConfig<T> = {}, parameterRules?: Rules): Promise<T> {
     const bookmarkManager = config.bookmarkManager === null ? undefined : (config.bookmarkManager ?? this.executeQueryBookmarkManager)
     const resultTransformer = (config.resultTransformer ?? resultTransformers.eager()) as ResultTransformer<T>
     const routingConfig: string = config.routing ?? routing.WRITE
@@ -632,7 +632,7 @@ class Driver {
       transactionConfig: config.transactionConfig,
       auth: config.auth,
       signal: config.signal
-    }, query, parameters, config.parameterRules)
+    }, query, parameters, parameterRules)
   }
 
   /**

--- a/packages/core/src/graph-types.ts
+++ b/packages/core/src/graph-types.ts
@@ -18,6 +18,7 @@ import Integer from './integer'
 import { stringify } from './json'
 import { Rules, GenericConstructor, as } from './mapping.highlevel'
 
+export const StandardDateClass = Date
 type StandardDate = Date
 /**
  * @typedef {number | Integer | bigint} NumberOrInteger

--- a/packages/core/src/graph-types.ts
+++ b/packages/core/src/graph-types.ts
@@ -90,8 +90,6 @@ class Node<T extends NumberOrInteger = Integer, P extends Properties = Propertie
    * @param {GenericConstructor<T> | Rules} constructorOrRules Constructor for the desired type or {@link Rules} for the hydration
    * @param {Rules} [rules] {@link Rules} for the hydration
    * @returns {T}
-   *
-   * @experimental Part of the Record Object Mapping preview feature
    */
   as <T extends {} = Object>(rules: Rules): T
   as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
@@ -225,8 +223,6 @@ class Relationship<T extends NumberOrInteger = Integer, P extends Properties = P
    * @param {GenericConstructor<T> | Rules} constructorOrRules Constructor for the desired type or {@link Rules} for the hydration
    * @param {Rules} [rules] {@link Rules} for the hydration
    * @returns {T}
-   *
-   * @experimental Part of the Record Object Mapping preview feature
    */
   as <T extends {} = Object>(rules: Rules): T
   as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
@@ -364,8 +360,6 @@ class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Propert
    * @param {GenericConstructor<T> | Rules} constructorOrRules Constructor for the desired type or {@link Rules} for the hydration
    * @param {Rules} [rules] {@link Rules} for the hydration
    * @returns {T}
-   *
-   * @experimental Part of the Record Object Mapping preview feature
    */
   as <T extends {} = Object>(rules: Rules): T
   as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T

--- a/packages/core/src/graph-types.ts
+++ b/packages/core/src/graph-types.ts
@@ -18,7 +18,6 @@ import Integer from './integer'
 import { stringify } from './json'
 import { Rules, GenericConstructor, as } from './mapping.highlevel'
 
-export const JSDate = Date
 type StandardDate = Date
 /**
  * @typedef {number | Integer | bigint} NumberOrInteger

--- a/packages/core/src/graph-types.ts
+++ b/packages/core/src/graph-types.ts
@@ -18,7 +18,7 @@ import Integer from './integer'
 import { stringify } from './json'
 import { Rules, GenericConstructor, as } from './mapping.highlevel'
 
-export const StandardDateClass = Date
+export const JSDate = Date
 type StandardDate = Date
 /**
  * @typedef {number | Integer | bigint} NumberOrInteger

--- a/packages/core/src/internal/query-executor.ts
+++ b/packages/core/src/internal/query-executor.ts
@@ -21,6 +21,7 @@ import Result from '../result'
 import ManagedTransaction from '../transaction-managed'
 import { AuthToken, Query } from '../types'
 import { TELEMETRY_APIS } from './constants'
+import { Rules } from '../mapping.highlevel'
 
 type SessionFactory = (config: { database?: string, bookmarkManager?: BookmarkManager, impersonatedUser?: string, auth?: AuthToken }) => Session
 
@@ -42,7 +43,7 @@ export default class QueryExecutor {
 
   }
 
-  public async execute<T>(config: ExecutionConfig<T>, query: Query, parameters?: any): Promise<T> {
+  public async execute<T>(config: ExecutionConfig<T>, query: Query, parameters?: any, parameterRules?: Rules): Promise<T> {
     const session = this._createSession({
       database: config.database,
       bookmarkManager: config.bookmarkManager,
@@ -65,7 +66,7 @@ export default class QueryExecutor {
         : session.executeWrite.bind(session)
 
       return await executeInTransaction(async (tx: ManagedTransaction) => {
-        const result = tx.run(query, parameters)
+        const result = tx.run(query, parameters, parameterRules)
         return await config.resultTransformer(result)
       }, config.transactionConfig)
     } finally {

--- a/packages/core/src/internal/util.ts
+++ b/packages/core/src/internal/util.ts
@@ -20,6 +20,7 @@ import { NumberOrInteger } from '../graph-types'
 import { EncryptionLevel } from '../types'
 import { stringify } from '../json'
 import { Rules, validateAndCleanParameters } from '../mapping.highlevel'
+import { newError } from '../error'
 
 const ENCRYPTION_ON: EncryptionLevel = 'ENCRYPTION_ON'
 const ENCRYPTION_OFF: EncryptionLevel = 'ENCRYPTION_OFF'
@@ -57,8 +58,9 @@ function isObject (obj: any): boolean {
 
 /**
  * Check and normalize given query and parameters.
- * @param {string|{text: string, parameters: Object}} query the query to check.
- * @param {Object} parameters
+ * @param {string|{text: string, parameters: Object, parameterRules: Rules}} query the query to check.
+ * @param {Object} parameters the parameters to validate
+ * @param {{skipAsserts: boolean, parameterRules: Rules}} opt options to skip assertions, and parameterRules to check if query is not an object.
  * @return {{validatedQuery: string|{text: string, parameters: Object}, params: Object}} the normalized query with parameters.
  * @throws TypeError when either given query or parameters are invalid.
  */
@@ -80,9 +82,15 @@ function validateQueryAndParameters (
   } else if (query instanceof String) {
     validatedQuery = query.toString()
   } else if (typeof query === 'object' && query.text != null) {
+    if (!skipAsserts) {
+      // TODO: in 7.0 throw error if parameters put in a separate argument when using Query object.
+      if (opt?.parameterRules != null) {
+        throw newError('When using a Query object, parameterRules should be present in the object and not in a separate argument.')
+      }
+    }
     validatedQuery = query.text
     params = query.parameters ?? {}
-    parameterRules = query.parameterRules ?? parameterRules
+    parameterRules = query.parameterRules
   }
 
   if (!skipAsserts) {

--- a/packages/core/src/internal/util.ts
+++ b/packages/core/src/internal/util.ts
@@ -74,6 +74,7 @@ function validateQueryAndParameters (
   let params = parameters ?? {}
   let parameterRules = opt?.parameterRules
   const skipAsserts: boolean = opt?.skipAsserts ?? false
+
   if (typeof query === 'string') {
     validatedQuery = query
   } else if (query instanceof String) {

--- a/packages/core/src/internal/util.ts
+++ b/packages/core/src/internal/util.ts
@@ -19,7 +19,7 @@ import Integer, { isInt, int } from '../integer'
 import { NumberOrInteger } from '../graph-types'
 import { EncryptionLevel } from '../types'
 import { stringify } from '../json'
-import { Rules, validateAndCleanParams } from '../mapping.highlevel'
+import { Rules, validateAndcleanParameters } from '../mapping.highlevel'
 
 const ENCRYPTION_ON: EncryptionLevel = 'ENCRYPTION_ON'
 const ENCRYPTION_OFF: EncryptionLevel = 'ENCRYPTION_OFF'
@@ -85,7 +85,7 @@ function validateQueryAndParameters (
   }
 
   if (!skipAsserts) {
-    params = validateAndCleanParams(params, parameterRules)
+    params = validateAndcleanParameters(params, parameterRules)
     assertCypherQuery(validatedQuery)
     assertQueryParameters(params)
   }

--- a/packages/core/src/internal/util.ts
+++ b/packages/core/src/internal/util.ts
@@ -19,6 +19,7 @@ import Integer, { isInt, int } from '../integer'
 import { NumberOrInteger } from '../graph-types'
 import { EncryptionLevel } from '../types'
 import { stringify } from '../json'
+import { Rules, validateAndCleanParams } from '../mapping.highlevel'
 
 const ENCRYPTION_ON: EncryptionLevel = 'ENCRYPTION_ON'
 const ENCRYPTION_OFF: EncryptionLevel = 'ENCRYPTION_OFF'
@@ -62,17 +63,17 @@ function isObject (obj: any): boolean {
  * @throws TypeError when either given query or parameters are invalid.
  */
 function validateQueryAndParameters (
-  query: string | String | { text: string, parameters?: any },
+  query: string | String | { text: string, parameters?: any, parameterRules?: Rules },
   parameters?: any,
-  opt?: { skipAsserts: boolean }
+  opt?: { skipAsserts?: boolean, parameterRules?: Rules }
 ): {
     validatedQuery: string
     params: any
   } {
   let validatedQuery: string = ''
   let params = parameters ?? {}
+  let parameterRules = opt?.parameterRules
   const skipAsserts: boolean = opt?.skipAsserts ?? false
-
   if (typeof query === 'string') {
     validatedQuery = query
   } else if (query instanceof String) {
@@ -80,9 +81,11 @@ function validateQueryAndParameters (
   } else if (typeof query === 'object' && query.text != null) {
     validatedQuery = query.text
     params = query.parameters ?? {}
+    parameterRules = query.parameterRules
   }
 
   if (!skipAsserts) {
+    params = validateAndCleanParams(params, parameterRules)
     assertCypherQuery(validatedQuery)
     assertQueryParameters(params)
   }

--- a/packages/core/src/internal/util.ts
+++ b/packages/core/src/internal/util.ts
@@ -82,7 +82,7 @@ function validateQueryAndParameters (
   } else if (typeof query === 'object' && query.text != null) {
     validatedQuery = query.text
     params = query.parameters ?? {}
-    parameterRules = query.parameterRules
+    parameterRules = query.parameterRules ?? parameterRules
   }
 
   if (!skipAsserts) {

--- a/packages/core/src/internal/util.ts
+++ b/packages/core/src/internal/util.ts
@@ -19,7 +19,7 @@ import Integer, { isInt, int } from '../integer'
 import { NumberOrInteger } from '../graph-types'
 import { EncryptionLevel } from '../types'
 import { stringify } from '../json'
-import { Rules, validateAndcleanParameters } from '../mapping.highlevel'
+import { Rules, validateAndCleanParameters } from '../mapping.highlevel'
 
 const ENCRYPTION_ON: EncryptionLevel = 'ENCRYPTION_ON'
 const ENCRYPTION_OFF: EncryptionLevel = 'ENCRYPTION_OFF'
@@ -86,7 +86,7 @@ function validateQueryAndParameters (
   }
 
   if (!skipAsserts) {
-    params = validateAndcleanParameters(params, parameterRules)
+    params = validateAndCleanParameters(params, parameterRules)
     assertCypherQuery(validatedQuery)
     assertQueryParameters(params)
   }

--- a/packages/core/src/mapping.decorators.ts
+++ b/packages/core/src/mapping.decorators.ts
@@ -124,7 +124,7 @@ function pointProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Duration.
  *
- * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
  * @returns {Function} Property Decorator
  */
 function durationProperty (config?: Rule & { stringify?: boolean }) {
@@ -136,7 +136,7 @@ function durationProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalTime
  *
- * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function localTimeProperty (config?: Rule & { stringify?: boolean }) {
@@ -148,7 +148,7 @@ function localTimeProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Time
  *
- * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
  * @returns {Function} Property Decorator
  */
 function timeProperty (config?: Rule & { stringify?: boolean }) {
@@ -160,7 +160,7 @@ function timeProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Date
  *
- * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
  * @returns {Function} Property Decorator
  */
 function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -172,7 +172,7 @@ function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boo
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalDateTIme
  *
- * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -184,7 +184,7 @@ function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeD
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a DateTIme
  *
- * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function dateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -208,7 +208,7 @@ function listProperty (config?: Rule & { apply?: Rule }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Vector
  *
- * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
+ * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64" }} config Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
  * @returns {Function} Property Decorator
  */
 function vectorProperty (config?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }) {

--- a/packages/core/src/mapping.decorators.ts
+++ b/packages/core/src/mapping.decorators.ts
@@ -39,7 +39,7 @@ function stringProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a number.
  *
- * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule.
+ * @param {Rule & { isInteger?: boolean }} config Configurations for the rule.
  * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
  * @returns {Function} Property Decorator
  */
@@ -134,6 +134,66 @@ function durationProperty (config?: Rule & { stringify?: boolean }) {
 }
 
 /**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalTime
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function localTimeProperty (config?: Rule & { stringify?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asLocalTime(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a Time
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function timeProperty (config?: Rule & { stringify?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asTime(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a Date
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asDate(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalDateTIme
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asLocalDateTime(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a DateTIme
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function dateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asDateTime(config)
+  }
+}
+
+/**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a List
  *
  * @param {Rule & { apply?: Rule }} config
@@ -148,10 +208,10 @@ function listProperty (config?: Rule & { apply?: Rule }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Vector
  *
- * @param {Rule & { asTypedList?: boolean }} config
+ * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config
  * @returns {Function} Property Decorator
  */
-function vectorProperty (config?: Rule & { asTypedList?: boolean }) {
+function vectorProperty (config?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }) {
   return (_: any, context: any) => {
     context.metadata[context.name] = rule.asVector(config)
   }
@@ -161,7 +221,6 @@ function vectorProperty (config?: Rule & { asTypedList?: boolean }) {
  * Property Decorator Factory that sets this property to optional.
  * NOTE: Should be put above a type decorator.
  *
- * @param {Rule} config
  * @returns {Function} Property Decorator
  */
 function optionalProperty () {
@@ -174,7 +233,7 @@ function optionalProperty () {
  * Property Decorator Factory that sets a custom parameter name to map this property to.
  * NOTE: Should be put above a type decorator.
  *
- * @param {Rule} config
+ * @param {string} name
  * @returns {Function} Property Decorator
  */
 function mapPropertyFromName (name: string) {
@@ -187,7 +246,7 @@ function mapPropertyFromName (name: string) {
  * Property Decorator Factory that sets the Neo4j Driver to convert this property to another type.
  * NOTE: Should be put above a type decorator of type Node or Relationship.
  *
- * @param {Rule} config
+ * @param {any} type
  * @returns {Function} Property Decorator
  */
 function convertPropertyToType (type: any) {
@@ -207,6 +266,11 @@ const forExport = {
   pathProperty,
   pointProperty,
   durationProperty,
+  localTimeProperty,
+  timeProperty,
+  dateProperty,
+  localDateTimeProperty,
+  dateTimeProperty,
   listProperty,
   vectorProperty,
   optionalProperty,

--- a/packages/core/src/mapping.decorators.ts
+++ b/packages/core/src/mapping.decorators.ts
@@ -5,7 +5,6 @@ import { rule } from './mapping.rulesfactories'
  * Class Decorator Factory that enables the Neo4j Driver to map result records to this class
  *
  * @returns {Function} Class Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function mappedClass () {
   return (_: any, context: any) => {
@@ -18,7 +17,6 @@ function mappedClass () {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function booleanProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -31,7 +29,6 @@ function booleanProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function stringProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -44,7 +41,6 @@ function stringProperty (config?: Rule) {
  *
  * @param {Rule & { acceptBigInt?: boolean }} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function numberProperty (config?: Rule & { acceptBigInt?: boolean }) {
   return (_: any, context: any) => {
@@ -57,7 +53,6 @@ function numberProperty (config?: Rule & { acceptBigInt?: boolean }) {
  *
  * @param {Rule & { acceptNumber?: boolean }} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function bigIntProperty (config?: Rule & { acceptNumber?: boolean }) {
   return (_: any, context: any) => {
@@ -70,7 +65,6 @@ function bigIntProperty (config?: Rule & { acceptNumber?: boolean }) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function nodeProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -83,7 +77,6 @@ function nodeProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function relationshipProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -96,7 +89,6 @@ function relationshipProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function pathProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -109,7 +101,6 @@ function pathProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function pointProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -122,7 +113,6 @@ function pointProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function durationProperty (config?: Rule & { stringify?: boolean }) {
   return (_: any, context: any) => {
@@ -135,7 +125,6 @@ function durationProperty (config?: Rule & { stringify?: boolean }) {
  *
  * @param {Rule & { apply?: Rule }} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function listProperty (config?: Rule & { apply?: Rule }) {
   return (_: any, context: any) => {
@@ -148,7 +137,6 @@ function listProperty (config?: Rule & { apply?: Rule }) {
  *
  * @param {Rule & { asTypedList?: boolean }} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function vectorProperty (config?: Rule & { asTypedList?: boolean }) {
   return (_: any, context: any) => {
@@ -162,7 +150,6 @@ function vectorProperty (config?: Rule & { asTypedList?: boolean }) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function optionalProperty () {
   return (_: any, context: any) => {
@@ -176,7 +163,6 @@ function optionalProperty () {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function mapPropertyFromName (name: string) {
   return (_: any, context: any) => {
@@ -190,7 +176,6 @@ function mapPropertyFromName (name: string) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function convertPropertyToType (type: any) {
   return (_: any, context: any) => {

--- a/packages/core/src/mapping.decorators.ts
+++ b/packages/core/src/mapping.decorators.ts
@@ -15,7 +15,7 @@ function mappedClass () {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a boolean.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule
  * @returns {Function} Property Decorator
  */
 function booleanProperty (config?: Rule) {
@@ -27,7 +27,7 @@ function booleanProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a string.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule
  * @returns {Function} Property Decorator
  */
 function stringProperty (config?: Rule) {
@@ -76,7 +76,7 @@ function integerProperty (config?: Rule & { acceptNumber?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Node.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule
  * @returns {Function} Property Decorator
  */
 function nodeProperty (config?: Rule) {
@@ -88,7 +88,7 @@ function nodeProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Relationship.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule.
  * @returns {Function} Property Decorator
  */
 function relationshipProperty (config?: Rule) {
@@ -100,7 +100,7 @@ function relationshipProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Path.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule.
  * @returns {Function} Property Decorator
  */
 function pathProperty (config?: Rule) {
@@ -112,7 +112,7 @@ function pathProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Point.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule.
  * @returns {Function} Property Decorator
  */
 function pointProperty (config?: Rule) {
@@ -124,7 +124,7 @@ function pointProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Duration.
  *
- * @param {Rule} config
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
  * @returns {Function} Property Decorator
  */
 function durationProperty (config?: Rule & { stringify?: boolean }) {
@@ -136,7 +136,7 @@ function durationProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalTime
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function localTimeProperty (config?: Rule & { stringify?: boolean }) {
@@ -148,7 +148,7 @@ function localTimeProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Time
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
  * @returns {Function} Property Decorator
  */
 function timeProperty (config?: Rule & { stringify?: boolean }) {
@@ -160,7 +160,7 @@ function timeProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Date
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
  * @returns {Function} Property Decorator
  */
 function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -172,7 +172,7 @@ function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boo
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalDateTIme
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -184,7 +184,7 @@ function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeD
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a DateTIme
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function dateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -196,7 +196,7 @@ function dateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?:
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a List
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { apply?: Rule }} config Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
  * @returns {Function} Property Decorator
  */
 function listProperty (config?: Rule & { apply?: Rule }) {
@@ -208,7 +208,7 @@ function listProperty (config?: Rule & { apply?: Rule }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Vector
  *
- * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config
+ * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
  * @returns {Function} Property Decorator
  */
 function vectorProperty (config?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }) {

--- a/packages/core/src/mapping.decorators.ts
+++ b/packages/core/src/mapping.decorators.ts
@@ -39,10 +39,11 @@ function stringProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a number.
  *
- * @param {Rule & { acceptBigInt?: boolean }} config
+ * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule.
+ * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
  * @returns {Function} Property Decorator
  */
-function numberProperty (config?: Rule & { acceptBigInt?: boolean }) {
+function numberProperty (config?: Rule & { isInteger?: boolean }) {
   return (_: any, context: any) => {
     context.metadata[context.name] = rule.asNumber(config)
   }
@@ -51,12 +52,24 @@ function numberProperty (config?: Rule & { acceptBigInt?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a BigInt.
  *
- * @param {Rule & { acceptNumber?: boolean }} config
+ * @param {Rule & { acceptNumber?: boolean }} config Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the convert function will turn Numbers into BigInts.
  * @returns {Function} Property Decorator
  */
 function bigIntProperty (config?: Rule & { acceptNumber?: boolean }) {
   return (_: any, context: any) => {
     context.metadata[context.name] = rule.asBigInt(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to an Integer.
+ *
+ * @param {Rule & { acceptNumber?: boolean }} config Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the convert function will turn Numbers into BigInts.
+ * @returns {Function} Property Decorator
+ */
+function integerProperty (config?: Rule & { acceptNumber?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asInteger(config)
   }
 }
 
@@ -188,6 +201,7 @@ const forExport = {
   stringProperty,
   numberProperty,
   bigIntProperty,
+  integerProperty,
   nodeProperty,
   relationshipProperty,
   pathProperty,

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { newError } from './error'
+import { Neo4jError, newError } from './error'
 import { nameConventions } from './mapping.nameconventions'
 
 /**
@@ -160,7 +160,15 @@ export function as <T extends {} = Object> (gettable: Gettable, constructorOrRul
 
 function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: Rule): void {
   const mappedkey = defaultNameMapping(key)
-  const value = gettable.get(rule?.from ?? mappedkey)
+  let value
+  try {
+    value = gettable.get(rule?.from ?? mappedkey)
+  } catch (e) {
+    if (rule?.optional === true && e instanceof Neo4jError && e.message.includes('This record has no field with key')) {
+      return
+    }
+    throw e
+  }
   const field = `${obj.constructor.name}#${key}`
   const processedValue = valueAs(value, field, rule)
   // @ts-expect-error

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -29,7 +29,7 @@ export interface Rule {
   optional?: boolean
   from?: string
   convert?: (recordValue: any, field: string) => any
-  convertToParam?: (objectValue: any) => any
+  parameterConversion?: (objectValue: any) => any
   validate?: (recordValue: any, field: string) => void
 }
 
@@ -181,14 +181,14 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
 
-export function valueAsParam (value: unknown, rule?: Rule): unknown {
+export function optionalParameterConversion (value: unknown, rule?: Rule): unknown {
   if (rule?.optional === true && value == null) {
     return value
   }
-  return ((rule?.convertToParam) != null) ? rule.convertToParam(value) : value
+  return ((rule?.parameterConversion) != null) ? rule.parameterConversion(value) : value
 }
 
-export function validateAndCleanParams (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
+export function validateAndcleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
   const cleanedParams: Record<string, any> = {}
   // @ts-expect-error
   const parameterRules = getRules(params.constructor, suppliedRules)
@@ -196,8 +196,8 @@ export function validateAndCleanParams (params: Record<string, any>, suppliedRul
     for (const key in parameterRules) {
       if (!(parameterRules?.[key]?.optional === true)) {
         let param = params[key]
-        if (parameterRules[key]?.convertToParam !== undefined) {
-          param = parameterRules[key].convertToParam(params[key])
+        if (parameterRules[key]?.parameterConversion !== undefined) {
+          param = parameterRules[key].parameterConversion(params[key])
         }
         if (param === undefined) {
           throw newError('Parameter object did not include required parameter.')

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -30,7 +30,7 @@ export type GenericConstructor<T extends {}> = new (...args: any[]) => T
  */
 export interface Rule {
   /**
-   * Whether or not the field is optional. If true, an undefined or null value will not fail validation.
+   * Whether or not the field is optional. If true, an undefined or null value will not fail validation, these will not be passed to conversion functions.
    */
   optional?: boolean
   /**
@@ -52,14 +52,14 @@ export interface Rule {
    *
    * NOTE: This function will not be called on null-ish values on optional parameters
    *
-   * @param objectValue The value provided as a parameter.
+   * @param {any} objectValue The value provided as a parameter.
    * @returns The converted value, this value will be passed to the validate function before transmission to the database.
    */
   parameterConversion?: (objectValue: any) => any
   /**
    * A function to validate the value, should throw an error if it is invalid.
    *
-   * @param value The value to validate.
+   * @param {any} value The value to validate.
    * @param {string} field The name of the field with the value.
    */
   validate?: (value: any, field: string) => void
@@ -203,8 +203,10 @@ function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: R
   }
   const field = `${obj.constructor.name}#${key}`
   const processedValue = valueAs(value, field, rule)
-  // @ts-expect-error
-  obj[key] = processedValue ?? obj[key]
+  if (processedValue != null || rule?.optional === true) {
+    // @ts-expect-error
+    obj[key] = processedValue
+  }
 }
 
 export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
@@ -232,6 +234,7 @@ export function validateAndCleanParameters (params: Record<string, any>, supplie
   if (parameterRules != null) {
     for (const key in parameterRules) {
       let param = params[key]
+      const mappedKey = parameterRules[key].from ?? defaultNameMapping(key)
       if (param != null && parameterRules[key].parameterConversion != null) {
         param = parameterRules[key].parameterConversion(param)
       }
@@ -241,15 +244,10 @@ export function validateAndCleanParameters (params: Record<string, any>, supplie
             `Mapped Parameter object did not include required parameter with key ${key}, 
             check provided parameters and parameter rules.`
           )
-        } else {
-          continue
         }
-      }
-      if (parameterRules[key].validate != null) {
+      } else if (parameterRules[key].validate != null) {
         parameterRules[key].validate(param, key)
       }
-      const mappedKey = parameterRules[key].from ?? defaultNameMapping(key)
-
       cleanedParams[mappedKey] = param
     }
     return cleanedParams

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -29,6 +29,7 @@ export interface Rule {
   optional?: boolean
   from?: string
   convert?: (recordValue: any, field: string) => any
+  convertToParam?: (objectValue: any) => any
   validate?: (recordValue: any, field: string) => void
 }
 
@@ -36,7 +37,7 @@ export type Rules = Record<string, Rule>
 
 export let rulesRegistry: Record<string, Rules> = {}
 
-let nameMapping: (name: string) => string = (name) => name
+export let nameMapping: (name: string) => string = (name) => name
 
 function register <T extends {} = Object> (constructor: GenericConstructor<T>, rules: Rules): void {
   rulesRegistry[constructor.name] = rules
@@ -179,6 +180,42 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
 
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
+
+export function validateAndCleanParams (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
+  const cleanedParams: Record<string, any> = {}
+  // @ts-expect-error
+  const parameterRules = getRules(params.constructor, suppliedRules)
+  if (parameterRules !== undefined) {
+    for (const key in parameterRules) {
+      if (!(parameterRules?.[key]?.optional === true)) {
+        let param = params[key]
+        if (parameterRules[key]?.convertToParam !== undefined) {
+          param = parameterRules[key].convertToParam(params[key])
+        }
+        if (param === undefined) {
+          throw newError('Parameter object did not include required parameter.')
+        }
+        if (parameterRules[key].validate != null) {
+          parameterRules[key].validate(param, key)
+          // @ts-expect-error
+          if (parameterRules[key].apply !== undefined) {
+            for (const entryKey in param) {
+              // @ts-expect-error
+              parameterRules[key].apply.validate(param[entryKey], entryKey)
+            }
+          }
+        }
+        const mappedKey = parameterRules[key].from ?? nameMapping(key)
+
+        cleanedParams[mappedKey] = param
+      }
+    }
+    return cleanedParams
+  } else {
+    return params
+  }
+}
+
 function getRules<T extends {} = Object> (constructorOrRules: Rules | GenericConstructor<T>, rules: Rules | undefined): Rules | undefined {
   const rulesDefined = typeof constructorOrRules === 'object' ? constructorOrRules : rules
   if (rulesDefined != null) {

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -181,6 +181,13 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
 
+export function valueAsParam (value: unknown, rule?: Rule): unknown {
+  if (rule?.optional === true && value == null) {
+    return value
+  }
+  return ((rule?.convertToParam) != null) ? rule.convertToParam(value) : value
+}
+
 export function validateAndCleanParams (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
   const cleanedParams: Record<string, any> = {}
   // @ts-expect-error

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -202,11 +202,8 @@ function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: R
     throw e
   }
   const field = `${obj.constructor.name}#${key}`
-  const processedValue = valueAs(value, field, rule)
-  if (processedValue != null || rule?.optional === true) {
-    // @ts-expect-error
-    obj[key] = processedValue
-  }
+  // @ts-expect-error
+  obj[key] = valueAs(value, field, rule)
 }
 
 export function valueAs (value: unknown, field: string, rule?: Rule): unknown {

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -25,12 +25,40 @@ import { nameConventions } from './mapping.nameconventions'
  */
 export type GenericConstructor<T extends {}> = new (...args: any[]) => T
 
+/**
+ * Rule used to provide mapping and type validation of parameters and records.
+ */
 export interface Rule {
+  /**
+   * Whether or not the field is optional. If true, an undefined or null value will not fail validation.
+   */
   optional?: boolean
+  /**
+   * The string used to identify this value in the database. For when parameters or returned fields do not match the name of your domain objects fields.
+   */
   from?: string
+  /**
+   * A function to convert the value from a result after it has been validated.
+   *
+   * @param recordValue The value from the raw result.
+   * @param {string} field name of the field.
+   * @returns {any} The converted value.
+   */
   convert?: (recordValue: any, field: string) => any
+  /**
+   * A function to convert a parameter before validation and transmission to the database.
+   *
+   * @param objectValue The value provided as a parameter.
+   * @returns The converted value, this value will be passed to the validate function before transmission to the database.
+   */
   parameterConversion?: (objectValue: any) => any
-  validate?: (recordValue: any, field: string) => void
+  /**
+   * A function to validate the value, should throw an error if it is invalid.
+   *
+   * @param value The value to validate.
+   * @param {string} field The name of the field with the value.
+   */
+  validate?: (value: any, field: string) => void
 }
 
 export type Rules = Record<string, Rule>
@@ -159,10 +187,10 @@ export function as <T extends {} = Object> (gettable: Gettable, constructorOrRul
 }
 
 function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: Rule): void {
-  const mappedkey = defaultNameMapping(key)
+  const mappedKey = defaultNameMapping(key)
   let value
   try {
-    value = gettable.get(rule?.from ?? mappedkey)
+    value = gettable.get(rule?.from ?? mappedKey)
   } catch (e) {
     if (rule?.optional === true && e instanceof Neo4jError && e.message.includes('This record has no field with key')) {
       return
@@ -191,7 +219,7 @@ export function optionalParameterConversion (value: unknown, rule: Rule): unknow
   if (rule.optional === true && value == null) {
     return value
   }
-  return ((rule?.parameterConversion) != null) ? rule.parameterConversion(value) : value
+  return (rule.parameterConversion != null) ? rule.parameterConversion(value) : value
 }
 
 export function validateAndCleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
@@ -200,20 +228,17 @@ export function validateAndCleanParameters (params: Record<string, any>, supplie
   if (parameterRules != null) {
     for (const key in parameterRules) {
       let param = params[key]
-      if (param == null && parameterRules[key].optional === true) {
-        continue
-      }
-      if (parameterRules[key].parameterConversion != null) {
+      if (param != null && parameterRules[key].parameterConversion != null) {
         param = parameterRules[key].parameterConversion(param)
-        if (param == null) {
-          if (parameterRules[key].optional !== true) {
-            throw newError(
-              `Mapped Parameter object did not include required parameter with key ${key}, 
-              check provided parameters and parameter rules.`
-            )
-          } else {
-            continue
-          }
+      }
+      if (param == null) {
+        if (parameterRules[key].optional !== true) {
+          throw newError(
+            `Mapped Parameter object did not include required parameter with key ${key}, 
+            check provided parameters and parameter rules.`
+          )
+        } else {
+          continue
         }
       }
       if (parameterRules[key].validate != null) {

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -37,7 +37,7 @@ export type Rules = Record<string, Rule>
 
 export let rulesRegistry: Record<string, Rules> = {}
 
-export let nameMapping: (name: string) => string = (name) => name
+export let defaultNameMapping: (name: string) => string = (name) => name
 
 function register <T extends {} = Object> (constructor: GenericConstructor<T>, rules: Rules): void {
   rulesRegistry[constructor.name] = rules
@@ -48,7 +48,7 @@ function clearMappingRegistry (): void {
 }
 
 function translateIdentifiers (translationFunction: (name: string) => string): void {
-  nameMapping = translationFunction
+  defaultNameMapping = translationFunction
 }
 
 function getCaseTranslator (databaseConvention: string, codeConvention: string): ((name: string) => string) {
@@ -108,6 +108,8 @@ export const RecordObjectMapping = Object.freeze({
  * Sets a default name translation from record keys to object properties.
  * If providing a function, provide a function that maps FROM your object properties names TO record key names.
  *
+ * NOTE: The keys of objects inside a record will only be translated if using the asObject rule with it, not by default.
+ *
  * The function getCaseTranslator can be used to provide a prewritten translation function between some common naming conventions.
  *
  * @example
@@ -157,7 +159,7 @@ export function as <T extends {} = Object> (gettable: Gettable, constructorOrRul
 }
 
 function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: Rule): void {
-  const mappedkey = nameMapping(key)
+  const mappedkey = defaultNameMapping(key)
   const value = gettable.get(rule?.from ?? mappedkey)
   const field = `${obj.constructor.name}#${key}`
   const processedValue = valueAs(value, field, rule)
@@ -177,41 +179,41 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
 
-export function optionalParameterConversion (value: unknown, rule?: Rule): unknown {
-  if (rule?.optional === true && value == null) {
+export function optionalParameterConversion (value: unknown, rule: Rule): unknown {
+  if (rule.optional === true && value == null) {
     return value
   }
   return ((rule?.parameterConversion) != null) ? rule.parameterConversion(value) : value
 }
 
-export function validateAndcleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
+export function validateAndCleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
   const cleanedParams: Record<string, any> = {}
-  // @ts-expect-error
-  const parameterRules = getRules(params.constructor, suppliedRules)
-  if (parameterRules !== undefined) {
+  const parameterRules = getRules(Object.getPrototypeOf(params).constructor, suppliedRules)
+  if (parameterRules != null) {
     for (const key in parameterRules) {
-      if (!(parameterRules?.[key]?.optional === true)) {
-        let param = params[key]
-        if (parameterRules[key]?.parameterConversion !== undefined) {
-          param = parameterRules[key].parameterConversion(params[key])
-        }
-        if (param === undefined) {
-          throw newError('Parameter object did not include required parameter.')
-        }
-        if (parameterRules[key].validate != null) {
-          parameterRules[key].validate(param, key)
-          // @ts-expect-error
-          if (parameterRules[key].apply !== undefined) {
-            for (const entryKey in param) {
-              // @ts-expect-error
-              parameterRules[key].apply.validate(param[entryKey], entryKey)
-            }
+      let param = params[key]
+      if (param == null && parameterRules[key].optional === true) {
+        continue
+      }
+      if (parameterRules[key].parameterConversion != null) {
+        param = parameterRules[key].parameterConversion(param)
+        if (param == null) {
+          if (parameterRules[key].optional !== true) {
+            throw newError(
+              `Mapped Parameter object did not include required parameter with key ${key}, 
+              check provided parameters and parameter rules.`
+            )
+          } else {
+            continue
           }
         }
-        const mappedKey = parameterRules[key].from ?? nameMapping(key)
-
-        cleanedParams[mappedKey] = param
       }
+      if (parameterRules[key].validate != null) {
+        parameterRules[key].validate(param, key)
+      }
+      const mappedKey = parameterRules[key].from ?? defaultNameMapping(key)
+
+      cleanedParams[mappedKey] = param
     }
     return cleanedParams
   } else {

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -72,7 +72,6 @@ function getCaseTranslator (databaseConvention: string, codeConvention: string):
 export const RecordObjectMapping = Object.freeze({
   /**
  * Clears all registered type mappings from the record object mapping registry.
- * @experimental Part of the Record Object Mapping preview feature
  */
   clearMappingRegistry,
   /**
@@ -80,7 +79,6 @@ export const RecordObjectMapping = Object.freeze({
  *
  * Recognized naming conventions are "camelCase", "PascalCase", "snake_case", "kebab-case", "SCREAMING_SNAKE_CASE"
  *
- * @experimental Part of the Record Object Mapping preview feature
  * @param {string} databaseConvention The naming convention in use in database result Records
  * @param {string} codeConvention The naming convention in use in JavaScript object properties
  * @returns {function} translation function
@@ -102,7 +100,6 @@ export const RecordObjectMapping = Object.freeze({
  *  resultTransformer: neo4j.resultTransformers.hydrated(Person)
  * })
  *
- * @experimental Part of the Record Object Mapping preview feature
  * @param {GenericConstructor} constructor The constructor function of the class to set rules for
  * @param {Rules} rules The rules to set for the provided class
  */
@@ -131,7 +128,6 @@ export const RecordObjectMapping = Object.freeze({
  * //or by registering them to the mapping registry
  * RecordObjectMapping.register(Person, personRules)
  *
- * @experimental Part of the Record Object Mapping preview feature
  * @param {function} translationFunction A function translating the names of your JS object property names to record key names
  */
   translateIdentifiers

--- a/packages/core/src/mapping.highlevel.ts
+++ b/packages/core/src/mapping.highlevel.ts
@@ -40,13 +40,17 @@ export interface Rule {
   /**
    * A function to convert the value from a result after it has been validated.
    *
-   * @param recordValue The value from the raw result.
+   * NOTE: This function will not be called on null-ish values on optional fields
+   *
+   * @param {any} recordValue The value from the raw result.
    * @param {string} field name of the field.
    * @returns {any} The converted value.
    */
   convert?: (recordValue: any, field: string) => any
   /**
    * A function to convert a parameter before validation and transmission to the database.
+   *
+   * NOTE: This function will not be called on null-ish values on optional parameters
    *
    * @param objectValue The value provided as a parameter.
    * @returns The converted value, this value will be passed to the validate function before transmission to the database.
@@ -192,7 +196,7 @@ function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: R
   try {
     value = gettable.get(rule?.from ?? mappedKey)
   } catch (e) {
-    if (rule?.optional === true && e instanceof Neo4jError && e.message.includes('This record has no field with key')) {
+    if (rule?.optional === true && e instanceof Neo4jError) {
       return
     }
     throw e
@@ -219,7 +223,7 @@ export function optionalParameterConversion (value: unknown, rule: Rule): unknow
   if (rule.optional === true && value == null) {
     return value
   }
-  return (rule.parameterConversion != null) ? rule.parameterConversion(value) : value
+  return (value != null && rule.parameterConversion != null) ? rule.parameterConversion(value) : value
 }
 
 export function validateAndCleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -23,6 +23,7 @@ import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
 import Vector, { vector } from './vector'
 import { newError } from './error'
+import Integer, { isInt } from './integer'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -96,22 +97,35 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { acceptBigInt?: boolean }} rule Configurations for the rule. If `acceptBigInt` is set to true, the created validate function will allow BigInts through and the convert function will turn BigInts into Numbers.
+   * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule.
+   * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */
-  asNumber (rule?: Rule & { acceptBigInt?: boolean }): Rule { // TODO: RECONSIDER HOW THE NUMBER RULES WORK, GIVEN Integers and Floats. asNumber and asBigInt should probably be asInteger and asFloat
+  asNumber (rule?: Rule & { isInteger?: boolean }): Rule {
     return {
       validate: (value: any, field: string) => {
-        if (typeof value === 'object' && value.low !== undefined && value.high !== undefined && Object.keys(value).length === 2) {
-          throw new TypeError('Number returned as Object. To use asNumber mapping, set disableLosslessIntegers or useBigInt in driver config object')
+        if (isInt(value) && rule?.isInteger !== true) {
+          throw new TypeError('Number returned as Integer Object. To use asNumber mapping with Integers, set "isInteger" in rule configuration.')
         }
-        if (typeof value !== 'number' && (rule?.acceptBigInt !== true || typeof value !== 'bigint')) {
+        if (rule?.isInteger !== true && typeof value === 'bigint') {
+          throw new TypeError('Number returned as BigInt. To use asNumber mapping with integer values, set "isInteger" in rule configuration.')
+        }
+        if (typeof value !== 'number') {
           throw new TypeError(`${field} should be a number but received ${typeof value}`)
         }
       },
-      convert: (value: number | bigint) => {
+      convert: (value: number | bigint | Integer) => {
         if (typeof value === 'bigint') {
           return Number(value)
+        }
+        if (isInt(value)) {
+          return value.toNumber()
+        }
+        return value
+      },
+      parameterConversion: (value: number | bigint | Integer) => {
+        if (rule?.isInteger === true) {
+          return Integer.fromValue(value)
         }
         return value
       },
@@ -129,13 +143,42 @@ export const rule = Object.freeze({
   asBigInt (rule?: Rule & { acceptNumber?: boolean }): Rule {
     return {
       validate: (value: any, field: string) => {
-        if (typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number')) {
+        if (
+          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !(isInt(value))
+        ) {
           throw new TypeError(`${field} should be a bigint but received ${typeof value}`)
         }
       },
-      convert: (value: number | bigint) => {
+      convert: (value: number | bigint | Integer) => {
         if (typeof value === 'number') {
           return BigInt(value)
+        }
+        if (isInt(value)) {
+          return value.toBigInt()
+        }
+        return value
+      },
+      ...rule
+    }
+  },
+  /**
+   * Create a {@link Rule} that validates the value is an {@link Integer}.
+   *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @param {Rule & { acceptNumber?: boolean } | undefined} rule Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the conversion functions will turn Numbers into Integers.
+   * @returns {Rule} A new rule for the value
+   */
+  asInteger (rule?: Rule & { acceptNumber?: boolean }): Rule {
+    return {
+      validate: (value: any, field: string) => {
+        if (typeof value !== 'bigint' && !isInt(value)) {
+          throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
+        }
+      },
+      convert: (value: number | bigint | Integer) => {
+        if (typeof value === 'bigint') {
+          return Integer.fromValue(value)
         }
         return value
       },

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -18,7 +18,7 @@
  */
 
 import { Rule, valueAs, optionalParameterConversion, Rules, defaultNameMapping } from './mapping.highlevel'
-import { JSDate, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
+import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
 import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
 import Vector, { vector } from './vector'
@@ -292,7 +292,7 @@ export const rule = Object.freeze({
     }
     let parameterConversion
     if (rule?.stringify === true) {
-      parameterConversion = (str: string) => Date.fromStandardDateLocal(new JSDate(str))
+      parameterConversion = (str: string) => Date.fromString(str)
     }
     if (rule?.JSNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => Date.fromStandardDateLocal(standardDate)

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -18,7 +18,7 @@
  */
 
 import { Rule, valueAs, optionalParameterConversion, Rules, defaultNameMapping } from './mapping.highlevel'
-import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
+import { StandardDate, isNode, isPath, isRelationship } from './graph-types'
 import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
 import Vector, { isVector, vector } from './vector'
@@ -26,11 +26,15 @@ import { newError } from './error'
 import Integer, { isInt } from './integer'
 
 /**
+ * @property {function(rule: ?Rule)} asBoolean Create a {@link Rule} that validates the value is a Boolean.
+ *
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
  *
- * @property {function(rule: ?Rule & { acceptBigInt?: boolean })} asNumber Create a {@link Rule} that validates the value is a Number.
+ * @property {function(rule: ?Rule & { isInteger?: boolean })} asNumber Create a {@link Rule} that validates the value is a {@link Number}.
  *
- * @property {function(rule: ?Rule & { acceptNumber?: boolean })} AsBigInt Create a {@link Rule} that validates the value is a BigInt.
+ * @property {function(rule: ?Rule & { acceptNumber?: boolean })} asBigInt Create a {@link Rule} that validates the value is a {@link BigInt}.
+ *
+ * @property {function(rule: ?Rule & { acceptNumber?: boolean })} asInteger Create a {@link Rule} that validates the value is an {@link Integer}.
  *
  * @property {function(rule: ?Rule)} asNode Create a {@link Rule} that validates the value is a {@link Node}.
  *
@@ -38,24 +42,25 @@ import Integer, { isInt } from './integer'
  *
  * @property {function(rule: ?Rule)} asPath Create a {@link Rule} that validates the value is a {@link Path}.
  *
+ * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
+ *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asDuration Create a {@link Rule} that validates the value is a {@link Duration}.
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asLocalTime Create a {@link Rule} that validates the value is a {@link LocalTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
- *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asTime Create a {@link Rule} that validates the value is a {@link Time}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean})} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean})} asDate Create a {@link Rule} that validates the value is a {@link Date}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
  *
- * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
  *
  * @property {function(rule: ?Rule & { apply?: Rule })} asList Create a {@link Rule} that validates the value is a List.
  *
- * @property {function(rule: ?Rule & { asTypedList: boolean })} asVector Create a {@link Rule} that validates the value is a List.
+ * @property {function(rule: ?Rule & { asTypedList?: boolean })} asVector Create a {@link Rule} that validates the value is a Vector.
  *
+ * @property {function(rules: Rules)} asObject Create a {@link Rule} for an object, allowing complex mapping of even nested results.
  */
 export const rule = Object.freeze({
   /**
@@ -97,7 +102,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule.
+   * @param {Rule & { isInteger?: boolean }| undefined } rule Configurations for the rule.
    * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */
@@ -137,14 +142,14 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { acceptNumber?: boolean } | undefined} rule Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the convert function will turn Numbers into BigInts.
+          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !isInt(value)
    * @returns {Rule} A new rule for the value
    */
   asBigInt (rule?: Rule & { acceptNumber?: boolean }): Rule {
     return {
       validate: (value: any, field: string) => {
         if (
-          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !(isInt(value))
+          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !isInt(value)
         ) {
           throw new TypeError(`${field} should be a bigint but received ${typeof value}`)
         }
@@ -172,7 +177,7 @@ export const rule = Object.freeze({
   asInteger (rule?: Rule & { acceptNumber?: boolean }): Rule {
     return {
       validate: (value: any, field: string) => {
-        if (typeof value !== 'bigint' && !isInt(value)) {
+        if (typeof value !== 'bigint' && !isInt(value) && !(typeof value === 'number' && rule?.acceptNumber === true)) {
           throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
         }
       },
@@ -200,8 +205,8 @@ export const rule = Object.freeze({
    *  movie: neo4j.rule.asNode({}),
    * }
    *
-   * @param {Rule} rule Configurations for the rule
-   * @returns {Rule} A new rule for the value
+   * @param {Rule | undefined} rule Configurations for the rule
+   * @returns {Rule | undefined} A new rule for the value
    */
   asNode (rule?: Rule): Rule {
     return {
@@ -228,7 +233,7 @@ export const rule = Object.freeze({
    *  employment: neo4j.rule.asRelationship({}),
    * }
    *
-   * @param {Rule} rule Configurations for the rule.
+   * @param {Rule | undefined} rule Configurations for the rule.
    * @returns {Rule} A new rule for the value
    */
   asRelationship (rule?: Rule): Rule {
@@ -242,29 +247,11 @@ export const rule = Object.freeze({
     }
   },
   /**
-   * Create a {@link Rule} that validates the value is an {@link UnboundRelationship}
-   *
-   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
-   *
-   * @param {Rule} rule Configurations for the rule
-   * @returns {Rule} A new rule for the value
-   */
-  asUnboundRelationship (rule?: Rule): Rule {
-    return {
-      validate: (value: any, field: string) => {
-        if (!isUnboundRelationship(value)) {
-          throw new TypeError(`${field} should be a UnboundRelationship but received ${typeof value}`)
-        }
-      },
-      ...rule
-    }
-  },
-  /**
    * Create a {@link Rule} that validates the value is a {@link Path}
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule | undefined} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
   asPath (rule?: Rule): Rule {
@@ -282,7 +269,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule | undefined} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
   asPoint (rule?: Rule): Rule {
@@ -300,7 +287,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
+   * @param {Rule & { stringify?: boolean } | undefined} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asDuration (rule?: Rule & { stringify?: boolean }): Rule {
@@ -321,7 +308,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalTime}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
+   * @param {Rule & { stringify?: boolean } | undefined} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asLocalTime (rule?: Rule & { stringify?: boolean }): Rule {
@@ -342,7 +329,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Time}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
+   * @param {Rule & { stringify?: boolean } | undefined} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asTime (rule?: Rule & { stringify?: boolean }): Rule {
@@ -363,24 +350,24 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Date}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
+   * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean } | undefined} rule Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
    * @returns {Rule} A new rule for the value
    */
-  asDate (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+  asDate (rule?: Rule & { stringify?: boolean, jsNativeDate?: boolean }): Rule {
     if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
     }
-    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
-      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    if (rule?.jsNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, jsNativeDate can not be used in combination with custom conversion functions.')
     }
-    if (rule?.stringify === true && rule?.JSNativeDate === true) {
-      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    if (rule?.stringify === true && rule?.jsNativeDate === true) {
+      throw newError('both stringify and jsNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => Date.fromString(str)
     }
-    if (rule?.JSNativeDate === true) {
+    if (rule?.jsNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => Date.fromStandardDateLocal(standardDate)
     }
     return {
@@ -397,24 +384,24 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalDateTime}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
+   * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean } | undefined} rule Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
    * @returns {Rule} A new rule for the value
    */
-  asLocalDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+  asLocalDateTime (rule?: Rule & { stringify?: boolean, jsNativeDate?: boolean }): Rule {
     if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
     }
-    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
-      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    if (rule?.jsNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, jsNativeDate can not be used in combination with custom conversion functions.')
     }
-    if (rule?.stringify === true && rule?.JSNativeDate === true) {
-      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    if (rule?.stringify === true && rule?.jsNativeDate === true) {
+      throw newError('both stringify and jsNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => LocalDateTime.fromString(str)
     }
-    if (rule?.JSNativeDate === true) {
+    if (rule?.jsNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
     }
     return {
@@ -431,23 +418,23 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
+   * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean } | undefined} rule Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
    */
-  asDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+  asDateTime (rule?: Rule & { stringify?: boolean, jsNativeDate?: boolean }): Rule {
     if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
     }
-    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
-      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    if (rule?.jsNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, jsNativeDate can not be used in combination with custom conversion functions.')
     }
-    if (rule?.stringify === true && rule?.JSNativeDate === true) {
-      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    if (rule?.stringify === true && rule?.jsNativeDate === true) {
+      throw newError('both stringify and jsNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => DateTime.fromString(str)
     }
-    if (rule?.JSNativeDate === true) {
+    if (rule?.jsNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
     }
     return {
@@ -462,7 +449,9 @@ export const rule = Object.freeze({
     }
   },
   /**
-   * Create a {@link Rule} that validates the value is a List. Optionally taking a rule for hydrating the contained values.
+   * Create a {@link Rule} that validates the value is a List.
+   *
+   * Optionally taking a rule for hydrating the contained values.
    *
    * @param {Rule & { apply?: Rule }} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
    * @returns {Rule} A new rule for the value
@@ -473,9 +462,9 @@ export const rule = Object.freeze({
         if (!Array.isArray(list)) {
           throw new TypeError(`${field} should be a list but received ${typeof list}`)
         }
-        if (rule?.apply != null && rule.apply.validate != null) {
-          // @ts-expect-error
-          list.forEach((value, index) => rule.apply.validate(value, `${field}[${index}]`))
+        const validate = rule?.apply?.validate
+        if (validate != null) {
+          list.forEach((value, index) => validate(value, `${field}[${index}]`))
         }
       },
       convert: (list: any[], field: string) => {
@@ -497,10 +486,10 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Vector.
    *
-   * @param {Rule & { asTypedList?: boolean }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
+   * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
    * @returns {Rule} A new rule for the value
    */
-  asVector (rule?: Rule & { asTypedList?: boolean }): Rule {
+  asVector (rule?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }): Rule {
     if (rule?.asTypedList != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, asTypedList can not be used in combination with custom conversion functions.')
     }
@@ -508,6 +497,12 @@ export const rule = Object.freeze({
       validate: (value: any, field: string) => {
         if (!isVector(value)) {
           throw new TypeError(`${field} should be a vector but received ${typeof value}`)
+        }
+        if (rule?.dimension != null && value.asTypedArray().length !== rule.dimension) {
+          throw new TypeError(`${field} should be a vector of length ${rule.dimension} but received length ${value.asTypedArray().length}`)
+        }
+        if (rule?.type != null && value.getType() !== rule.type) {
+          throw new TypeError(`${field} should be a vector of type ${rule.type} but received type ${value.getType()}`)
         }
       },
       convert: (value: Vector<any>) => {
@@ -531,6 +526,7 @@ export const rule = Object.freeze({
   asObject (rules: Rules): Rule {
     return {
       validate: (value: Record<string, Object>, field: string) => {
+        console.error(JSON.stringify(value))
         for (const key in rules) {
           const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
           if (value[mappedKey] == null) {
@@ -538,7 +534,7 @@ export const rule = Object.freeze({
               continue
             } else {
               throw newError(
-                `Mapped Parameter object did not include required field with key ${mappedKey}, 
+                `Mapped Parameter object did not include required field ${field} with key ${mappedKey}, 
                 check provided parameters and parameter rules.`
               )
             }
@@ -570,7 +566,7 @@ export const rule = Object.freeze({
           if (value[key] == null && rules[key].optional === true) {
             continue
           }
-          if (rules[key].parameterConversion != null) {
+          if (value[key] != null && rules[key].parameterConversion != null) {
             convertedValue[mappedKey] = rules[key].parameterConversion(value[key])
           } else {
             convertedValue[mappedKey] = value[key]
@@ -585,11 +581,11 @@ export const rule = Object.freeze({
 
 interface ConvertableToStdDateOrStr { toStandardDate: () => StandardDate, toString: () => string }
 
-function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { stringify?: boolean, JSNativeDate?: boolean }): string | V | StandardDate {
+function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { stringify?: boolean, jsNativeDate?: boolean }): string | V | StandardDate {
   if (rule != null) {
     if (rule.stringify === true) {
       return value.toString()
-    } else if (rule.JSNativeDate === true) {
+    } else if (rule.jsNativeDate === true) {
       return value.toStandardDate()
     }
   }

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import { Rule, valueAs, valueAsParam } from './mapping.highlevel'
-import { StandardDateClass, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
+import { Rule, valueAs, optionalParameterConversion } from './mapping.highlevel'
+import { JSDate, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
 import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
 import Vector, { vector } from './vector'
@@ -250,7 +250,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Duration) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify === true ? (str: string) => Duration.fromString(str) : undefined,
+      parameterConversion: rule?.stringify === true ? (str: string) => Duration.fromString(str) : undefined,
       ...rule
     }
   },
@@ -269,7 +269,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalTime) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify === true ? (str: string) => LocalTime.fromString(str) : undefined,
+      parameterConversion: rule?.stringify === true ? (str: string) => LocalTime.fromString(str) : undefined,
       ...rule
     }
   },
@@ -288,7 +288,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Time) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify === true ? (str: string) => Time.fromString(str) : undefined,
+      parameterConversion: rule?.stringify === true ? (str: string) => Time.fromString(str) : undefined,
       ...rule
     }
   },
@@ -307,7 +307,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Date) => convertStdDate(value, rule),
-      convertToParam: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new StandardDateClass(str)) : undefined,
+      parameterConversion: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new JSDate(str)) : undefined,
       ...rule
     }
   },
@@ -319,12 +319,12 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asLocalDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
-    let convertToParam
+    let parameterConversion
     if (rule?.stringify === true) {
-      convertToParam = (str: string) => LocalDateTime.fromStandardDate(new StandardDateClass(str))
+      parameterConversion = (str: string) => LocalDateTime.fromString(str)
     }
     if (rule?.toStandardDate === true) {
-      convertToParam = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
+      parameterConversion = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
     }
     return {
       validate: (value: any, field: string) => {
@@ -333,7 +333,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalDateTime) => convertStdDate(value, rule),
-      convertToParam,
+      parameterConversion,
       ...rule
     }
   },
@@ -345,12 +345,12 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
-    let convertToParam
+    let parameterConversion
     if (rule?.stringify === true) {
-      convertToParam = (str: string) => DateTime.fromStandardDate(new StandardDateClass(str))
+      parameterConversion = (str: string) => DateTime.fromString(str)
     }
     if (rule?.toStandardDate === true) {
-      convertToParam = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
+      parameterConversion = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
     }
     return {
       validate: (value: any, field: string) => {
@@ -359,7 +359,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: DateTime) => convertStdDate(value, rule),
-      convertToParam,
+      parameterConversion,
       ...rule
     }
   },
@@ -383,9 +383,9 @@ export const rule = Object.freeze({
         }
         return list
       },
-      convertToParam: (list: any[]) => {
+      parameterConversion: (list: any[]) => {
         if (rule?.apply != null) {
-          return list.map((value) => valueAsParam(value, rule.apply))
+          return list.map((value) => optionalParameterConversion(value, rule.apply))
         }
         return list
       },
@@ -412,7 +412,7 @@ export const rule = Object.freeze({
         }
         return value
       },
-      convertToParam: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray) : undefined,
+      parameterConversion: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray) : undefined,
       ...rule
     }
   }

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -76,6 +76,8 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a String.
    *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -92,10 +94,12 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Number}.
    *
-   * @param {Rule & { acceptBigInt?: boolean }} rule Configurations for the rule
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @param {Rule & { acceptBigInt?: boolean }} rule Configurations for the rule. If `acceptBigInt` is set to true, the created validate function will allow BigInts through and the convert function will turn BigInts into Numbers.
    * @returns {Rule} A new rule for the value
    */
-  asNumber (rule?: Rule & { acceptBigInt?: boolean }): Rule {
+  asNumber (rule?: Rule & { acceptBigInt?: boolean }): Rule { // TODO: RECONSIDER HOW THE NUMBER RULES WORK, GIVEN Integers and Floats. asNumber and asBigInt should probably be asInteger and asFloat
     return {
       validate: (value: any, field: string) => {
         if (typeof value === 'object' && value.low !== undefined && value.high !== undefined && Object.keys(value).length === 2) {
@@ -117,7 +121,9 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link BigInt}.
    *
-   * @param {Rule & { acceptNumber?: boolean }} rule Configurations for the rule
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @param {Rule & { acceptNumber?: boolean } | undefined} rule Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the convert function will turn Numbers into BigInts.
    * @returns {Rule} A new rule for the value
    */
   asBigInt (rule?: Rule & { acceptNumber?: boolean }): Rule {
@@ -138,6 +144,8 @@ export const rule = Object.freeze({
   },
   /**
    * Create a {@link Rule} that validates the value is a {@link Node}.
+   *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
    * @example
    * const actingJobsRules: Rules = {
@@ -165,6 +173,18 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Relationship}.
    *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @example
+   * const actingJobsRules: Rules = {
+   *  // Converts the role relationship to a Role object in accordance with provided rules
+   *  role: neo4j.rule.asRelationship({
+   *    convert: (rel: Relationship) => rel.as(Role, roleRules)
+   *  }),
+   *  // Returns the employment relationship as a Relationship
+   *  employment: neo4j.rule.asRelationship({}),
+   * }
+   *
    * @param {Rule} rule Configurations for the rule.
    * @returns {Rule} A new rule for the value
    */
@@ -180,6 +200,8 @@ export const rule = Object.freeze({
   },
   /**
    * Create a {@link Rule} that validates the value is an {@link UnboundRelationship}
+   *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
@@ -197,6 +219,8 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Path}
    *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -212,6 +236,8 @@ export const rule = Object.freeze({
   },
   /**
    * Create a {@link Rule} that validates the value is a {@link Point}
+   *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
@@ -229,10 +255,15 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Duration}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and Durations in the database.
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asDuration (rule?: Rule & { stringify?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isDuration(value)) {
@@ -247,10 +278,13 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalTime}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and LocalTimes in the database.
+   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asLocalTime (rule?: Rule & { stringify?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isLocalTime(value)) {
@@ -265,10 +299,13 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Time}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and Times in the database.
+   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asTime (rule?: Rule & { stringify?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isTime(value)) {
@@ -283,10 +320,16 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Date}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and Dates in the database.
+   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asDate (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
+    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    }
     if (rule?.stringify === true && rule?.JSNativeDate === true) {
       throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
@@ -311,10 +354,16 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalDateTime}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and LocalDateTimes in the database.
+   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asLocalDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
+    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    }
     if (rule?.stringify === true && rule?.JSNativeDate === true) {
       throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
@@ -339,10 +388,15 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and DateTimes in the database.
-   * @returns {Rule} A new rule for the value
+   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
    */
   asDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
+    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    }
     if (rule?.stringify === true && rule?.JSNativeDate === true) {
       throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
@@ -404,6 +458,9 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asVector (rule?: Rule & { asTypedList?: boolean }): Rule {
+    if (rule?.asTypedList != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, asTypedList can not be used in combination with custom conversion functions.')
+    }
     return {
       validate: (value: any, field: string) => {
         if (!(value instanceof Vector)) {
@@ -432,26 +489,33 @@ export const rule = Object.freeze({
     return {
       validate: (value: Record<string, Object>, field: string) => {
         for (const key in rules) {
-          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if (value[mappedkey] == null && rules[key].optional === true) {
-            continue
+          const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          if (value[mappedKey] == null) {
+            if (rules[key].optional === true) {
+              continue
+            } else {
+              throw newError(
+                `Mapped Parameter object did not include required field with key ${mappedKey}, 
+                check provided parameters and parameter rules.`
+              )
+            }
           }
           if (rules[key].validate != null) {
-            rules[key].validate(value[mappedkey], `${field}[${key}]`)
+            rules[key].validate(value[mappedKey], `${field}[${key}]`)
           }
         }
       },
       convert: (value: Record<string, Object>, field: string) => {
         const convertedValue: Record<string, Object> = {}
         for (const key in rules) {
-          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
           if (value[key] == null && rules[key].optional === true) {
             continue
           }
           if (rules[key].convert != null) {
-            convertedValue[key] = rules[key].convert(value[mappedkey], `${field}[${mappedkey}]`)
+            convertedValue[key] = rules[key].convert(value[mappedKey], `${field}[${mappedKey}]`)
           } else {
-            convertedValue[key] = value[mappedkey]
+            convertedValue[key] = value[mappedKey]
           }
         }
         return convertedValue
@@ -459,14 +523,14 @@ export const rule = Object.freeze({
       parameterConversion: (value: Record<string, Object>) => {
         const convertedValue: Record<string, Object> = {}
         for (const key in rules) {
-          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
           if (value[key] == null && rules[key].optional === true) {
             continue
           }
           if (rules[key].parameterConversion != null) {
-            convertedValue[mappedkey] = rules[key].parameterConversion(value[key])
+            convertedValue[mappedKey] = rules[key].parameterConversion(value[key])
           } else {
-            convertedValue[mappedkey] = value[key]
+            convertedValue[mappedKey] = value[key]
           }
         }
         return convertedValue

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -420,6 +420,7 @@ export const rule = Object.freeze({
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
    * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean } | undefined} rule Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
+   * @returns {Rule} A new rule for the value
    */
   asDateTime (rule?: Rule & { stringify?: boolean, jsNativeDate?: boolean }): Rule {
     if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -17,11 +17,12 @@
  * limitations under the License.
  */
 
-import { Rule, valueAs, optionalParameterConversion } from './mapping.highlevel'
+import { Rule, valueAs, optionalParameterConversion, Rules, defaultNameMapping } from './mapping.highlevel'
 import { JSDate, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
 import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
 import Vector, { vector } from './vector'
+import { newError } from './error'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -40,13 +41,13 @@ import Vector, { vector } from './vector'
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asLocalTime Create a {@link Rule} that validates the value is a {@link LocalTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asTime Create a {@link Rule} that validates the value is a {@link Time}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean})} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean})} asDate Create a {@link Rule} that validates the value is a {@link Date}.
  *
  * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
  *
@@ -228,7 +229,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Duration}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and Durations in the database.
    * @returns {Rule} A new rule for the value
    */
   asDuration (rule?: Rule & { stringify?: boolean }): Rule {
@@ -246,7 +247,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalTime}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and LocalTimes in the database.
    * @returns {Rule} A new rule for the value
    */
   asLocalTime (rule?: Rule & { stringify?: boolean }): Rule {
@@ -264,7 +265,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Time}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and Times in the database.
    * @returns {Rule} A new rule for the value
    */
   asTime (rule?: Rule & { stringify?: boolean }): Rule {
@@ -282,10 +283,20 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Date}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and Dates in the database.
    * @returns {Rule} A new rule for the value
    */
-  asDate (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+  asDate (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify === true && rule?.JSNativeDate === true) {
+      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    }
+    let parameterConversion
+    if (rule?.stringify === true) {
+      parameterConversion = (str: string) => Date.fromStandardDateLocal(new JSDate(str))
+    }
+    if (rule?.JSNativeDate === true) {
+      parameterConversion = (standardDate: StandardDate) => Date.fromStandardDateLocal(standardDate)
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isDate(value)) {
@@ -293,22 +304,25 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Date) => convertStdDate(value, rule),
-      parameterConversion: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new JSDate(str)) : undefined,
+      parameterConversion,
       ...rule
     }
   },
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalDateTime}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and LocalDateTimes in the database.
    * @returns {Rule} A new rule for the value
    */
-  asLocalDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+  asLocalDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify === true && rule?.JSNativeDate === true) {
+      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => LocalDateTime.fromString(str)
     }
-    if (rule?.toStandardDate === true) {
+    if (rule?.JSNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
     }
     return {
@@ -325,15 +339,18 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and DateTimes in the database.
    * @returns {Rule} A new rule for the value
    */
-  asDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+  asDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify === true && rule?.JSNativeDate === true) {
+      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => DateTime.fromString(str)
     }
-    if (rule?.toStandardDate === true) {
+    if (rule?.JSNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
     }
     return {
@@ -350,14 +367,18 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a List. Optionally taking a rule for hydrating the contained values.
    *
-   * @param {Rule & { apply?: Rule }} rule Configurations for the rule
+   * @param {Rule & { apply?: Rule }} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
    * @returns {Rule} A new rule for the value
    */
   asList (rule?: Rule & { apply?: Rule }): Rule {
     return {
-      validate: (value: any, field: string) => {
-        if (!Array.isArray(value)) {
-          throw new TypeError(`${field} should be a list but received ${typeof value}`)
+      validate: (list: any, field: string) => {
+        if (!Array.isArray(list)) {
+          throw new TypeError(`${field} should be a list but received ${typeof list}`)
+        }
+        if (rule?.apply != null && rule.apply.validate != null) {
+          // @ts-expect-error
+          list.forEach((value, index) => rule.apply.validate(value, `${field}[${index}]`))
         }
       },
       convert: (list: any[], field: string) => {
@@ -367,8 +388,9 @@ export const rule = Object.freeze({
         return list
       },
       parameterConversion: (list: any[]) => {
-        if (rule?.apply != null) {
-          return list.map((value) => optionalParameterConversion(value, rule.apply))
+        const apply = rule?.apply
+        if (apply != null) {
+          return list.map((value) => optionalParameterConversion(value, apply))
         }
         return list
       },
@@ -378,7 +400,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Vector.
    *
-   * @param {Rule & { asTypedList?: boolean }} rule Configurations for the rule
+   * @param {Rule & { asTypedList?: boolean }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
    * @returns {Rule} A new rule for the value
    */
   asVector (rule?: Rule & { asTypedList?: boolean }): Rule {
@@ -397,16 +419,70 @@ export const rule = Object.freeze({
       parameterConversion: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray) : undefined,
       ...rule
     }
+  },
+  /**
+   * Create a {@link Rule} for an object, allowing complex mapping of even nested results
+   *
+   * NOTE: When using this rule, object identifiers will be mapped according to any name mapping set with neo4j.RecordObjectMapping.translateIdentifiers.
+   *
+   * @param {Rules} rules rules for the fields of the object.
+   * @returns {Rule} A new rule for the value
+   */
+  asObject (rules: Rules): Rule {
+    return {
+      validate: (value: Record<string, Object>, field: string) => {
+        for (const key in rules) {
+          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          if (value[mappedkey] == null && rules[key].optional === true) {
+            continue
+          }
+          if (rules[key].validate != null) {
+            rules[key].validate(value[mappedkey], `${field}[${key}]`)
+          }
+        }
+      },
+      convert: (value: Record<string, Object>, field: string) => {
+        const convertedValue: Record<string, Object> = {}
+        for (const key in rules) {
+          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          if (value[key] == null && rules[key].optional === true) {
+            continue
+          }
+          if (rules[key].convert != null) {
+            convertedValue[key] = rules[key].convert(value[mappedkey], `${field}[${mappedkey}]`)
+          } else {
+            convertedValue[key] = value[mappedkey]
+          }
+        }
+        return convertedValue
+      },
+      parameterConversion: (value: Record<string, Object>) => {
+        const convertedValue: Record<string, Object> = {}
+        for (const key in rules) {
+          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          if (value[key] == null && rules[key].optional === true) {
+            continue
+          }
+          if (rules[key].parameterConversion != null) {
+            convertedValue[mappedkey] = rules[key].parameterConversion(value[key])
+          } else {
+            convertedValue[mappedkey] = value[key]
+          }
+        }
+        return convertedValue
+      },
+      ...rule
+    }
   }
 })
 
 interface ConvertableToStdDateOrStr { toStandardDate: () => StandardDate, toString: () => string }
 
-function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { stringify?: boolean, toStandardDate?: boolean }): string | V | StandardDate {
+function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { stringify?: boolean, JSNativeDate?: boolean }): string | V | StandardDate {
   if (rule != null) {
     if (rule.stringify === true) {
       return value.toString()
-    } else if (rule.toStandardDate === true) {
+    } else if (rule.JSNativeDate === true) {
       return value.toStandardDate()
     }
   }

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -17,11 +17,13 @@
  * limitations under the License.
  */
 
-import { Rule, valueAs } from './mapping.highlevel'
+import { Rule, valueAs, valueAsParam } from './mapping.highlevel'
 import { StandardDateClass, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
 import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
 import Vector, { vector } from './vector'
+import { newError } from './error'
+import Integer, { int, isInt } from './integer'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -29,6 +31,8 @@ import Vector, { vector } from './vector'
  * @property {function(rule: ?Rule & { acceptBigInt?: boolean })} asNumber Create a {@link Rule} that validates the value is a Number.
  *
  * @property {function(rule: ?Rule & { acceptNumber?: boolean })} AsBigInt Create a {@link Rule} that validates the value is a BigInt.
+ *
+ * @property {function(rule: ?Rule & { asNumber?: boolean, asBigInt?: boolean })} AsInteger Create a {@link Rule} that validates the value is an Integer.
  *
  * @property {function(rule: ?Rule)} asNode Create a {@link Rule} that validates the value is a {@link Node}.
  *
@@ -136,6 +140,44 @@ export const rule = Object.freeze({
           return BigInt(value)
         }
         return value
+      },
+      ...rule
+    }
+  },
+  /**
+   * Create a {@link Rule} that validates the value is an {@link Integer}.
+   *
+   * @experimental Part of the Record Object Mapping preview feature
+   * @param {Rule & { asNumber?: boolean, asBigInt?: boolean }} rule Configurations for the rule
+   * @returns {Rule} A new rule for the value
+   */
+  asInteger (rule?: Rule & { asNumber?: boolean, asBigInt?: boolean }): Rule {
+    if (rule?.asNumber === true && rule.asBigInt === true) {
+      throw newError('Cannot set both asNumber and asBigInt in a asInteger rule')
+    }
+    return {
+      validate: (value: any, field: string) => {
+        if (!isInt(value)) {
+          throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
+        }
+      },
+      convert: (value: Integer) => {
+        if (rule?.asNumber === true) {
+          return value.low
+        }
+        if (rule?.asBigInt === true) {
+          return value.toBigInt()
+        }
+        return value
+      },
+      convertToParam: (objectValue: any) => {
+        if (rule?.asNumber === true) {
+          return int(objectValue)
+        }
+        if (rule?.asBigInt === true) {
+          return int(objectValue)
+        }
+        return objectValue
       },
       ...rule
     }
@@ -380,6 +422,12 @@ export const rule = Object.freeze({
       convert: (list: any[], field: string) => {
         if (rule?.apply != null) {
           return list.map((value, index) => valueAs(value, `${field}[${index}]`, rule.apply))
+        }
+        return list
+      },
+      convertToParam: (list: any[]) => {
+        if (rule?.apply != null) {
+          return list.map((value) => valueAsParam(value, rule.apply))
         }
         return list
       },

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -18,10 +18,10 @@
  */
 
 import { Rule, valueAs } from './mapping.highlevel'
-import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
+import { StandardDateClass, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
 import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
-import Vector from './vector'
+import Vector, { vector } from './vector'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -250,6 +250,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Duration) => rule?.stringify === true ? value.toString() : value,
+      convertToParam: rule?.stringify === true ? (str: string) => Duration.fromString(str) : undefined,
       ...rule
     }
   },
@@ -268,6 +269,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalTime) => rule?.stringify === true ? value.toString() : value,
+      convertToParam: rule?.stringify === true ? (str: string) => LocalTime.fromString(str) : undefined,
       ...rule
     }
   },
@@ -286,6 +288,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Time) => rule?.stringify === true ? value.toString() : value,
+      convertToParam: rule?.stringify === true ? (str: string) => Time.fromString(str) : undefined,
       ...rule
     }
   },
@@ -304,6 +307,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Date) => convertStdDate(value, rule),
+      convertToParam: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new StandardDateClass(str)) : undefined,
       ...rule
     }
   },
@@ -315,6 +319,13 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asLocalDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+    let convertToParam
+    if (rule?.stringify === true) {
+      convertToParam = (str: string) => LocalDateTime.fromStandardDate(new StandardDateClass(str))
+    }
+    if (rule?.toStandardDate === true) {
+      convertToParam = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isLocalDateTime(value)) {
@@ -322,6 +333,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalDateTime) => convertStdDate(value, rule),
+      convertToParam,
       ...rule
     }
   },
@@ -333,6 +345,13 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+    let convertToParam
+    if (rule?.stringify === true) {
+      convertToParam = (str: string) => DateTime.fromStandardDate(new StandardDateClass(str))
+    }
+    if (rule?.toStandardDate === true) {
+      convertToParam = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isDateTime(value)) {
@@ -340,6 +359,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: DateTime) => convertStdDate(value, rule),
+      convertToParam,
       ...rule
     }
   },
@@ -386,6 +406,7 @@ export const rule = Object.freeze({
         }
         return value
       },
+      convertToParam: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray) : undefined,
       ...rule
     }
   }

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -40,6 +40,8 @@ import Integer, { isInt } from './integer'
  *
  * @property {function(rule: ?Rule)} asRelationship Create a {@link Rule} that validates the value is a {@link Relationship}.
  *
+ * @property {function(rule: ?Rule)} asUnboundRelationship Create a {@link Rule} that validates the value is an {@link UnboundRelationship}.
+ *
  * @property {function(rule: ?Rule)} asPath Create a {@link Rule} that validates the value is a {@link Path}.
  *
  * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
@@ -50,15 +52,15 @@ import Integer, { isInt } from './integer'
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asTime Create a {@link Rule} that validates the value is a {@link Time}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
  *
  * @property {function(rule: ?Rule & { apply?: Rule })} asList Create a {@link Rule} that validates the value is a List.
  *
- * @property {function(rule: ?Rule & { asTypedList?: boolean })} asVector Create a {@link Rule} that validates the value is a Vector.
+ * @property {function(rule: ?Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64" })} asVector Create a {@link Rule} that validates the value is a Vector.
  *
  * @property {function(rules: Rules)} asObject Create a {@link Rule} for an object, allowing complex mapping of even nested results.
  */
@@ -66,7 +68,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Boolean.
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule | undefined} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
   asBoolean (rule?: Rule): Rule {
@@ -84,7 +86,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule | undefined} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
   asString (rule?: Rule): Rule {
@@ -102,7 +104,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { isInteger?: boolean }| undefined } rule Configurations for the rule.
+   * @param {Rule & { isInteger?: boolean } | undefined } rule Configurations for the rule.
    * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */
@@ -142,7 +144,6 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !isInt(value)
    * @returns {Rule} A new rule for the value
    */
   asBigInt (rule?: Rule & { acceptNumber?: boolean }): Rule {
@@ -206,7 +207,7 @@ export const rule = Object.freeze({
    * }
    *
    * @param {Rule | undefined} rule Configurations for the rule
-   * @returns {Rule | undefined} A new rule for the value
+   * @returns {Rule} A new rule for the value
    */
   asNode (rule?: Rule): Rule {
     return {
@@ -453,7 +454,7 @@ export const rule = Object.freeze({
    *
    * Optionally taking a rule for hydrating the contained values.
    *
-   * @param {Rule & { apply?: Rule }} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
+   * @param {Rule & { apply?: Rule } | undefined} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
    * @returns {Rule} A new rule for the value
    */
   asList (rule?: Rule & { apply?: Rule }): Rule {
@@ -486,7 +487,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Vector.
    *
-   * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
+   * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' } | undefined} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
    * @returns {Rule} A new rule for the value
    */
   asVector (rule?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }): Rule {
@@ -526,7 +527,6 @@ export const rule = Object.freeze({
   asObject (rules: Rules): Rule {
     return {
       validate: (value: Record<string, Object>, field: string) => {
-        console.error(JSON.stringify(value))
         for (const key in rules) {
           const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
           if (value[mappedKey] == null) {
@@ -548,10 +548,7 @@ export const rule = Object.freeze({
         const convertedValue: Record<string, Object> = {}
         for (const key in rules) {
           const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if (value[key] == null && rules[key].optional === true) {
-            continue
-          }
-          if (rules[key].convert != null) {
+          if (value[mappedKey] != null && rules[key].convert != null) {
             convertedValue[key] = rules[key].convert(value[mappedKey], `${field}[${mappedKey}]`)
           } else {
             convertedValue[key] = value[mappedKey]
@@ -563,9 +560,6 @@ export const rule = Object.freeze({
         const convertedValue: Record<string, Object> = {}
         for (const key in rules) {
           const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if (value[key] == null && rules[key].optional === true) {
-            continue
-          }
           if (value[key] != null && rules[key].parameterConversion != null) {
             convertedValue[mappedKey] = rules[key].parameterConversion(value[key])
           } else {

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -30,8 +30,6 @@ import Vector, { vector } from './vector'
  *
  * @property {function(rule: ?Rule & { acceptNumber?: boolean })} AsBigInt Create a {@link Rule} that validates the value is a BigInt.
  *
- * @property {function(rule: ?Rule & { asNumber?: boolean, asBigInt?: boolean })} AsInteger Create a {@link Rule} that validates the value is an Integer.
- *
  * @property {function(rule: ?Rule)} asNode Create a {@link Rule} that validates the value is a {@link Node}.
  *
  * @property {function(rule: ?Rule)} asRelationship Create a {@link Rule} that validates the value is a {@link Relationship}.

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -22,8 +22,6 @@ import { StandardDateClass, StandardDate, isNode, isPath, isRelationship, isUnbo
 import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
 import Vector, { vector } from './vector'
-import { newError } from './error'
-import Integer, { int, isInt } from './integer'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -140,44 +138,6 @@ export const rule = Object.freeze({
           return BigInt(value)
         }
         return value
-      },
-      ...rule
-    }
-  },
-  /**
-   * Create a {@link Rule} that validates the value is an {@link Integer}.
-   *
-   * @experimental Part of the Record Object Mapping preview feature
-   * @param {Rule & { asNumber?: boolean, asBigInt?: boolean }} rule Configurations for the rule
-   * @returns {Rule} A new rule for the value
-   */
-  asInteger (rule?: Rule & { asNumber?: boolean, asBigInt?: boolean }): Rule {
-    if (rule?.asNumber === true && rule.asBigInt === true) {
-      throw newError('Cannot set both asNumber and asBigInt in a asInteger rule')
-    }
-    return {
-      validate: (value: any, field: string) => {
-        if (!isInt(value)) {
-          throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
-        }
-      },
-      convert: (value: Integer) => {
-        if (rule?.asNumber === true) {
-          return value.low
-        }
-        if (rule?.asBigInt === true) {
-          return value.toBigInt()
-        }
-        return value
-      },
-      convertToParam: (objectValue: any) => {
-        if (rule?.asNumber === true) {
-          return int(objectValue)
-        }
-        if (rule?.asBigInt === true) {
-          return int(objectValue)
-        }
-        return objectValue
       },
       ...rule
     }

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -40,8 +40,6 @@ import Integer, { isInt } from './integer'
  *
  * @property {function(rule: ?Rule)} asRelationship Create a {@link Rule} that validates the value is a {@link Relationship}.
  *
- * @property {function(rule: ?Rule)} asUnboundRelationship Create a {@link Rule} that validates the value is an {@link UnboundRelationship}.
- *
  * @property {function(rule: ?Rule)} asPath Create a {@link Rule} that validates the value is a {@link Path}.
  *
  * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
@@ -52,11 +50,11 @@ import Integer, { isInt } from './integer'
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asTime Create a {@link Rule} that validates the value is a {@link Time}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
  *
  * @property {function(rule: ?Rule & { apply?: Rule })} asList Create a {@link Rule} that validates the value is a List.
  *
@@ -104,7 +102,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { isInteger?: boolean } | undefined } rule Configurations for the rule.
+   * @param {Rule & { isInteger?: boolean } | undefined} rule Configurations for the rule.
    * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -54,13 +54,11 @@ import Vector, { vector } from './vector'
  *
  * @property {function(rule: ?Rule & { asTypedList: boolean })} asVector Create a {@link Rule} that validates the value is a List.
  *
- * @experimental Part of the Record Object Mapping preview feature
  */
 export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Boolean.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -77,7 +75,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a String.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -94,7 +91,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Number}.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule & { acceptBigInt?: boolean }} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -120,7 +116,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link BigInt}.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule & { acceptNumber?: boolean }} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -153,7 +148,6 @@ export const rule = Object.freeze({
    *  movie: neo4j.rule.asNode({}),
    * }
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -170,7 +164,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Relationship}.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule.
    * @returns {Rule} A new rule for the value
    */
@@ -187,7 +180,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is an {@link UnboundRelationship}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -204,7 +196,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Path}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -221,7 +212,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Point}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -238,7 +228,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Duration}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -257,7 +246,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalTime}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -276,7 +264,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Time}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -295,7 +282,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Date}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -314,7 +300,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalDateTime}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -340,7 +325,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -366,7 +350,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a List. Optionally taking a rule for hydrating the contained values.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule & { apply?: Rule }} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -395,7 +378,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Vector.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule & { asTypedList?: boolean }} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */

--- a/packages/core/src/mapping.rulesfactories.ts
+++ b/packages/core/src/mapping.rulesfactories.ts
@@ -21,7 +21,7 @@ import { Rule, valueAs, optionalParameterConversion, Rules, defaultNameMapping }
 import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types'
 import { isPoint } from './spatial-types'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types'
-import Vector, { vector } from './vector'
+import Vector, { isVector, vector } from './vector'
 import { newError } from './error'
 import Integer, { isInt } from './integer'
 
@@ -506,7 +506,7 @@ export const rule = Object.freeze({
     }
     return {
       validate: (value: any, field: string) => {
-        if (!(value instanceof Vector)) {
+        if (!isVector(value)) {
           throw new TypeError(`${field} should be a vector but received ${typeof value}`)
         }
       },

--- a/packages/core/src/result-transformers.ts
+++ b/packages/core/src/result-transformers.ts
@@ -294,7 +294,6 @@ class ResultTransformers {
    *
    * @returns {ResultTransformer<ResultSummary<T>>} The result transformer
    * @see {@link Driver#executeQuery}
-   * @experimental Part of the Record Object Mapping preview feature
    */
   hydrated <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }> {
     return async result => await result.as(constructorOrRules as unknown as GenericConstructor<T>, rules).then()

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -46,7 +46,6 @@ type ManagedTransactionWork<T> = (tx: ManagedTransaction) => Promise<T> | T
 interface TransactionConfig {
   timeout?: NumberOrInteger
   metadata?: object
-  parameterRules?: Rules
 }
 
 /**
@@ -183,7 +182,7 @@ class Session {
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
-   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object .
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @return {Result} New Result.
    */
   run<R extends RecordShape = RecordShape> (

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -183,6 +183,7 @@ class Session {
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object .
    * @return {Result} New Result.
    */
   run<R extends RecordShape = RecordShape> (

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -38,6 +38,7 @@ import { RecordShape } from './record'
 import NotificationFilter from './notification-filter'
 import { Logger } from './internal/logger'
 import { cacheKey } from './internal/auth-util'
+import { Rules } from './mapping.highlevel'
 
 type ConnectionConsumer<T> = (connection: Connection) => Promise<T> | T
 type ManagedTransactionWork<T> = (tx: ManagedTransaction) => Promise<T> | T
@@ -45,6 +46,7 @@ type ManagedTransactionWork<T> = (tx: ManagedTransaction) => Promise<T> | T
 interface TransactionConfig {
   timeout?: NumberOrInteger
   metadata?: object
+  parameterRules?: Rules
 }
 
 /**
@@ -186,11 +188,13 @@ class Session {
   run<R extends RecordShape = RecordShape> (
     query: Query,
     parameters?: any,
-    transactionConfig?: TransactionConfig
+    transactionConfig?: TransactionConfig,
+    parameterRules?: Rules
   ): Result<R> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
-      parameters
+      parameters,
+      { parameterRules }
     )
     const autoCommitTxConfig = (transactionConfig != null)
       ? new TxConfig(transactionConfig, this._log)

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -182,7 +182,7 @@ class Session {
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
-   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
+   * @param {Rules} [parameterRules] - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @return {Result} New Result.
    */
   run<R extends RecordShape = RecordShape> (

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -1008,6 +1008,6 @@ function parseDurationNanos (str: string): number {
 
 function checkDurationFieldIsInt (value: number, field: string): void {
   if (!Number.isInteger(value)) {
-    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds. `)
+    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds.`)
   }
 }

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -894,7 +894,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     const values = String(str.replace(/,/g, '.')).match(
       new RegExp(
         /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?/.source + // DateTime
-        /([Z|z]|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?)?(?:\[([^\]]*)\])?$/.source // Timezone
+        /([Z|z]|\+|-)?(?:(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?)?(?:\[([^\]]*)\])?$/.source // Timezone
       )
     )
     if (values === null) {

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -101,7 +101,7 @@ export class Duration<T extends NumberOrInteger = Integer> {
    * @returns {Duration<NumberOrInteger>}
    */
   static fromString (str: string): Duration<NumberOrInteger> {
-    const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
+    const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T?(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
     if (matches !== null) {
       const dur = new Duration(
         ~~parseInt(matches[1]) * 12 + ~~parseInt(matches[2]),
@@ -661,7 +661,7 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
         Math.round(parseFloat('0' + values[7]) * 10 ** 9)
       )
     }
-    throw newError('Time could not be parsed from string')
+    throw newError('LocalDateTime could not be parsed from string')
   }
 }
 
@@ -867,11 +867,11 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         parseInt(values[4]),
         parseInt(values[5]),
         parseInt(values[6]),
-        Math.round(parseFloat('0.' + values[7]) * 10 ** 9),
-        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt(values[11]))
+        Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))
       )
     }
-    throw newError('Time could not be parsed from string')
+    throw newError('DateTime could not be parsed from string')
   }
 
   /**

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -109,26 +109,26 @@ export class Duration<T extends NumberOrInteger = Integer> {
       /^([-|+]?)[P|p](?:(-?\d*\.?\d*)[Y|y])?(?:(-?\d*\.?\d*)[M|m])?(?:(-?\d*\.?\d*)[W|w])?(?:(-?\d*\.?\d*)[D|d])?/.source + // Date portion
       /([T|t](?:(-?\d*\.?\d*)[H|h])?(?:(-?\d*\.?\d*)[M|m])?(?:(-)?(\d*)(\.\d*)?[S|s])?)?$/.source // Time portion
     ))
-    if (matches !== null) {
-      if (
-        matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null &&
-        matches[7] == null && matches[8] == null && matches[10] == null && matches[11] == null
-      ) {
-        throw newError(`Duration could not be parsed from string: ${str}`)
-      }
-      const negativeDuration = matches[1] === '-' ? -1 : 1
-      const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
-      const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
-      const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
-      const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'))
-      const nanos = negativeDuration * parseDurationNanos((matches[9] ?? '') + '0' + (matches[11] ?? ''))
-      checkDurationFieldIsInt(months, 'Months')
-      checkDurationFieldIsInt(days, 'Days')
-      checkDurationFieldIsInt(hoursAndMinutes, 'Seconds')
-      checkDurationFieldIsInt(nanos, 'Nanoseconds')
-      return new Duration(int(months), int(days), int(BigInt(negativeDuration) * (BigInt(hoursAndMinutes) + seconds.toBigInt())), int(nanos))
+    if (matches === null) {
+      throw newError(`Duration could not be parsed from string: ${str}`)
     }
-    throw newError(`Duration could not be parsed from string: ${str}`)
+    if (
+      matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null &&
+      matches[7] == null && matches[8] == null && matches[10] == null && matches[11] == null
+    ) {
+      throw newError(`Duration could not be parsed from string: ${str}`)
+    }
+    const negativeDuration = matches[1] === '-' ? -1 : 1
+    const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
+    const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
+    const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
+    const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'))
+    const nanos = negativeDuration * parseDurationNanos((matches[9] ?? '') + '0' + (matches[11] ?? ''))
+    checkDurationFieldIsInt(months, 'Months')
+    checkDurationFieldIsInt(days, 'Days')
+    checkDurationFieldIsInt(hoursAndMinutes, 'Seconds')
+    checkDurationFieldIsInt(nanos, 'Nanoseconds')
+    return new Duration(int(months), int(days), int(BigInt(negativeDuration) * (BigInt(hoursAndMinutes) + seconds.toBigInt())), int(nanos))
   }
 
   /**
@@ -249,16 +249,16 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
    */
   static fromString (str: string): LocalTime {
     const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?$/)
-    if (values !== null) {
-      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
-      return new LocalTime(
-        hours,
-        minutes,
-        seconds,
-        nanoseconds
-      )
+    if (values === null) {
+      throw newError('LocalTime could not be parsed from string')
     }
-    throw newError('LocalTime could not be parsed from string')
+    const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
+    return new LocalTime(
+      hours,
+      minutes,
+      seconds,
+      nanoseconds
+    )
   }
 }
 
@@ -375,36 +375,36 @@ export class Time<T extends NumberOrInteger = Integer> {
    *
    * @param {string} str The string to convert
    * @returns {Time}
-   */
+  */
   static fromString (str: string): Time {
     const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
-    if (values !== null) {
-      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
-      if (values[5] === 'Z') {
-        return new Time(
-          hours,
-          minutes,
-          seconds,
-          nanoseconds,
-          int(0)
-        )
-      }
-      if (values[6] == null) {
-        throw newError('Error parsing timezone offset.')
-      }
+    if (values === null) {
+      throw newError('Time could not be parsed from string')
+    }
+    const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
+    if (values[5] === 'Z') {
       return new Time(
         hours,
         minutes,
         seconds,
         nanoseconds,
-        int((values[5] === '+' ? 1 : -1) * (
-          parseTemporalInt(values[6]).toInt() * 3600 + // timezone offset hours
-          parseTemporalInt(values[7]).toInt() * 60 + // timezone offset minutes
-          parseTemporalInt(values[8]).toInt() // timezone offset seconds
-        ))
+        int(0)
       )
     }
-    throw newError('Time could not be parsed from string')
+    if (values[6] == null) {
+      throw newError('Error parsing timezone offset.')
+    }
+    return new Time(
+      hours,
+      minutes,
+      seconds,
+      nanoseconds,
+      int((values[5] === '+' ? 1 : -1) * (
+        parseTemporalInt(values[6]).toInt() * 3600 + // timezone offset hours
+        parseTemporalInt(values[7]).toInt() * 60 + // timezone offset minutes
+        parseTemporalInt(values[8]).toInt() // timezone offset seconds
+      ))
+    )
   }
 }
 
@@ -543,14 +543,14 @@ export class Date<T extends NumberOrInteger = Integer> {
    */
   static fromString (str: string): Date {
     const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})$/)
-    if (values !== null) {
-      return new Date(
-        parseTemporalInt(values[1]), // years
-        parseTemporalInt(values[2]), // months
-        parseTemporalInt(values[3]) // days
-      )
+    if (values === null) {
+      throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\' or \'[+|-]YYYYY-MM-DD\'')
     }
-    throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\' or \'[+|-]YYYYY-MM-DD\'')
+    return new Date(
+      parseTemporalInt(values[1]), // years
+      parseTemporalInt(values[2]), // months
+      parseTemporalInt(values[3]) // days
+    )
   }
 }
 
@@ -694,19 +694,19 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
    */
   static fromString (str: string): LocalDateTime {
     const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?$/)
-    if (values !== null) {
-      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
-      return new LocalDateTime(
-        parseTemporalInt(values[1]), // years
-        parseTemporalInt(values[2]), // months
-        parseTemporalInt(values[3]), // days
-        hours,
-        minutes,
-        seconds,
-        nanoseconds
-      )
+    if (values === null) {
+      throw newError('LocalDateTime could not be parsed from string')
     }
-    throw newError('LocalDateTime could not be parsed from string')
+    const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
+    return new LocalDateTime(
+      parseTemporalInt(values[1]), // years
+      parseTemporalInt(values[2]), // months
+      parseTemporalInt(values[3]), // days
+      hours,
+      minutes,
+      seconds,
+      nanoseconds
+    )
   }
 }
 
@@ -897,47 +897,48 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?((\[)([^\]]*)(\]))?$/.source // Timezone
       )
     )
-    if (values !== null) {
-      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
-      if (values[8] === 'Z') {
-        return new DateTime(
-          parseTemporalInt(values[1]), // years
-          parseTemporalInt(values[2]), // months
-          parseTemporalInt(values[3]), // days
-          hours,
-          minutes,
-          seconds,
-          nanoseconds,
-          int(0)
-        )
-      }
-      if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
-        return new DateTime(
-          parseTemporalInt(values[1]), // years
-          parseTemporalInt(values[2]), // months
-          parseTemporalInt(values[3]), // days
-          hours,
-          minutes,
-          seconds,
-          nanoseconds,
-          int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
-        )
-      }
-      if (values[14] !== undefined) {
-        return new DateTime(
-          parseTemporalInt(values[1]), // years
-          parseTemporalInt(values[2]), // months
-          parseTemporalInt(values[3]), // days
-          hours,
-          minutes,
-          seconds,
-          nanoseconds,
-          undefined,
-          values[14]
-        )
-      }
+    if (values === null) {
+      throw newError('DateTime could not be parsed from string')
     }
-    throw newError('DateTime could not be parsed from string')
+    const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
+    if (values[8] === 'Z') {
+      return new DateTime(
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]), // days
+        hours,
+        minutes,
+        seconds,
+        nanoseconds,
+        int(0)
+      )
+    }
+    if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
+      return new DateTime(
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]), // days
+        hours,
+        minutes,
+        seconds,
+        nanoseconds,
+        int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
+      )
+    }
+    if (values[14] !== undefined) {
+      return new DateTime(
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]), // days
+        hours,
+        minutes,
+        seconds,
+        nanoseconds,
+        undefined,
+        values[14]
+      )
+    }
+    throw newError('DateTime could not be parsed from string, provided string needs either timezoneId or offset')
   }
 
   /**

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -849,7 +849,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
    * @returns {DateTime<NumberOrInteger>}
    */
   static fromString (str: string): DateTime<NumberOrInteger> {
-    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)?(\[)?([^\]]*)?(\])?/)
     if (values !== null) {
       if (values[8] === 'Z') {
         return new DateTime(
@@ -863,16 +863,31 @@ export class DateTime<T extends NumberOrInteger = Integer> {
           0
         )
       }
-      return new DateTime(
-        parseInt(values[1]),
-        parseInt(values[2]),
-        parseInt(values[3]),
-        parseInt(values[4]),
-        parseInt(values[5]),
-        parseInt(values[6]),
-        Math.round(parseFloat('0' + values[7]) * 10 ** 9),
-        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))
-      )
+      if (values[8] === '+' || values[8] === '-') {
+        return new DateTime(
+          parseInt(values[1]),
+          parseInt(values[2]),
+          parseInt(values[3]),
+          parseInt(values[4]),
+          parseInt(values[5]),
+          parseInt(values[6]),
+          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+          (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))
+        )
+      }
+      if (values[13] !== undefined) {
+        return new DateTime(
+          parseInt(values[1]),
+          parseInt(values[2]),
+          parseInt(values[3]),
+          parseInt(values[4]),
+          parseInt(values[5]),
+          parseInt(values[6]),
+          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+          undefined,
+          values[13]
+        )
+      }
     }
     throw newError('DateTime could not be parsed from string')
   }
@@ -1008,6 +1023,6 @@ function parseDurationNanos (str: string): number {
 
 function checkDurationFieldIsInt (value: number, field: string): void {
   if (!Number.isInteger(value)) {
-    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds.`)
+    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can only send durations which can be simplified to integer values of months, days, seconds and nanoseconds.`)
   }
 }

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -525,6 +525,24 @@ export class Date<T extends NumberOrInteger = Integer> {
   toString (): string {
     return util.dateToIsoString(this.year, this.month, this.day)
   }
+
+  /**
+   * Creates a {@link Date} from an ISO 8601 string
+   *
+   * @param {string} str The string to convert
+   * @returns {Date<NumberOrInteger>}
+   */
+  static fromString (str: string): Date<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)$/)
+    if (values !== null) {
+      return new Date(
+        parseTemporalInt(values[1], 'years'),
+        parseTemporalInt(values[2], 'months'),
+        parseTemporalInt(values[3], 'days')
+      )
+    }
+    throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\'')
+  }
 }
 
 Object.defineProperty(

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -94,6 +94,20 @@ export class Duration<T extends NumberOrInteger = Integer> {
     Object.freeze(this)
   }
 
+  static fromString (str: string): Duration<NumberOrInteger> {
+    const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
+    if (matches !== null) {
+      const dur = new Duration(
+        ~~parseInt(matches[1]) * 12 + ~~parseInt(matches[2]),
+        ~~parseInt(matches[3]) * 7 + ~~parseInt(matches[4]),
+        ~~parseInt(matches[5]) * 3600 + ~~parseInt(matches[6]) * 60 + ~~parseInt(matches[7]),
+        Math.round((parseFloat(matches[7]) - parseInt(matches[7])) * 10 ** 9)
+      )
+      return dur
+    }
+    throw newError('Duration could not be parsed from string')
+  }
+
   /**
    * @ignore
    */
@@ -203,6 +217,21 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
       this.nanosecond
     )
   }
+
+  static fromString (str: string): LocalTime<NumberOrInteger> {
+    console.log(str)
+    const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
+    console.log(values)
+    if (values !== null) {
+      return new LocalTime(
+        parseInt(values[0]),
+        parseInt(values[1]),
+        parseInt(values[2]),
+        Math.round(parseFloat('0.' + values[3]) * 10 ** 9)
+      )
+    }
+    throw newError('LocalTime could not be parsed from string')
+  }
 }
 
 Object.defineProperty(
@@ -311,6 +340,23 @@ export class Time<T extends NumberOrInteger = Integer> {
         this.nanosecond
       ) + util.timeZoneOffsetToIsoString(this.timeZoneOffsetSeconds)
     )
+  }
+
+  static fromString (str: string): Time<NumberOrInteger> {
+    const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)(Z|\+|-)?(\d*)/)
+    if (values !== null) {
+      if (values[4] === 'Z') {
+        return new Time(parseInt(values[0]), parseInt(values[1]), parseInt(values[2]), parseInt(values[3]) * 10 ** 9, 0)
+      }
+      return new Time(
+        parseInt(values[0]),
+        parseInt(values[1]),
+        parseInt(values[2]),
+        Math.round(parseFloat('0.' + values[3]) * 10 ** 9),
+        (values[4] === '+' ? 1 : -1) * parseInt(values[5])
+      )
+    }
+    throw newError('Time could not be parsed from string')
   }
 }
 

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -94,6 +94,12 @@ export class Duration<T extends NumberOrInteger = Integer> {
     Object.freeze(this)
   }
 
+  /**
+   * Creates a {@link Duration} from an ISO 8601 string
+   *
+   * @param {string} str The string to convert
+   * @returns {Duration<NumberOrInteger>}
+   */
   static fromString (str: string): Duration<NumberOrInteger> {
     const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
     if (matches !== null) {
@@ -218,6 +224,12 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
     )
   }
 
+  /**
+   * Creates a {@link LocalTime} from an ISO 8601 string
+   *
+   * @param {string} str The string to convert
+   * @returns {LocalTime<NumberOrInteger>}
+   */
   static fromString (str: string): LocalTime<NumberOrInteger> {
     const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
     if (values !== null) {
@@ -340,6 +352,12 @@ export class Time<T extends NumberOrInteger = Integer> {
     )
   }
 
+  /**
+   * Creates a {@link Time} from an ISO 8601 string.
+   *
+   * @param {string} str The string to convert
+   * @returns {Time<NumberOrInteger>}
+   */
   static fromString (str: string): Time<NumberOrInteger> {
     const values = String(str).match(/(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
     if (values !== null) {
@@ -624,6 +642,12 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
     )
   }
 
+  /**
+   * Creates a {@link LocalDateTime} from an ISO 8601 string
+   *
+   * @param {string} str The string to convert
+   * @returns {LocalDateTime<NumberOrInteger>}
+   */
   static fromString (str: string): LocalDateTime<NumberOrInteger> {
     const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
     if (values !== null) {
@@ -815,6 +839,12 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     return localDateTimeStr + timeOffset + timeZoneStr
   }
 
+  /**
+   * Creates a {@link DateTime} from an ISO 8601 string
+   *
+   * @param {string} str The string to convert
+   * @returns {DateTime<NumberOrInteger>}
+   */
   static fromString (str: string): DateTime<NumberOrInteger> {
     const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
     if (values !== null) {

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -894,7 +894,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     const values = String(str.replace(/,/g, '.')).match(
       new RegExp(
         /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?/.source + // DateTime
-        /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?((\[)([^\]]*)(\]))?$/.source // Timezone
+        /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?(?:\[([^\]]*)\])?$/.source // Timezone
       )
     )
     if (values === null) {
@@ -925,7 +925,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
       )
     }
-    if (values[14] !== undefined) {
+    if (values[12] !== undefined) {
       return new DateTime(
         parseTemporalInt(values[1]), // years
         parseTemporalInt(values[2]), // months
@@ -935,7 +935,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         seconds,
         nanoseconds,
         undefined,
-        values[14]
+        values[12]
       )
     }
     throw newError('DateTime could not be parsed from string, provided string needs either timezoneId or offset')
@@ -1070,8 +1070,7 @@ function parseTemporalInt (str: string | undefined): Integer {
   if (str === undefined || str.length === 0) {
     return int(0)
   }
-  const result = int(str)
-  return result
+  return int(str)
 }
 
 function handleTimeDecimals (hourString?: string, minuteString?: string, secondString?: string, decimalString?: string): [Integer, Integer, Integer, Integer] {

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -96,20 +96,23 @@ export class Duration<T extends NumberOrInteger = Integer> {
 
   /**
    * Creates a {@link Duration} from an ISO 8601 string
+   * NOTE: Bolt transmits durations as 4 integers: Months, Days, Seconds and Nanoseconds. Parsing strings like P1.5M4.3D will throw an error. P0.5Y can be sent as it can be simplified as 6 months.
    *
    * @param {string} str The string to convert
    * @returns {Duration<NumberOrInteger>}
    */
   static fromString (str: string): Duration<NumberOrInteger> {
-    const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T?(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
+    const matches = String(str).match(/P(?:([-.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-.,\d]+)W)?(?:([-.,\d]+)D)?T?(?:([-.,\d]+)H)?(?:([-.,\d]+)M)?(?:([-.,\d]+)S)?/)
     if (matches !== null) {
-      const dur = new Duration(
-        ~~parseInt(matches[1]) * 12 + ~~parseInt(matches[2]),
-        ~~parseInt(matches[3]) * 7 + ~~parseInt(matches[4]),
-        ~~parseInt(matches[5]) * 3600 + ~~parseInt(matches[6]) * 60 + ~~parseInt(matches[7]),
-        Math.round((parseFloat(matches[7]) - parseInt(matches[7])) * 10 ** 9)
-      )
-      return dur
+      const months = parseDurationFloat(matches[1], 'Years') * 12 + parseDurationFloat(matches[2], 'Months')
+      const days = parseDurationFloat(matches[3], 'Weeks') * 7 + parseDurationFloat(matches[4], 'Days')
+      const seconds = parseDurationFloat(matches[5], 'Hours') * 3600 + parseDurationFloat(matches[6], 'Minutes') * 60 + ~~parseInt(matches[7])
+      const nanos = parseDurationNanos(matches[7])
+      checkDurationFieldIsInt(months, 'Months')
+      checkDurationFieldIsInt(days, 'Days')
+      checkDurationFieldIsInt(seconds, 'Seconds')
+      checkDurationFieldIsInt(nanos, 'Nanoseconds')
+      return new Duration(months, days, seconds, nanos)
     }
     throw newError('Duration could not be parsed from string')
   }
@@ -984,5 +987,27 @@ function verifyStandardDateAndNanos (
   assertValidDate(standardDate, 'Standard date')
   if (nanosecond !== null && nanosecond !== undefined) {
     assertNumberOrInteger(nanosecond, 'Nanosecond')
+  }
+}
+
+function parseDurationFloat (str: string, field: string): number {
+  if (str === undefined || str.length === 0) {
+    return 0
+  } else {
+    const value: number = parseFloat(str)
+    if (isNaN(value)) {
+      throw newError(`Failed to parse duration field ${field}. Got string: ${str}.`)
+    }
+    return value
+  }
+}
+
+function parseDurationNanos (str: string): number {
+  return Math.round((parseDurationFloat(str, 'Seconds') - ~~parseInt(str)) * 10 ** 9)
+}
+
+function checkDurationFieldIsInt (value: number, field: string): void {
+  if (!Number.isInteger(value)) {
+    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds. `)
   }
 }

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -99,7 +99,7 @@ export class Duration<T extends NumberOrInteger = Integer> {
    * NOTE: Bolt transmits durations as 4 integers: Months, Days, Seconds and Nanoseconds. Parsing strings like P1.5M4.3D will throw an error. P0.5Y can be sent as it can be simplified as 6 months.
    *
    * @param {string} str The string to convert
-   * @returns {Duration<NumberOrInteger>}
+   * @returns {Duration}
    */
   static fromString (str: string): Duration {
     if (str.slice(-1).toUpperCase() === 'T') {
@@ -120,7 +120,7 @@ export class Duration<T extends NumberOrInteger = Integer> {
       const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
       const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
       const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
-      const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'), 'seconds')
+      const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'))
       const nanos = negativeDuration * parseDurationNanos((matches[9] ?? '') + '0' + (matches[11] ?? ''))
       checkDurationFieldIsInt(months, 'Months')
       checkDurationFieldIsInt(days, 'Days')
@@ -245,10 +245,10 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
    * Creates a {@link LocalTime} from an ISO 8601 string
    *
    * @param {string} str The string to convert
-   * @returns {LocalTime<NumberOrInteger>}
+   * @returns {LocalTime}
    */
   static fromString (str: string): LocalTime {
-    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/)
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       return new LocalTime(
@@ -374,10 +374,10 @@ export class Time<T extends NumberOrInteger = Integer> {
    * Creates a {@link Time} from an ISO 8601 string.
    *
    * @param {string} str The string to convert
-   * @returns {Time<NumberOrInteger>}
+   * @returns {Time}
    */
   static fromString (str: string): Time {
-    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       if (values[5] === 'Z') {
@@ -392,15 +392,15 @@ export class Time<T extends NumberOrInteger = Integer> {
       if (values[6] == null) {
         throw newError('Error parsing timezone offset.')
       }
-      return new Time<Integer>(
+      return new Time(
         hours,
         minutes,
         seconds,
         nanoseconds,
         int((values[5] === '+' ? 1 : -1) * (
-          parseTemporalInt(values[6], 'timezone offset hours').toInt() * 3600 +
-          parseTemporalInt(values[7], 'timezone offset minutes').toInt() * 60 +
-          parseTemporalInt(values[8], 'timezone offset seconds').toInt()
+          parseTemporalInt(values[6]).toInt() * 3600 + // timezone offset hours
+          parseTemporalInt(values[7]).toInt() * 60 + // timezone offset minutes
+          parseTemporalInt(values[8]).toInt() // timezone offset seconds
         ))
       )
     }
@@ -539,15 +539,15 @@ export class Date<T extends NumberOrInteger = Integer> {
    * Creates a {@link Date} from an ISO 8601 string
    *
    * @param {string} str The string to convert
-   * @returns {Date<NumberOrInteger>}
+   * @returns {Date}
    */
   static fromString (str: string): Date {
     const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})$/)
     if (values !== null) {
       return new Date(
-        parseTemporalInt(values[1], 'years'),
-        parseTemporalInt(values[2], 'months'),
-        parseTemporalInt(values[3], 'days')
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]) // days
       )
     }
     throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\' or \'[+|-]YYYYY-MM-DD\'')
@@ -690,16 +690,16 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
    * Creates a {@link LocalDateTime} from an ISO 8601 string
    *
    * @param {string} str The string to convert
-   * @returns {LocalDateTime<NumberOrInteger>}
+   * @returns {LocalDateTime}
    */
   static fromString (str: string): LocalDateTime {
-    const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/)
+    const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       return new LocalDateTime(
-        parseTemporalInt(values[1], 'years'),
-        parseTemporalInt(values[2], 'months'),
-        parseTemporalInt(values[3], 'days'),
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]), // days
         hours,
         minutes,
         seconds,
@@ -888,12 +888,12 @@ export class DateTime<T extends NumberOrInteger = Integer> {
    * Creates a {@link DateTime} from an ISO 8601 string
    *
    * @param {string} str The string to convert
-   * @returns {DateTime<NumberOrInteger>}
+   * @returns {DateTime}
    */
   static fromString (str: string): DateTime {
     const values = String(str.replace(/,/g, '.')).match(
       new RegExp(
-        /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?/.source + // DateTime
+        /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?/.source + // DateTime
         /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?((\[)([^\]]*)(\]))?$/.source // Timezone
       )
     )
@@ -901,9 +901,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       if (values[8] === 'Z') {
         return new DateTime(
-          parseTemporalInt(values[1], 'years'),
-          parseTemporalInt(values[2], 'months'),
-          parseTemporalInt(values[3], 'days'),
+          parseTemporalInt(values[1]), // years
+          parseTemporalInt(values[2]), // months
+          parseTemporalInt(values[3]), // days
           hours,
           minutes,
           seconds,
@@ -912,10 +912,10 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         )
       }
       if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
-        return new DateTime<Integer>(
-          parseTemporalInt(values[1], 'years'),
-          parseTemporalInt(values[2], 'months'),
-          parseTemporalInt(values[3], 'days'),
+        return new DateTime(
+          parseTemporalInt(values[1]), // years
+          parseTemporalInt(values[2]), // months
+          parseTemporalInt(values[3]), // days
           hours,
           minutes,
           seconds,
@@ -925,9 +925,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       }
       if (values[14] !== undefined) {
         return new DateTime(
-          parseTemporalInt(values[1], 'years'),
-          parseTemporalInt(values[2], 'months'),
-          parseTemporalInt(values[3], 'days'),
+          parseTemporalInt(values[1]), // years
+          parseTemporalInt(values[2]), // months
+          parseTemporalInt(values[3]), // days
           hours,
           minutes,
           seconds,
@@ -1065,11 +1065,9 @@ function parseTemporalFloat (str: string | undefined, field: string): number {
   }
 }
 
-function parseTemporalInt (str: string | undefined, field: string, maxLength?: number): Integer {
-  if (str === undefined || str.length === 0 || str === 'undefined') {
+function parseTemporalInt (str: string | undefined): Integer {
+  if (str === undefined || str.length === 0) {
     return int(0)
-  } else if (maxLength != null && str.length > maxLength) {
-    throw newError(`Failed to parse temporal field ${field}. Got string: ${str} which is longer than max length: ${maxLength}.`)
   }
   const result = int(str)
   return result
@@ -1080,22 +1078,22 @@ function handleTimeDecimals (hourString?: string, minuteString?: string, secondS
   let minutes
   let seconds
   let nanoseconds
-  const decimalInt = decimalString !== undefined ? parseFloat('0' + decimalString) : 0
+  const decimalNumber = decimalString !== undefined ? parseFloat('0' + decimalString) : 0
   if (minuteString === undefined || minuteString === '') {
-    hours = parseTemporalInt(hourString, 'hours')
-    minutes = int(decimalInt * 60)
-    seconds = int((decimalInt * 3600) % 60)
-    nanoseconds = int((decimalInt * 3600 * 10 ** 9) % 10 ** 9)
+    hours = parseTemporalInt(hourString)
+    minutes = int(decimalNumber * 60)
+    seconds = int((decimalNumber * 3600) % 60)
+    nanoseconds = int((decimalNumber * 3600 * 10 ** 9) % 10 ** 9)
   } else if (secondString === undefined || secondString === '') {
-    hours = parseTemporalInt(hourString, 'hours')
-    minutes = parseTemporalInt(minuteString, 'minutes')
-    seconds = int((decimalInt * 60) % 60)
-    nanoseconds = int((decimalInt * 60 * (10 ** 9)) % 10 ** 9)
+    hours = parseTemporalInt(hourString)
+    minutes = parseTemporalInt(minuteString)
+    seconds = int((decimalNumber * 60) % 60)
+    nanoseconds = int((decimalNumber * 60 * (10 ** 9)) % 10 ** 9)
   } else {
-    hours = parseTemporalInt(hourString, 'hours')
-    minutes = parseTemporalInt(minuteString, 'minutes')
-    seconds = parseTemporalInt(secondString, 'seconds')
-    nanoseconds = int(decimalInt * 10 ** 9)
+    hours = parseTemporalInt(hourString)
+    minutes = parseTemporalInt(minuteString)
+    seconds = parseTemporalInt(secondString)
+    nanoseconds = int(decimalNumber * 10 ** 9)
   }
   return [hours, minutes, seconds, nanoseconds]
 }

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -902,6 +902,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     }
     const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
     if (values[8] === 'Z') {
+      if (values[9] != null) {
+        throw newError('DateTime could not be parsed from string, can not parse string with offset after Z')
+      }
       return new DateTime(
         parseTemporalInt(values[1]), // years
         parseTemporalInt(values[2]), // months

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -101,8 +101,14 @@ export class Duration<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Duration<NumberOrInteger>}
    */
-  static fromString (str: string): Duration<Integer> {
-    const matches = String(str.replace(/,/g, '.')).match(/^([-|+]?)[P|p](?:(-?[\d]*\.?[\d]*)[Y|y])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-?[\d]*\.?[\d]*)[W|w])?(?:(-?[\d]*\.?[\d]*)[D|d])?([T|t](?:(-?[\d]*\.?[\d]*)[H|h])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-)?([\d]*)(\.[\d]*)?[S|s])?)?$/)
+  static fromString (str: string): Duration {
+    if (str.slice(-1).toUpperCase() === 'T') {
+      throw newError(`Duration string '${str}' ends with 'T', time delimiter must be excluded if Duration contains no time components`)
+    }
+    const matches = String(str.replace(/,/g, '.')).match(new RegExp(
+      /^([-|+]?)[P|p](?:(-?\d*\.?\d*)[Y|y])?(?:(-?\d*\.?\d*)[M|m])?(?:(-?\d*\.?\d*)[W|w])?(?:(-?\d*\.?\d*)[D|d])?/.source + // Date portion
+      /([T|t](?:(-?\d*\.?\d*)[H|h])?(?:(-?\d*\.?\d*)[M|m])?(?:(-)?(\d*)(\.\d*)?[S|s])?)?$/.source // Time portion
+    ))
     if (matches !== null) {
       if (
         matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null &&
@@ -241,8 +247,8 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {LocalTime<NumberOrInteger>}
    */
-  static fromString (str: string): LocalTime<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^T?(\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?$/)
+  static fromString (str: string): LocalTime {
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       return new LocalTime(
@@ -370,8 +376,8 @@ export class Time<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Time<NumberOrInteger>}
    */
-  static fromString (str: string): Time<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?(Z|\+|-)(\d{0,2}):?(\d{0,2}):?(\d{0,2})$/)
+  static fromString (str: string): Time {
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       if (values[5] === 'Z') {
@@ -382,6 +388,9 @@ export class Time<T extends NumberOrInteger = Integer> {
           nanoseconds,
           int(0)
         )
+      }
+      if (values[6] == null) {
+        throw newError('Error parsing timezone offset.')
       }
       return new Time<Integer>(
         hours,
@@ -532,8 +541,8 @@ export class Date<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Date<NumberOrInteger>}
    */
-  static fromString (str: string): Date<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)$/)
+  static fromString (str: string): Date {
+    const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})$/)
     if (values !== null) {
       return new Date(
         parseTemporalInt(values[1], 'years'),
@@ -541,7 +550,7 @@ export class Date<T extends NumberOrInteger = Integer> {
         parseTemporalInt(values[3], 'days')
       )
     }
-    throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\'')
+    throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\' or \'[+|-]YYYYY-MM-DD\'')
   }
 }
 
@@ -683,8 +692,8 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {LocalDateTime<NumberOrInteger>}
    */
-  static fromString (str: string): LocalDateTime<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)[T|t](\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?$/)
+  static fromString (str: string): LocalDateTime {
+    const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       return new LocalDateTime(
@@ -881,8 +890,13 @@ export class DateTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {DateTime<NumberOrInteger>}
    */
-  static fromString (str: string): DateTime<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)[T|t](\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?(Z|\+|-)?(\d{0,2}):?(\d{0,2}):?(\d{0,2})?((\[)([^\]]*)(\]))?$/)
+  static fromString (str: string): DateTime {
+    const values = String(str.replace(/,/g, '.')).match(
+      new RegExp(
+        /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?/.source + // DateTime
+        /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?((\[)([^\]]*)(\]))?$/.source // Timezone
+      )
+    )
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       if (values[8] === 'Z') {
@@ -897,7 +911,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
           int(0)
         )
       }
-      if (values[8] === '+' || values[8] === '-') {
+      if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
         return new DateTime<Integer>(
           parseTemporalInt(values[1], 'years'),
           parseTemporalInt(values[2], 'months'),
@@ -1039,7 +1053,7 @@ function verifyStandardDateAndNanos (
   }
 }
 
-function parseTemporalFloat (str: string, field: string, maxLength?: number): number {
+function parseTemporalFloat (str: string | undefined, field: string): number {
   if (str === undefined || str.length === 0) {
     return 0
   } else {
@@ -1051,7 +1065,7 @@ function parseTemporalFloat (str: string, field: string, maxLength?: number): nu
   }
 }
 
-function parseTemporalInt (str: string, field: string, maxLength?: number): Integer {
+function parseTemporalInt (str: string | undefined, field: string, maxLength?: number): Integer {
   if (str === undefined || str.length === 0 || str === 'undefined') {
     return int(0)
   } else if (maxLength != null && str.length > maxLength) {
@@ -1061,26 +1075,27 @@ function parseTemporalInt (str: string, field: string, maxLength?: number): Inte
   return result
 }
 
-function handleTimeDecimals (hourString: string, minuteString: string, secondString: string, decimalString: string): [Integer, Integer, Integer, Integer] {
+function handleTimeDecimals (hourString?: string, minuteString?: string, secondString?: string, decimalString?: string): [Integer, Integer, Integer, Integer] {
   let hours
   let minutes
   let seconds
   let nanoseconds
-  if (minuteString === undefined || secondString === '') {
+  const decimalInt = decimalString !== undefined ? parseFloat('0' + decimalString) : 0
+  if (minuteString === undefined || minuteString === '') {
     hours = parseTemporalInt(hourString, 'hours')
-    minutes = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) : 0)
-    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600) % 60 : 0)
-    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600 * (10 ** 9)) % 10 ** 9 : 0)
+    minutes = int(decimalInt * 60)
+    seconds = int((decimalInt * 3600) % 60)
+    nanoseconds = int((decimalInt * 3600 * 10 ** 9) % 10 ** 9)
   } else if (secondString === undefined || secondString === '') {
     hours = parseTemporalInt(hourString, 'hours')
     minutes = parseTemporalInt(minuteString, 'minutes')
-    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) % 60 : 0)
-    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60 * (10 ** 9)) % 10 ** 9 : 0)
+    seconds = int((decimalInt * 60) % 60)
+    nanoseconds = int((decimalInt * 60 * (10 ** 9)) % 10 ** 9)
   } else {
     hours = parseTemporalInt(hourString, 'hours')
     minutes = parseTemporalInt(minuteString, 'minutes')
     seconds = parseTemporalInt(secondString, 'seconds')
-    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 10 ** 9) : 0)
+    nanoseconds = int(decimalInt * 10 ** 9)
   }
   return [hours, minutes, seconds, nanoseconds]
 }

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -219,9 +219,7 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
   }
 
   static fromString (str: string): LocalTime<NumberOrInteger> {
-    console.log(str)
     const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
-    console.log(values)
     if (values !== null) {
       return new LocalTime(
         parseInt(values[0]),
@@ -343,17 +341,23 @@ export class Time<T extends NumberOrInteger = Integer> {
   }
 
   static fromString (str: string): Time<NumberOrInteger> {
-    const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)(Z|\+|-)?(\d*)/)
+    const values = String(str).match(/(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
     if (values !== null) {
-      if (values[4] === 'Z') {
-        return new Time(parseInt(values[0]), parseInt(values[1]), parseInt(values[2]), parseInt(values[3]) * 10 ** 9, 0)
+      if (values[5] === 'Z') {
+        return new Time(
+          parseInt(values[1]),
+          parseInt(values[2]),
+          parseInt(values[3]),
+          values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
+          0
+        )
       }
       return new Time(
-        parseInt(values[0]),
         parseInt(values[1]),
         parseInt(values[2]),
-        Math.round(parseFloat('0.' + values[3]) * 10 ** 9),
-        (values[4] === '+' ? 1 : -1) * parseInt(values[5])
+        parseInt(values[3]),
+        values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
+        (values[5] === '+' ? 1 : -1) * (parseInt(values[6]) * 3600 + parseInt(values[7]) * 60 + parseInt(values[8]))
       )
     }
     throw newError('Time could not be parsed from string')
@@ -619,6 +623,22 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
       this.nanosecond
     )
   }
+
+  static fromString (str: string): LocalDateTime<NumberOrInteger> {
+    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+    if (values !== null) {
+      return new LocalDateTime(
+        parseInt(values[1]),
+        parseInt(values[2]),
+        parseInt(values[3]),
+        parseInt(values[4]),
+        parseInt(values[5]),
+        parseInt(values[6]),
+        Math.round(parseFloat('0' + values[7]) * 10 ** 9)
+      )
+    }
+    throw newError('Time could not be parsed from string')
+  }
 }
 
 Object.defineProperty(
@@ -793,6 +813,35 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       : ''
 
     return localDateTimeStr + timeOffset + timeZoneStr
+  }
+
+  static fromString (str: string): DateTime<NumberOrInteger> {
+    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+    if (values !== null) {
+      if (values[8] === 'Z') {
+        return new DateTime(
+          parseInt(values[1]),
+          parseInt(values[2]),
+          parseInt(values[3]),
+          parseInt(values[4]),
+          parseInt(values[5]),
+          parseInt(values[6]),
+          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+          0
+        )
+      }
+      return new DateTime(
+        parseInt(values[1]),
+        parseInt(values[2]),
+        parseInt(values[3]),
+        parseInt(values[4]),
+        parseInt(values[5]),
+        parseInt(values[6]),
+        Math.round(parseFloat('0.' + values[7]) * 10 ** 9),
+        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt(values[11]))
+      )
+    }
+    throw newError('Time could not be parsed from string')
   }
 
   /**

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -375,7 +375,7 @@ export class Time<T extends NumberOrInteger = Integer> {
    *
    * @param {string} str The string to convert
    * @returns {Time}
-  */
+   */
   static fromString (str: string): Time {
     const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
     if (values === null) {
@@ -894,7 +894,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     const values = String(str.replace(/,/g, '.')).match(
       new RegExp(
         /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?/.source + // DateTime
-        /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?(?:\[([^\]]*)\])?$/.source // Timezone
+        /([Z|z]|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?)?(?:\[([^\]]*)\])?$/.source // Timezone
       )
     )
     if (values === null) {
@@ -910,10 +910,14 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         minutes,
         seconds,
         nanoseconds,
-        int(0)
+        int(0),
+        values[12]
       )
     }
-    if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
+    if (values[8] === '+' || values[8] === '-') {
+      if (values[9] == null) {
+        throw newError(`DateTime could not be parsed from string, could not parse an offset after ${values[8]} sign.`)
+      }
       return new DateTime(
         parseTemporalInt(values[1]), // years
         parseTemporalInt(values[2]), // months
@@ -922,7 +926,8 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         minutes,
         seconds,
         nanoseconds,
-        int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
+        int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))),
+        values[12]
       )
     }
     if (values[12] !== undefined) {

--- a/packages/core/src/temporal-types.ts
+++ b/packages/core/src/temporal-types.ts
@@ -101,20 +101,28 @@ export class Duration<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Duration<NumberOrInteger>}
    */
-  static fromString (str: string): Duration<NumberOrInteger> {
-    const matches = String(str).match(/P(?:([-.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-.,\d]+)W)?(?:([-.,\d]+)D)?T?(?:([-.,\d]+)H)?(?:([-.,\d]+)M)?(?:([-.,\d]+)S)?/)
+  static fromString (str: string): Duration<Integer> {
+    const matches = String(str.replace(/,/g, '.')).match(/^([-|+]?)[P|p](?:(-?[\d]*\.?[\d]*)[Y|y])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-?[\d]*\.?[\d]*)[W|w])?(?:(-?[\d]*\.?[\d]*)[D|d])?([T|t](?:(-?[\d]*\.?[\d]*)[H|h])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-)?([\d]*)(\.[\d]*)?[S|s])?)?$/)
     if (matches !== null) {
-      const months = parseDurationFloat(matches[1], 'Years') * 12 + parseDurationFloat(matches[2], 'Months')
-      const days = parseDurationFloat(matches[3], 'Weeks') * 7 + parseDurationFloat(matches[4], 'Days')
-      const seconds = parseDurationFloat(matches[5], 'Hours') * 3600 + parseDurationFloat(matches[6], 'Minutes') * 60 + ~~parseInt(matches[7])
-      const nanos = parseDurationNanos(matches[7])
+      if (
+        matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null &&
+        matches[7] == null && matches[8] == null && matches[10] == null && matches[11] == null
+      ) {
+        throw newError(`Duration could not be parsed from string: ${str}`)
+      }
+      const negativeDuration = matches[1] === '-' ? -1 : 1
+      const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
+      const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
+      const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
+      const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'), 'seconds')
+      const nanos = negativeDuration * parseDurationNanos((matches[9] ?? '') + '0' + (matches[11] ?? ''))
       checkDurationFieldIsInt(months, 'Months')
       checkDurationFieldIsInt(days, 'Days')
-      checkDurationFieldIsInt(seconds, 'Seconds')
+      checkDurationFieldIsInt(hoursAndMinutes, 'Seconds')
       checkDurationFieldIsInt(nanos, 'Nanoseconds')
-      return new Duration(months, days, seconds, nanos)
+      return new Duration(int(months), int(days), int(BigInt(negativeDuration) * (BigInt(hoursAndMinutes) + seconds.toBigInt())), int(nanos))
     }
-    throw newError('Duration could not be parsed from string')
+    throw newError(`Duration could not be parsed from string: ${str}`)
   }
 
   /**
@@ -233,14 +241,15 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {LocalTime<NumberOrInteger>}
    */
-  static fromString (str: string): LocalTime<NumberOrInteger> {
-    const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
+  static fromString (str: string): LocalTime<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^T?(\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?$/)
     if (values !== null) {
+      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       return new LocalTime(
-        parseInt(values[0]),
-        parseInt(values[1]),
-        parseInt(values[2]),
-        Math.round(parseFloat('0.' + values[3]) * 10 ** 9)
+        hours,
+        minutes,
+        seconds,
+        nanoseconds
       )
     }
     throw newError('LocalTime could not be parsed from string')
@@ -361,24 +370,29 @@ export class Time<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Time<NumberOrInteger>}
    */
-  static fromString (str: string): Time<NumberOrInteger> {
-    const values = String(str).match(/(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+  static fromString (str: string): Time<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?(Z|\+|-)(\d{0,2}):?(\d{0,2}):?(\d{0,2})$/)
     if (values !== null) {
+      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       if (values[5] === 'Z') {
         return new Time(
-          parseInt(values[1]),
-          parseInt(values[2]),
-          parseInt(values[3]),
-          values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
-          0
+          hours,
+          minutes,
+          seconds,
+          nanoseconds,
+          int(0)
         )
       }
-      return new Time(
-        parseInt(values[1]),
-        parseInt(values[2]),
-        parseInt(values[3]),
-        values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
-        (values[5] === '+' ? 1 : -1) * (parseInt(values[6]) * 3600 + parseInt(values[7]) * 60 + parseInt(values[8]))
+      return new Time<Integer>(
+        hours,
+        minutes,
+        seconds,
+        nanoseconds,
+        int((values[5] === '+' ? 1 : -1) * (
+          parseTemporalInt(values[6], 'timezone offset hours').toInt() * 3600 +
+          parseTemporalInt(values[7], 'timezone offset minutes').toInt() * 60 +
+          parseTemporalInt(values[8], 'timezone offset seconds').toInt()
+        ))
       )
     }
     throw newError('Time could not be parsed from string')
@@ -651,17 +665,18 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {LocalDateTime<NumberOrInteger>}
    */
-  static fromString (str: string): LocalDateTime<NumberOrInteger> {
-    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+  static fromString (str: string): LocalDateTime<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)[T|t](\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?$/)
     if (values !== null) {
+      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       return new LocalDateTime(
-        parseInt(values[1]),
-        parseInt(values[2]),
-        parseInt(values[3]),
-        parseInt(values[4]),
-        parseInt(values[5]),
-        parseInt(values[6]),
-        Math.round(parseFloat('0' + values[7]) * 10 ** 9)
+        parseTemporalInt(values[1], 'years'),
+        parseTemporalInt(values[2], 'months'),
+        parseTemporalInt(values[3], 'days'),
+        hours,
+        minutes,
+        seconds,
+        nanoseconds
       )
     }
     throw newError('LocalDateTime could not be parsed from string')
@@ -848,44 +863,45 @@ export class DateTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {DateTime<NumberOrInteger>}
    */
-  static fromString (str: string): DateTime<NumberOrInteger> {
-    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)?(\[)?([^\]]*)?(\])?/)
+  static fromString (str: string): DateTime<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)[T|t](\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?(Z|\+|-)?(\d{0,2}):?(\d{0,2}):?(\d{0,2})?((\[)([^\]]*)(\]))?$/)
     if (values !== null) {
+      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       if (values[8] === 'Z') {
         return new DateTime(
-          parseInt(values[1]),
-          parseInt(values[2]),
-          parseInt(values[3]),
-          parseInt(values[4]),
-          parseInt(values[5]),
-          parseInt(values[6]),
-          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
-          0
+          parseTemporalInt(values[1], 'years'),
+          parseTemporalInt(values[2], 'months'),
+          parseTemporalInt(values[3], 'days'),
+          hours,
+          minutes,
+          seconds,
+          nanoseconds,
+          int(0)
         )
       }
       if (values[8] === '+' || values[8] === '-') {
-        return new DateTime(
-          parseInt(values[1]),
-          parseInt(values[2]),
-          parseInt(values[3]),
-          parseInt(values[4]),
-          parseInt(values[5]),
-          parseInt(values[6]),
-          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
-          (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))
+        return new DateTime<Integer>(
+          parseTemporalInt(values[1], 'years'),
+          parseTemporalInt(values[2], 'months'),
+          parseTemporalInt(values[3], 'days'),
+          hours,
+          minutes,
+          seconds,
+          nanoseconds,
+          int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
         )
       }
-      if (values[13] !== undefined) {
+      if (values[14] !== undefined) {
         return new DateTime(
-          parseInt(values[1]),
-          parseInt(values[2]),
-          parseInt(values[3]),
-          parseInt(values[4]),
-          parseInt(values[5]),
-          parseInt(values[6]),
-          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+          parseTemporalInt(values[1], 'years'),
+          parseTemporalInt(values[2], 'months'),
+          parseTemporalInt(values[3], 'days'),
+          hours,
+          minutes,
+          seconds,
+          nanoseconds,
           undefined,
-          values[13]
+          values[14]
         )
       }
     }
@@ -1005,20 +1021,54 @@ function verifyStandardDateAndNanos (
   }
 }
 
-function parseDurationFloat (str: string, field: string): number {
+function parseTemporalFloat (str: string, field: string, maxLength?: number): number {
   if (str === undefined || str.length === 0) {
     return 0
   } else {
     const value: number = parseFloat(str)
     if (isNaN(value)) {
-      throw newError(`Failed to parse duration field ${field}. Got string: ${str}.`)
+      throw newError(`Failed to parse temporal field ${field}. Got string: ${str}.`)
     }
     return value
   }
 }
 
+function parseTemporalInt (str: string, field: string, maxLength?: number): Integer {
+  if (str === undefined || str.length === 0 || str === 'undefined') {
+    return int(0)
+  } else if (maxLength != null && str.length > maxLength) {
+    throw newError(`Failed to parse temporal field ${field}. Got string: ${str} which is longer than max length: ${maxLength}.`)
+  }
+  const result = int(str)
+  return result
+}
+
+function handleTimeDecimals (hourString: string, minuteString: string, secondString: string, decimalString: string): [Integer, Integer, Integer, Integer] {
+  let hours
+  let minutes
+  let seconds
+  let nanoseconds
+  if (minuteString === undefined || secondString === '') {
+    hours = parseTemporalInt(hourString, 'hours')
+    minutes = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) : 0)
+    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600) % 60 : 0)
+    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600 * (10 ** 9)) % 10 ** 9 : 0)
+  } else if (secondString === undefined || secondString === '') {
+    hours = parseTemporalInt(hourString, 'hours')
+    minutes = parseTemporalInt(minuteString, 'minutes')
+    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) % 60 : 0)
+    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60 * (10 ** 9)) % 10 ** 9 : 0)
+  } else {
+    hours = parseTemporalInt(hourString, 'hours')
+    minutes = parseTemporalInt(minuteString, 'minutes')
+    seconds = parseTemporalInt(secondString, 'seconds')
+    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 10 ** 9) : 0)
+  }
+  return [hours, minutes, seconds, nanoseconds]
+}
+
 function parseDurationNanos (str: string): number {
-  return Math.round((parseDurationFloat(str, 'Seconds') - ~~parseInt(str)) * 10 ** 9)
+  return Math.round(parseTemporalFloat(str, 'nanoseconds') * 10 ** 9)
 }
 
 function checkDurationFieldIsInt (value: number, field: string): void {

--- a/packages/core/src/transaction-managed.ts
+++ b/packages/core/src/transaction-managed.ts
@@ -19,8 +19,9 @@ import Result from './result'
 import Transaction from './transaction'
 import { Query } from './types'
 import { RecordShape } from './record'
+import { Rules } from './mapping.highlevel'
 
-type Run<R extends RecordShape = RecordShape> = (query: Query, parameters?: any) => Result<R>
+type Run<R extends RecordShape = RecordShape> = (query: Query, parameters?: any, parameterRules?: Rules) => Result<R>
 
 /**
  * Represents a transaction that is managed by the transaction executor.
@@ -59,8 +60,8 @@ class ManagedTransaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run<R extends RecordShape = RecordShape> (query: Query, parameters?: any): Result<R> {
-    return this._run(query, parameters)
+  run<R extends RecordShape = RecordShape> (query: Query, parameters?: any, parameterRules?: Rules): Result<R> {
+    return this._run(query, parameters, parameterRules)
   }
 }
 

--- a/packages/core/src/transaction-managed.ts
+++ b/packages/core/src/transaction-managed.ts
@@ -58,6 +58,7 @@ class ManagedTransaction {
    * or with the query and parameters as separate arguments.
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @return {Result} New Result
    */
   run<R extends RecordShape = RecordShape> (query: Query, parameters?: any, parameterRules?: Rules): Result<R> {

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -38,6 +38,7 @@ import { Query } from './types'
 import { RecordShape } from './record'
 import NotificationFilter from './notification-filter'
 import { TelemetryApis, TELEMETRY_APIS } from './internal/constants'
+import { Rules } from './mapping.highlevel'
 
 type NonAutoCommitTelemetryApis = Exclude<TelemetryApis, typeof TELEMETRY_APIS.AUTO_COMMIT_TRANSACTION>
 type NonAutoCommitApiTelemetryConfig = ApiTelemetryConfig<NonAutoCommitTelemetryApis>
@@ -196,10 +197,11 @@ class Transaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run<R extends RecordShape = RecordShape> (query: Query, parameters?: any): Result<R> {
+  run<R extends RecordShape = RecordShape> (query: Query, parameters?: any, parameterRules?: Rules): Result<R> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
-      parameters
+      parameters,
+      { parameterRules }
     )
 
     const result = this._state.run(validatedQuery, params, {

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -195,6 +195,7 @@ class Transaction {
    * or with the query and parameters as separate arguments.
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @return {Result} New Result
    */
   run<R extends RecordShape = RecordShape> (query: Query, parameters?: any, parameterRules?: Rules): Result<R> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,12 +16,13 @@
  */
 
 import ClientCertificate, { ClientCertificateProvider } from './client-certificate'
+import { Rules } from './mapping.highlevel'
 import NotificationFilter from './notification-filter'
 
 /**
  * @private
  */
-export type Query = string | String | { text: string, parameters?: any }
+export type Query = string | String | { text: string, parameters?: any, parameterRules?: Rules }
 
 export type EncryptionLevel = 'ENCRYPTION_ON' | 'ENCRYPTION_OFF'
 

--- a/packages/core/test/driver.test.ts
+++ b/packages/core/test/driver.test.ts
@@ -405,7 +405,7 @@ describe('Driver', () => {
           routing: routing.WRITE,
           database: undefined,
           impersonatedUser: undefined
-        }, query, params)
+        }, query, params, undefined)
       })
 
       it('should be able to destruct the result in records, keys and summary', async () => {
@@ -431,7 +431,7 @@ describe('Driver', () => {
           routing: routing.WRITE,
           database: undefined,
           impersonatedUser: undefined
-        }, query, params)
+        }, query, params, undefined)
       })
 
       it('should be able get type-safe Records', async () => {
@@ -505,7 +505,7 @@ describe('Driver', () => {
 
         await driver?.executeQuery(query, params, config)
 
-        expect(spiedExecute).toBeCalledWith(buildExpectedConfig(), query, params)
+        expect(spiedExecute).toBeCalledWith(buildExpectedConfig(), query, params, undefined)
       })
 
       it('should handle correct type mapping for a custom result transformer', async () => {

--- a/packages/core/test/internal/query-executor.test.ts
+++ b/packages/core/test/internal/query-executor.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { bookmarkManager, newError, Result, Session, TransactionConfig } from '../../src'
+import { bookmarkManager, newError, Result, Rules, Session, TransactionConfig } from '../../src'
 import QueryExecutor from '../../src/internal/query-executor'
 import ManagedTransaction from '../../src/transaction-managed'
 import ResultStreamObserverMock from '../utils/result-stream-observer.mock'
@@ -150,7 +150,7 @@ describe('QueryExecutor', () => {
       await queryExecutor.execute(baseConfig, 'query', { a: 'b' })
 
       expect(spyOnRun).toHaveBeenCalledTimes(1)
-      expect(spyOnRun).toHaveBeenCalledWith('query', { a: 'b' })
+      expect(spyOnRun).toHaveBeenCalledWith('query', { a: 'b' }, undefined)
     })
 
     it('should return the transformed result', async () => {
@@ -353,7 +353,7 @@ describe('QueryExecutor', () => {
       await queryExecutor.execute(baseConfig, 'query', { a: 'b' })
 
       expect(spyOnRun).toHaveBeenCalledTimes(1)
-      expect(spyOnRun).toHaveBeenCalledWith('query', { a: 'b' })
+      expect(spyOnRun).toHaveBeenCalledWith('query', { a: 'b' }, undefined)
     })
 
     it('should return the transformed result', async () => {
@@ -522,7 +522,7 @@ describe('QueryExecutor', () => {
 
   function createManagedTransaction (): {
     managedTransaction: ManagedTransaction
-    spyOnRun: jest.SpyInstance<Result, [query: Query, parameters?: any]>
+    spyOnRun: jest.SpyInstance<Result, [query: Query, parameters?: any, parameterRules?: Rules | undefined]>
     resultObservers: ResultStreamObserverMock[]
     results: Result[]
   } {
@@ -531,7 +531,7 @@ describe('QueryExecutor', () => {
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const managedTransaction = {
-      run: (query: string, parameters?: any): Result => {
+      run: (query: string, parameters?: any, parameterRules?: Rules | undefined): Result => {
         const resultObserver = new ResultStreamObserverMock()
         resultObservers.push(resultObserver)
         const result = new Result(

--- a/packages/core/test/mapping.highlevel.test.ts
+++ b/packages/core/test/mapping.highlevel.test.ts
@@ -232,5 +232,50 @@ describe('Record Object Mapping', () => {
 
       expect(result.string).toBe(undefined)
     })
+
+    it('should keep optional undefined as undefined and null as null', () => {
+      const rules: Rules = {
+        string: rule.asString({ optional: true }),
+        null: rule.asString({ optional: true }),
+        obj: rule.asObject({ undefined: rule.asString({ optional: true }), null: rule.asString({ optional: true }) })
+      }
+
+      class Obj {
+        undefined?: undefined
+        null?: null
+      }
+
+      class Mapped {
+        string?: string
+        null?: string | null
+        obj?: Obj
+      }
+
+      const gettable = {
+        get: (index: string) => {
+          switch (index) {
+            case 'string':
+              throw newError(
+                'This record has no field with key \'string\', available keys are: [].\''
+              )
+            case 'null':
+              return null
+            case 'obj':
+              return { undefined, null: null }
+            default:
+              return undefined
+          }
+        }
+      }
+      // @ts-expect-error
+      const result = as<Mapped>(gettable, rules)
+
+      expect(result.string).toBe(undefined)
+      expect(result.null).toBe(null)
+      // @ts-expect-error
+      expect(result.obj.null).toBe(null)
+      // @ts-expect-error
+      expect(result.obj.undefined).toBe(undefined)
+    })
   })
 })

--- a/packages/core/test/mapping.highlevel.test.ts
+++ b/packages/core/test/mapping.highlevel.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector, newError } from '../src'
+import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector, newError, Integer } from '../src'
 import { as } from '../src/mapping.highlevel'
 
 describe('Record Object Mapping', () => {
@@ -90,6 +90,7 @@ describe('Record Object Mapping', () => {
         number: rule.asNumber(),
         string: rule.asString(),
         bigint: rule.asBigInt(),
+        integer: rule.asInteger(),
         date: rule.asDate(),
         dateTime: rule.asDateTime(),
         duration: rule.asDuration(),
@@ -105,6 +106,7 @@ describe('Record Object Mapping', () => {
         string: string
         number: number
         bigint: BigInt
+        integer: Integer
         date: Date
         dateTime: DateTime
         duration: Duration
@@ -125,6 +127,8 @@ describe('Record Object Mapping', () => {
               return 1
             case 'bigint':
               return BigInt(1)
+            case 'integer':
+              return new Integer(1, 0)
             case 'date':
               return new Date(1, 1, 1)
             case 'dateTime':
@@ -155,6 +159,8 @@ describe('Record Object Mapping', () => {
       expect(result.number).toBe(1)
 
       expect(result.bigint).toBe(BigInt(1))
+
+      expect(result.integer).toEqual(new Integer(1, 0))
 
       expect(result.list[0]).toBe('hello')
 

--- a/packages/core/test/mapping.highlevel.test.ts
+++ b/packages/core/test/mapping.highlevel.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector, int } from '../src'
+import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector } from '../src'
 import { as } from '../src/mapping.highlevel'
 
 describe('#unit Record Object Mapping', () => {
@@ -77,8 +77,6 @@ describe('#unit Record Object Mapping', () => {
       ['Number', rule.asNumber(), 1, 1],
       ['String', rule.asString(), 'hi', 'hi'],
       ['BigInt', rule.asBigInt(), BigInt(1), BigInt(1)],
-      ['Integer Converted to BigInt', rule.asInteger({ asBigInt: true }), BigInt(1), int(1)],
-      ['Integer Converted to Number', rule.asInteger({ asNumber: true }), 1, int(1)],
       ['Date', rule.asDate(), new Date(1, 1, 1), new Date(1, 1, 1)],
       ['DateTime', rule.asDateTime(), new DateTime(1, 1, 1, 1, 1, 1, 1, 1), new DateTime(1, 1, 1, 1, 1, 1, 1, 1)],
       ['Duration', rule.asDuration(), new Duration(1, 1, 1, 1), new Duration(1, 1, 1, 1)],

--- a/packages/core/test/mapping.highlevel.test.ts
+++ b/packages/core/test/mapping.highlevel.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector, newError, Integer } from '../src'
+import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector, newError, Integer, LocalDateTime, LocalTime, Point } from '../src'
 import { as } from '../src/mapping.highlevel'
 
 describe('Record Object Mapping', () => {
@@ -87,14 +87,18 @@ describe('Record Object Mapping', () => {
         name: rule.asString({ from: 'firstname' })
       }
       const rules: Rules = {
+        bool: rule.asBoolean(),
         number: rule.asNumber(),
         string: rule.asString(),
         bigint: rule.asBigInt(),
         integer: rule.asInteger(),
-        date: rule.asDate(),
-        dateTime: rule.asDateTime(),
+        point: rule.asPoint(),
         duration: rule.asDuration(),
+        localTime: rule.asLocalTime(),
         time: rule.asTime(),
+        date: rule.asDate(),
+        localDateTime: rule.asLocalDateTime(),
+        dateTime: rule.asDateTime(),
         list: rule.asList({ apply: rule.asString() }),
         node: rule.asNode({ convert: (node) => node.as(Person, personRules) }),
         rel: rule.asRelationship({ convert: (rel) => rel.as(Person, personRules) }),
@@ -103,14 +107,18 @@ describe('Record Object Mapping', () => {
       }
 
       class mapped {
+        bool: boolean
         string: string
         number: number
         bigint: BigInt
         integer: Integer
-        date: Date
-        dateTime: DateTime
+        point: Point
         duration: Duration
+        localTime: LocalTime
         time: Time
+        date: Date
+        localDateTime: LocalDateTime
+        dateTime: DateTime
         list: string[]
         node: Person
         rel: Person
@@ -121,6 +129,8 @@ describe('Record Object Mapping', () => {
       const gettable = {
         get: (index: string) => {
           switch (index) {
+            case 'bool':
+              return true
             case 'string':
               return 'hi'
             case 'number':
@@ -129,14 +139,20 @@ describe('Record Object Mapping', () => {
               return BigInt(1)
             case 'integer':
               return new Integer(1, 0)
-            case 'date':
-              return new Date(1, 1, 1)
-            case 'dateTime':
-              return new DateTime(1, 1, 1, 1, 1, 1, 1, 1)
+            case 'point':
+              return new Point(0, 1, 1)
             case 'duration':
               return new Duration(1, 1, 1, 1)
+            case 'localTime':
+              return new LocalTime(1, 1, 1, 1)
             case 'time':
               return new Time(1, 1, 1, 1, 1)
+            case 'date':
+              return new Date(1, 1, 1)
+            case 'localDateTime':
+              return new LocalDateTime(1, 1, 1, 1, 1, 1, 1)
+            case 'dateTime':
+              return new DateTime(1, 1, 1, 1, 1, 1, 1, 1)
             case 'list':
               return ['hello']
             case 'node':
@@ -154,6 +170,8 @@ describe('Record Object Mapping', () => {
       // @ts-expect-error
       const result = as<mapped>(gettable, rules)
 
+      expect(result.bool).toBe(true)
+
       expect(result.string).toBe('hi')
 
       expect(result.number).toBe(1)
@@ -162,19 +180,25 @@ describe('Record Object Mapping', () => {
 
       expect(result.integer).toEqual(new Integer(1, 0))
 
-      expect(result.list[0]).toBe('hello')
-
-      expect(result.date.toString()).toBe('0001-01-01')
-
-      expect(result.dateTime.toString()).toBe('0001-01-01T01:01:01.000000001+00:00:01')
+      expect(result.point).toEqual(new Point(0, 1, 1))
 
       expect(result.duration.toString()).toBe('P1M1DT1.000000001S')
 
+      expect(result.localTime.toString()).toBe('01:01:01.000000001')
+
       expect(result.time.toString()).toBe('01:01:01.000000001+00:00:01')
+
+      expect(result.date.toString()).toBe('0001-01-01')
+
+      expect(result.localDateTime.toString()).toBe('0001-01-01T01:01:01.000000001')
+
+      expect(result.dateTime.toString()).toBe('0001-01-01T01:01:01.000000001+00:00:01')
 
       expect(result.node.name).toBe('hi')
 
       expect(result.rel.name).toBe('bye')
+
+      expect(result.list[0]).toBe('hello')
 
       expect(result.vec._typedArray[0]).toBe(0)
 

--- a/packages/core/test/mapping.highlevel.test.ts
+++ b/packages/core/test/mapping.highlevel.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector } from '../src'
+import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector, int } from '../src'
 import { as } from '../src/mapping.highlevel'
 
 describe('#unit Record Object Mapping', () => {
@@ -72,6 +72,45 @@ describe('#unit Record Object Mapping', () => {
       // @ts-expect-error
       expect(() => as(gettable, personRules)).toThrow('Object#name should be a number but received string')
     })
+
+    it.each([
+      ['Number', rule.asNumber(), 1, 1],
+      ['String', rule.asString(), 'hi', 'hi'],
+      ['BigInt', rule.asBigInt(), BigInt(1), BigInt(1)],
+      ['Integer Converted to BigInt', rule.asInteger({ asBigInt: true }), BigInt(1), int(1)],
+      ['Integer Converted to Number', rule.asInteger({ asNumber: true }), 1, int(1)],
+      ['Date', rule.asDate(), new Date(1, 1, 1), new Date(1, 1, 1)],
+      ['DateTime', rule.asDateTime(), new DateTime(1, 1, 1, 1, 1, 1, 1, 1), new DateTime(1, 1, 1, 1, 1, 1, 1, 1)],
+      ['Duration', rule.asDuration(), new Duration(1, 1, 1, 1), new Duration(1, 1, 1, 1)],
+      ['Time', rule.asTime(), new Time(1, 1, 1, 1, 1), new Time(1, 1, 1, 1, 1)],
+      ['Simple List', rule.asList({ apply: rule.asString() }), ['hello'], ['hello']],
+      [
+        'Complex List',
+        rule.asList({ apply: rule.asVector({ asTypedList: true }) }),
+        [Float32Array.from([0.1, 0.2]), Float32Array.from([0.3, 0.4]), Float32Array.from([0.5, 0.6])],
+        [new Vector(Float32Array.from([0.1, 0.2])), new Vector(Float32Array.from([0.3, 0.4])), new Vector(Float32Array.from([0.5, 0.6]))]
+      ],
+      [
+        'Vector',
+        rule.asVector(),
+        new Vector(Int32Array.from([0, 1, 2])),
+        new Vector(Int32Array.from([0, 1, 2]))
+      ],
+      [
+        'Converted Vector',
+        rule.asVector({ asTypedList: true, from: 'vec' }),
+        Float32Array.from([0.1, 0.2]),
+        new Vector(Float32Array.from([0.1, 0.2]))
+      ]
+    ])('should be able to map %s as property', (_, rule, param, expected) => {
+      if (rule.convertToParam != null) {
+        param = rule.convertToParam(param)
+      }
+      // @ts-expect-error
+      rule.validate(param)
+      expect(param).toEqual(expected)
+    })
+
     it('should be able to read all property types', () => {
       class Person {
         name

--- a/packages/core/test/mapping.highlevel.test.ts
+++ b/packages/core/test/mapping.highlevel.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector } from '../src'
+import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector, newError } from '../src'
 import { as } from '../src/mapping.highlevel'
 
 describe('Record Object Mapping', () => {
@@ -173,6 +173,34 @@ describe('Record Object Mapping', () => {
       expect(result.vec._typedArray[0]).toBe(0)
 
       expect(result.convertedVec[2]).toBe(2)
+    })
+
+    it('should allow records with missing optional results', () => {
+      const rules: Rules = {
+        string: rule.asString({ optional: true })
+      }
+
+      class mapped {
+        string?: string
+      }
+
+      const gettable = {
+        get: (index: string) => {
+          switch (index) {
+            case 'string':
+              throw newError(
+                'This record has no field with key \'string\', available keys are: [].\''
+              )
+            default:
+              return undefined
+          }
+        }
+      }
+
+      // @ts-expect-error
+      const result = as<mapped>(gettable, rules)
+
+      expect(result.string).toBe(undefined)
     })
   })
 })

--- a/packages/core/test/mapping.highlevel.test.ts
+++ b/packages/core/test/mapping.highlevel.test.ts
@@ -18,7 +18,7 @@
 import { Date, DateTime, Duration, RecordObjectMapping, Node, Relationship, Rules, rule, Time, Vector } from '../src'
 import { as } from '../src/mapping.highlevel'
 
-describe('#unit Record Object Mapping', () => {
+describe('Record Object Mapping', () => {
   describe('as', () => {
     it('should use rules set with register', () => {
       class Person {
@@ -71,42 +71,6 @@ describe('#unit Record Object Mapping', () => {
       }
       // @ts-expect-error
       expect(() => as(gettable, personRules)).toThrow('Object#name should be a number but received string')
-    })
-
-    it.each([
-      ['Number', rule.asNumber(), 1, 1],
-      ['String', rule.asString(), 'hi', 'hi'],
-      ['BigInt', rule.asBigInt(), BigInt(1), BigInt(1)],
-      ['Date', rule.asDate(), new Date(1, 1, 1), new Date(1, 1, 1)],
-      ['DateTime', rule.asDateTime(), new DateTime(1, 1, 1, 1, 1, 1, 1, 1), new DateTime(1, 1, 1, 1, 1, 1, 1, 1)],
-      ['Duration', rule.asDuration(), new Duration(1, 1, 1, 1), new Duration(1, 1, 1, 1)],
-      ['Time', rule.asTime(), new Time(1, 1, 1, 1, 1), new Time(1, 1, 1, 1, 1)],
-      ['Simple List', rule.asList({ apply: rule.asString() }), ['hello'], ['hello']],
-      [
-        'Complex List',
-        rule.asList({ apply: rule.asVector({ asTypedList: true }) }),
-        [Float32Array.from([0.1, 0.2]), Float32Array.from([0.3, 0.4]), Float32Array.from([0.5, 0.6])],
-        [new Vector(Float32Array.from([0.1, 0.2])), new Vector(Float32Array.from([0.3, 0.4])), new Vector(Float32Array.from([0.5, 0.6]))]
-      ],
-      [
-        'Vector',
-        rule.asVector(),
-        new Vector(Int32Array.from([0, 1, 2])),
-        new Vector(Int32Array.from([0, 1, 2]))
-      ],
-      [
-        'Converted Vector',
-        rule.asVector({ asTypedList: true, from: 'vec' }),
-        Float32Array.from([0.1, 0.2]),
-        new Vector(Float32Array.from([0.1, 0.2]))
-      ]
-    ])('should be able to map %s as property', (_, rule, param, expected) => {
-      if (rule.convertToParam != null) {
-        param = rule.convertToParam(param)
-      }
-      // @ts-expect-error
-      rule.validate(param)
-      expect(param).toEqual(expected)
     })
 
     it('should be able to read all property types', () => {

--- a/packages/core/test/mapping.rulesfactories.test.ts
+++ b/packages/core/test/mapping.rulesfactories.test.ts
@@ -1,4 +1,4 @@
-import { Date, DateTime, Duration, int, Integer, Time, Vector } from '../src'
+import { Date, DateTime, Duration, int, Integer, LocalDateTime, LocalTime, Point, Time, Vector } from '../src'
 import { rule } from '../src/mapping.rulesfactories'
 
 describe('Rulesfactories', () => {
@@ -7,10 +7,13 @@ describe('Rulesfactories', () => {
     ['String', rule.asString(), 'hi', 'hi'],
     ['BigInt', rule.asBigInt(), BigInt(1), BigInt(1)],
     ['Integer', rule.asInteger(), Integer.fromValue(1), Integer.fromValue(1)],
-    ['Date', rule.asDate(), new Date(1, 1, 1), new Date(1, 1, 1)],
-    ['DateTime', rule.asDateTime(), new DateTime(1, 1, 1, 1, 1, 1, 1, 1), new DateTime(1, 1, 1, 1, 1, 1, 1, 1)],
+    ['Point', rule.asPoint(), new Point(0, 1, 1), new Point(0, 1, 1)],
     ['Duration', rule.asDuration(), new Duration(1, 1, 1, 1), new Duration(1, 1, 1, 1)],
+    ['LocalTime', rule.asLocalTime(), new LocalTime(1, 1, 1, 1), new LocalTime(1, 1, 1, 1)],
     ['Time', rule.asTime(), new Time(1, 1, 1, 1, 1), new Time(1, 1, 1, 1, 1)],
+    ['Date', rule.asDate(), new Date(1, 1, 1), new Date(1, 1, 1)],
+    ['LocalDateTime', rule.asLocalDateTime(), new LocalDateTime(1, 1, 1, 1, 1, 1, 1), new LocalDateTime(1, 1, 1, 1, 1, 1, 1)],
+    ['DateTime', rule.asDateTime(), new DateTime(1, 1, 1, 1, 1, 1, 1, 1), new DateTime(1, 1, 1, 1, 1, 1, 1, 1)],
     ['Simple List', rule.asList({ apply: rule.asString() }), ['hello'], ['hello']],
     [
       'Complex List',

--- a/packages/core/test/mapping.rulesfactories.test.ts
+++ b/packages/core/test/mapping.rulesfactories.test.ts
@@ -1,0 +1,64 @@
+import { Date, DateTime, Duration, Time, Vector } from '../src'
+import { rule } from '../src/mapping.rulesfactories'
+
+describe('Rulesfactories', () => {
+  it.each([
+    ['Number', rule.asNumber(), 1, 1],
+    ['String', rule.asString(), 'hi', 'hi'],
+    ['BigInt', rule.asBigInt(), BigInt(1), BigInt(1)],
+    ['Date', rule.asDate(), new Date(1, 1, 1), new Date(1, 1, 1)],
+    ['DateTime', rule.asDateTime(), new DateTime(1, 1, 1, 1, 1, 1, 1, 1), new DateTime(1, 1, 1, 1, 1, 1, 1, 1)],
+    ['Duration', rule.asDuration(), new Duration(1, 1, 1, 1), new Duration(1, 1, 1, 1)],
+    ['Time', rule.asTime(), new Time(1, 1, 1, 1, 1), new Time(1, 1, 1, 1, 1)],
+    ['Simple List', rule.asList({ apply: rule.asString() }), ['hello'], ['hello']],
+    [
+      'Complex List',
+      rule.asList({ apply: rule.asVector({ asTypedList: true }) }),
+      [Float32Array.from([0.1, 0.2]), Float32Array.from([0.3, 0.4]), Float32Array.from([0.5, 0.6])],
+      [new Vector(Float32Array.from([0.1, 0.2])), new Vector(Float32Array.from([0.3, 0.4])), new Vector(Float32Array.from([0.5, 0.6]))]
+    ],
+    [
+      'Vector',
+      rule.asVector(),
+      new Vector(Int32Array.from([0, 1, 2])),
+      new Vector(Int32Array.from([0, 1, 2]))
+    ],
+    [
+      'Converted Vector',
+      rule.asVector({ asTypedList: true, from: 'vec' }),
+      Float32Array.from([0.1, 0.2]),
+      new Vector(Float32Array.from([0.1, 0.2]))
+    ]
+  ])('should be able to map %s as property', (_, rule, param, expected) => {
+    if (rule.parameterConversion != null) {
+      param = rule.parameterConversion(param)
+    }
+    // @ts-expect-error
+    rule.validate(param)
+    expect(param).toEqual(expected)
+  })
+
+  it.each([
+    ['Date', rule.asDate({ stringify: true }), '2024-01-12'],
+    ['DateTime', rule.asDateTime({ stringify: true }), '2024-01-01T01:01:01-10:23:03'],
+    ['Duration', rule.asDuration({ stringify: true }), 'PT1H'],
+    ['Time', rule.asTime({ stringify: true }), '10:10:10Z'],
+    ['Simple List', rule.asList({ apply: rule.asString() }), ['hello']],
+    [
+      'Complex List',
+      rule.asList({ apply: rule.asVector({ asTypedList: true }) }),
+      [Float32Array.from([0.1, 0.2]), Float32Array.from([0.3, 0.4]), Float32Array.from([0.5, 0.6])]
+    ],
+    [
+      'Converted Vector',
+      rule.asVector({ asTypedList: true, from: 'vec' }),
+      Float32Array.from([0.1, 0.2])
+    ]
+  ])('mapping %s as property and back should be lossless', (_, rule, param) => {
+    if (rule.parameterConversion != null && rule.convert != null) {
+      expect(rule.convert(rule.parameterConversion(param), 'test convertion')).toEqual(param)
+    } else {
+      throw new Error('rule lacks parameterConversion and/or convert')
+    }
+  })
+})

--- a/packages/core/test/mapping.rulesfactories.test.ts
+++ b/packages/core/test/mapping.rulesfactories.test.ts
@@ -1,4 +1,4 @@
-import { Date, DateTime, Duration, Time, Vector } from '../src'
+import { Date, DateTime, Duration, int, Time, Vector } from '../src'
 import { rule } from '../src/mapping.rulesfactories'
 
 describe('Rulesfactories', () => {
@@ -37,7 +37,7 @@ describe('Rulesfactories', () => {
         vec: Int16Array.from([4, 8])
       },
       {
-        date: new Date(2024, 1, 12),
+        date: new Date(int(2024), int(1), int(12)),
         vector: new Vector(Int16Array.from([4, 8]))
       }
     ]

--- a/packages/core/test/mapping.rulesfactories.test.ts
+++ b/packages/core/test/mapping.rulesfactories.test.ts
@@ -28,6 +28,18 @@ describe('Rulesfactories', () => {
       rule.asVector({ asTypedList: true, from: 'vec' }),
       Float32Array.from([0.1, 0.2]),
       new Vector(Float32Array.from([0.1, 0.2]))
+    ],
+    [
+      'Object with nested rules',
+      rule.asObject({ date: rule.asDate({ stringify: true }), vec: rule.asVector({ asTypedList: true, from: 'vector' }) }),
+      {
+        date: '2024-01-12',
+        vec: Int16Array.from([4, 8])
+      },
+      {
+        date: new Date(2024, 1, 12),
+        vector: new Vector(Int16Array.from([4, 8]))
+      }
     ]
   ])('should be able to map %s as property', (_, rule, param, expected) => {
     if (rule.parameterConversion != null) {
@@ -51,12 +63,20 @@ describe('Rulesfactories', () => {
     ],
     [
       'Converted Vector',
-      rule.asVector({ asTypedList: true, from: 'vec' }),
+      rule.asVector({ asTypedList: true }),
       Float32Array.from([0.1, 0.2])
+    ],
+    [
+      'Object with nested rules',
+      rule.asObject({ date: rule.asDate({ stringify: true }), vec: rule.asVector({ asTypedList: true }) }),
+      {
+        date: '2024-01-12',
+        vec: Int16Array.from([4, 8])
+      }
     ]
   ])('mapping %s as property and back should be lossless', (_, rule, param) => {
     if (rule.parameterConversion != null && rule.convert != null) {
-      expect(rule.convert(rule.parameterConversion(param), 'test convertion')).toEqual(param)
+      expect(rule.convert(rule.parameterConversion(param), 'test conversion')).toEqual(param)
     } else {
       throw new Error('rule lacks parameterConversion and/or convert')
     }

--- a/packages/core/test/mapping.rulesfactories.test.ts
+++ b/packages/core/test/mapping.rulesfactories.test.ts
@@ -1,4 +1,4 @@
-import { Date, DateTime, Duration, int, Time, Vector } from '../src'
+import { Date, DateTime, Duration, int, Integer, Time, Vector } from '../src'
 import { rule } from '../src/mapping.rulesfactories'
 
 describe('Rulesfactories', () => {
@@ -6,6 +6,7 @@ describe('Rulesfactories', () => {
     ['Number', rule.asNumber(), 1, 1],
     ['String', rule.asString(), 'hi', 'hi'],
     ['BigInt', rule.asBigInt(), BigInt(1), BigInt(1)],
+    ['Integer', rule.asInteger(), Integer.fromValue(1), Integer.fromValue(1)],
     ['Date', rule.asDate(), new Date(1, 1, 1), new Date(1, 1, 1)],
     ['DateTime', rule.asDateTime(), new DateTime(1, 1, 1, 1, 1, 1, 1, 1), new DateTime(1, 1, 1, 1, 1, 1, 1, 1)],
     ['Duration', rule.asDuration(), new Duration(1, 1, 1, 1), new Duration(1, 1, 1, 1)],
@@ -73,6 +74,11 @@ describe('Rulesfactories', () => {
         date: '2024-01-12',
         vec: Int16Array.from([4, 8])
       }
+    ],
+    [
+      'Integer-mapped Number',
+      rule.asNumber({ isInteger: true }),
+      1
     ]
   ])('mapping %s as property and back should be lossless', (_, rule, param) => {
     if (rule.parameterConversion != null && rule.convert != null) {

--- a/packages/core/test/session.test.ts
+++ b/packages/core/test/session.test.ts
@@ -665,7 +665,7 @@ describe('session', () => {
       })
 
       expect(status.functionCalled).toEqual(true)
-      expect(run).toHaveBeenCalledWith(query, params)
+      expect(run).toHaveBeenCalledWith(query, params, undefined)
     })
 
     it('should round up sub milliseconds transaction timeouts', async () => {

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -248,6 +248,12 @@ describe('Duration', () => {
     ])('should successfully convert duration strings', (string: string, expected: Duration<number>) => {
       expect(Duration.fromString(string)).toEqual(expected)
     })
+    it.each([
+      ['P0.5M', 'Parsing Duration field: Months resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds.'],
+      ['P..0.2..25M', 'Failed to parse duration field Months. Got string: ..0.2..25.']
+    ])('should successfully convert duration strings', (string: string, expected: string) => {
+      expect(() => Duration.fromString(string)).toThrow(expected)
+    })
   })
 })
 

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -243,6 +243,7 @@ describe('DateTime', () => {
     })
     it.each([
       ['2026-01-05T15:36:42Z00:00', 'DateTime could not be parsed from string, can not parse string with offset after Z'],
+      ['2026-01-05T15:36:42Z:00', 'DateTime could not be parsed from string'],
       ['2026-01-05T15:36:42ZZ', 'DateTime could not be parsed from string'],
       ['2026-01-05T-15:36:42Z', 'DateTime could not be parsed from string'],
       ['2026-01-05 15:36:42Z', 'DateTime could not be parsed from string'],

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -78,6 +78,25 @@ describe('Date', () => {
       expect(standardDate.getUTCDate()).toEqual(localDatetime.day)
     })
   })
+  describe('fromString', () => {
+    it.each([
+      ['2026-01-05', new Date(int(2026), int(1), int(5))],
+      ['2026-01-05', new Date(int(2026), int(1), int(5))],
+      ['2026-01-05', new Date(int(2026), int(1), int(5))],
+      ['2026-01-05', new Date(int(2026), int(1), int(5))],
+      ['2026-01-05', new Date(int(2026), int(1), int(5))],
+      ['2026-01-05', new Date(int(2026), int(1), int(5))]
+    ])('should successfully convert date strings', (string: string, expected: Date<Integer>) => {
+      expect(Date.fromString(string)).toEqual(expected)
+    })
+    it.each([
+      ['2026-01-05T15:36:42ZZ', 'Date could not be parsed from string'],
+      ['2026-01-42', 'Day is expected to be in range [1, 31] but was: 42'],
+      ['2026-13-05', 'Month is expected to be in range [1, 12] but was: 13']
+    ])('should thrown when converting invalid string', (string: string, expected: string) => {
+      expect(() => Date.fromString(string)).toThrow(expected)
+    })
+  })
 })
 
 describe('LocalDateTime', () => {

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -234,16 +234,21 @@ describe('DateTime', () => {
       ['2026-01-05T15:36:42.12414Z', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(124140000), int(0))],
       ['2026-01-05T15:36.12414Z', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(7), int(448400000), int(0))],
       ['2026-01-05T15:36:42[America/Anchorage]', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), undefined, 'America/Anchorage')],
-      ['0001-01-01T01:01:01.000000001+00:00:01', new DateTime(int(1), int(1), int(1), int(1), int(1), int(1), int(1), int(1))]
-    ])('should successfully convert date strings', (string: string, expected: DateTime<Integer>) => {
+      ['0001-01-01T01:01:01.000000001+00:00:01', new DateTime(int(1), int(1), int(1), int(1), int(1), int(1), int(1), int(1))],
+      ['2026-01-05T15:36:42+0001[America/Anchorage]', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), int(60), 'America/Anchorage')],
+      ['2026-01-05T15:36:42Z[America/Anchorage]', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), int(0), 'America/Anchorage')],
+      ['2026-01-05T15:36:42-00:00[America/Anchorage]', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), int(0), 'America/Anchorage')]
+    ])('should successfully convert date string %s', (string: string, expected: DateTime<Integer>) => {
       expect(DateTime.fromString(string)).toEqual(expected)
     })
     it.each([
       ['2026-01-05T15:36:42ZZ', 'DateTime could not be parsed from string'],
       ['2026-01-05T-15:36:42Z', 'DateTime could not be parsed from string'],
       ['2026-01-05 15:36:42Z', 'DateTime could not be parsed from string'],
-      ['2026-01-05T15:36:42', 'DateTime could not be parsed from string']
-    ])('should thrown when converting invalid string', (string: string, expected: string) => {
+      ['2026-01-05T15:36:42', 'DateTime could not be parsed from string'],
+      ['2026-01-05T15:36:42+[America/Anchorage]', 'DateTime could not be parsed from string'],
+      ['2026-01-05T15:36:42-[America/Anchorage]', 'DateTime could not be parsed from string']
+    ])('should thrown when converting invalid string %s', (string: string, expected: string) => {
       expect(() => DateTime.fromString(string)).toThrow(expected)
     })
   })

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -242,12 +242,14 @@ describe('DateTime', () => {
       expect(DateTime.fromString(string)).toEqual(expected)
     })
     it.each([
+      ['2026-01-05T15:36:42Z00:00', 'DateTime could not be parsed from string, can not parse string with offset after Z'],
       ['2026-01-05T15:36:42ZZ', 'DateTime could not be parsed from string'],
       ['2026-01-05T-15:36:42Z', 'DateTime could not be parsed from string'],
       ['2026-01-05 15:36:42Z', 'DateTime could not be parsed from string'],
       ['2026-01-05T15:36:42', 'DateTime could not be parsed from string'],
       ['2026-01-05T15:36:42+[America/Anchorage]', 'DateTime could not be parsed from string'],
-      ['2026-01-05T15:36:42-[America/Anchorage]', 'DateTime could not be parsed from string']
+      ['2026-01-05T15:36:42-[America/Anchorage]', 'DateTime could not be parsed from string'],
+      ['2026-01-05T15:36:42Z00:00[America/Anchorage]', 'DateTime could not be parsed from string, can not parse string with offset after Z']
     ])('should thrown when converting invalid string %s', (string: string, expected: string) => {
       expect(() => DateTime.fromString(string)).toThrow(expected)
     })

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -243,7 +243,8 @@ describe('Duration', () => {
       ['PT-3H-1.001S', new Duration(0, 0, 3600 * -3 - 2, 999000000)],
       ['P1Y4M2D', new Duration(16, 2, 0, 0)],
       ['P4M', new Duration(4, 0, 0, 0)],
-      ['PT4M', new Duration(0, 0, 240, 0)]
+      ['PT4M', new Duration(0, 0, 240, 0)],
+      ['P0.5Y', new Duration(6, 0, 0, 0)]
     ])('should successfully convert duration strings', (string: string, expected: Duration<number>) => {
       expect(Duration.fromString(string)).toEqual(expected)
     })

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -81,16 +81,16 @@ describe('Date', () => {
   describe('fromString', () => {
     it.each([
       ['2026-01-05', new Date(int(2026), int(1), int(5))],
-      ['2026-01-05', new Date(int(2026), int(1), int(5))],
-      ['2026-01-05', new Date(int(2026), int(1), int(5))],
-      ['2026-01-05', new Date(int(2026), int(1), int(5))],
-      ['2026-01-05', new Date(int(2026), int(1), int(5))],
-      ['2026-01-05', new Date(int(2026), int(1), int(5))]
+      ['0001-01-05', new Date(int(1), int(1), int(5))],
+      ['2026-1-5', new Date(int(2026), int(1), int(5))]
     ])('should successfully convert date strings', (string: string, expected: Date<Integer>) => {
       expect(Date.fromString(string)).toEqual(expected)
     })
     it.each([
       ['2026-01-05T15:36:42ZZ', 'Date could not be parsed from string'],
+      ['2026-01-05hello', 'Date could not be parsed from string'],
+      ['godbye2026-01-05', 'Date could not be parsed from string'],
+      ['2026-01--05', 'Date could not be parsed from string'],
       ['2026-01-42', 'Day is expected to be in range [1, 31] but was: 42'],
       ['2026-13-05', 'Month is expected to be in range [1, 12] but was: 13']
     ])('should thrown when converting invalid string', (string: string, expected: string) => {
@@ -236,7 +236,10 @@ describe('DateTime', () => {
       expect(DateTime.fromString(string)).toEqual(expected)
     })
     it.each([
-      ['2026-01-05T15:36:42ZZ', 'DateTime could not be parsed from string']
+      ['2026-01-05T15:36:42ZZ', 'DateTime could not be parsed from string'],
+      ['2026-01-05T-15:36:42Z', 'DateTime could not be parsed from string'],
+      ['2026-01-05 15:36:42Z', 'DateTime could not be parsed from string'],
+      ['2026-01-05T15:36:42', 'DateTime could not be parsed from string']
     ])('should thrown when converting invalid string', (string: string, expected: string) => {
       expect(() => DateTime.fromString(string)).toThrow(expected)
     })
@@ -319,7 +322,12 @@ describe('Time', () => {
       expect(Time.fromString(string)).toEqual(expected)
     })
     it.each([
-      ['25:59:00Z', 'Hour is expected to be in range [0, 23] but was: 25']
+      ['25:59:00Z', 'Hour is expected to be in range [0, 23] but was: 25'],
+      ['23:61:00Z', 'Minute is expected to be in range [0, 59] but was: 61'],
+      ['23:59:61Z', 'Second is expected to be in range [0, 59] but was: 61'],
+      ['25:59:00', 'Time could not be parsed from string'],
+      ['25:59:00Zhello', 'Time could not be parsed from string'],
+      ['Time:25:59:00Z', 'Time could not be parsed from string']
     ])('should fail to parse invalid time strings', (string: string, expected: string) => {
       expect(() => Time.fromString(string)).toThrow(expected)
     })

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -344,7 +344,8 @@ describe('LocalTime', () => {
       ['23:59:00', new LocalTime(int(23), int(59), int(0), int(0))],
       ['23:59:00.1', new LocalTime(int(23), int(59), int(0), int(100000000))],
       ['23', new LocalTime(int(23), int(0), int(0), int(0))],
-      ['23.5', new LocalTime(int(23), int(30), int(0), int(0))]
+      ['23.5', new LocalTime(int(23), int(30), int(0), int(0))],
+      ['T010203', new LocalTime(int(1), int(2), int(3), int(0))]
     ])('should successfully convert localtime strings', (string: string, expected: LocalTime<Integer>) => {
       expect(LocalTime.fromString(string)).toEqual(expected)
     })

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -82,7 +82,7 @@ describe('Date', () => {
     it.each([
       ['2026-01-05', new Date(int(2026), int(1), int(5))],
       ['0001-01-05', new Date(int(1), int(1), int(5))],
-      ['2026-1-5', new Date(int(2026), int(1), int(5))]
+      ['+20260-10-15', new Date(int(20260), int(10), int(15))]
     ])('should successfully convert date strings', (string: string, expected: Date<Integer>) => {
       expect(Date.fromString(string)).toEqual(expected)
     })
@@ -92,7 +92,9 @@ describe('Date', () => {
       ['godbye2026-01-05', 'Date could not be parsed from string'],
       ['2026-01--05', 'Date could not be parsed from string'],
       ['2026-01-42', 'Day is expected to be in range [1, 31] but was: 42'],
-      ['2026-13-05', 'Month is expected to be in range [1, 12] but was: 13']
+      ['2026-13-05', 'Month is expected to be in range [1, 12] but was: 13'],
+      ['20260-01-05T15:36:42', 'Date could not be parsed from string'],
+      ['2026-001-05T15:36:42', 'Date could not be parsed from string']
     ])('should thrown when converting invalid string', (string: string, expected: string) => {
       expect(() => Date.fromString(string)).toThrow(expected)
     })
@@ -141,7 +143,7 @@ describe('LocalDateTime', () => {
       ['2026-01-05TT15:36', 'LocalDateTime could not be parsed from string'],
       ['2026-01-05T15:36:-42', 'LocalDateTime could not be parsed from string'],
       ['2026--1-05T15:36:42', 'LocalDateTime could not be parsed from string'],
-      ['1000000000000000000000-01-05T00:01:00.1', 'Year is expected to be in range [-999999999, 999999999] but was:'],
+      ['+1000000000000000000000-01-05T00:01:00.1', 'Year is expected to be in range [-999999999, 999999999] but was:'],
       ['0000-01-05T00:01:00.1bc', 'LocalDateTime could not be parsed from string']
     ])('should thrown when converting invalid string', (string: string, expected: string) => {
       expect(() => LocalDateTime.fromString(string)).toThrow(expected)
@@ -231,7 +233,8 @@ describe('DateTime', () => {
       ['2026-01-05T15:36:42Z', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), int(0))],
       ['2026-01-05T15:36:42.12414Z', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(124140000), int(0))],
       ['2026-01-05T15:36.12414Z', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(7), int(448400000), int(0))],
-      ['2026-01-05T15:36:42[America/Anchorage]', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), undefined, 'America/Anchorage')]
+      ['2026-01-05T15:36:42[America/Anchorage]', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), undefined, 'America/Anchorage')],
+      ['0001-01-01T01:01:01.000000001+00:00:01', new DateTime(int(1), int(1), int(1), int(1), int(1), int(1), int(1), int(1))]
     ])('should successfully convert date strings', (string: string, expected: DateTime<Integer>) => {
       expect(DateTime.fromString(string)).toEqual(expected)
     })
@@ -303,8 +306,9 @@ describe('Duration', () => {
       ['PT0.3.3S', 'Duration could not be parsed from string: PT0.3.3'],
       ['ok... so somewhere in here is a PT1S duration...', 'Duration could not be parsed from string'],
       ['P', 'Duration could not be parsed from string: P'],
-      ['PT', 'Duration could not be parsed from string: PT'],
-      ['P1S', 'Duration could not be parsed from string: P1S']
+      ['PT', 'Duration string \'PT\' ends with \'T\', time delimiter must be excluded if Duration contains no time components'],
+      ['P1S', 'Duration could not be parsed from string: P1S'],
+      ['P1YT', 'Duration string \'P1YT\' ends with \'T\', time delimiter must be excluded if Duration contains no time components']
     ])('should fail to parse invalid duration strings', (string: string, expected: string) => {
       expect(() => Duration.fromString(string)).toThrow(expected)
     })
@@ -316,7 +320,7 @@ describe('Time', () => {
     it.each([
       ['23:59:00Z', new Time(int(23), int(59), int(0), int(0), int(0))],
       ['23:59:00+1010', new Time(int(23), int(59), int(0), int(0), int(10 * 3600 + 10 * 60))],
-      ['23:59:00+1', new Time(int(23), int(59), int(0), int(0), int(3600))],
+      ['23:59:00+01', new Time(int(23), int(59), int(0), int(0), int(3600))],
       ['23:59:00-01:01', new Time(int(23), int(59), int(0), int(0), int(-3660))]
     ])('should successfully convert time strings', (string: string, expected: Time<Integer>) => {
       expect(Time.fromString(string)).toEqual(expected)

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -18,7 +18,7 @@
 import { LocalDateTime, Date, DateTime, Duration, isDuration, LocalTime, isLocalTime, Time, isTime, isDate, isLocalDateTime, isDateTime } from '../src/temporal-types'
 import { temporalUtil } from '../src/internal'
 import fc from 'fast-check'
-import { Integer } from '../src'
+import { int, Integer } from '../src'
 
 const MIN_UTC_IN_MS = -8_640_000_000_000_000
 const MAX_UTC_IN_MS = 8_640_000_000_000_000
@@ -107,11 +107,25 @@ describe('LocalDateTime', () => {
       )
     })
   })
-  describe('fromString', () => {
+  describe('.fromString', () => {
     it.each([
-      ['2026-01-05T15:36:42', new LocalDateTime(2026, 1, 5, 15, 36, 42, 0)]
-    ])('should successfully convert date strings', (string: string, expected: LocalDateTime<number>) => {
+      ['2026-01-05T15:36:42', new LocalDateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0))],
+      ['2026-01-05T15:36:42.1', new LocalDateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(100000000))],
+      ['0000-01-05T00:01:00.1', new LocalDateTime(int(0), int(1), int(5), int(0), int(1), int(0), int(100000000))]
+    ])('should successfully convert date strings', (string: string, expected: LocalDateTime<Integer>) => {
       expect(LocalDateTime.fromString(string)).toEqual(expected)
+    })
+    it.each([
+      ['2026-01-05TT15:36:42', 'LocalDateTime could not be parsed from string'],
+      [' 2026-01-05T15:36:42', 'LocalDateTime could not be parsed from string'],
+      ['+2026-01-05T15:36:42', 'LocalDateTime could not be parsed from string'],
+      ['2026-01-05TT15:36', 'LocalDateTime could not be parsed from string'],
+      ['2026-01-05T15:36:-42', 'LocalDateTime could not be parsed from string'],
+      ['2026--1-05T15:36:42', 'LocalDateTime could not be parsed from string'],
+      ['1000000000000000000000-01-05T00:01:00.1', 'Year is expected to be in range [-999999999, 999999999] but was:'],
+      ['0000-01-05T00:01:00.1bc', 'LocalDateTime could not be parsed from string']
+    ])('should thrown when converting invalid string', (string: string, expected: string) => {
+      expect(() => LocalDateTime.fromString(string)).toThrow(expected)
     })
   })
 })
@@ -193,12 +207,19 @@ describe('DateTime', () => {
 
   describe('fromString', () => {
     it.each([
-      ['2026-01-05T15:36:42.01+01:00', new DateTime(2026, 1, 5, 15, 36, 42, 10000000, 3600)],
-      ['2026-01-05T15:36:42.01-01:00', new DateTime(2026, 1, 5, 15, 36, 42, 10000000, -3600)],
-      ['2026-01-05T15:36:42Z', new DateTime(2026, 1, 5, 15, 36, 42, 0, 0)],
-      ['2026-01-05T15:36:42[America/Anchorage]', new DateTime(2026, 1, 5, 15, 36, 42, 0, undefined, 'America/Anchorage')]
-    ])('should successfully convert date strings', (string: string, expected: DateTime<number>) => {
+      ['2026-01-05T15:36:42.01+01:00', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(10000000), int(3600))],
+      ['2026-01-05T15:36:42.01-01:00', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(10000000), int(-3600))],
+      ['2026-01-05T15:36:42Z', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), int(0))],
+      ['2026-01-05T15:36:42.12414Z', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(124140000), int(0))],
+      ['2026-01-05T15:36.12414Z', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(7), int(448400000), int(0))],
+      ['2026-01-05T15:36:42[America/Anchorage]', new DateTime(int(2026), int(1), int(5), int(15), int(36), int(42), int(0), undefined, 'America/Anchorage')]
+    ])('should successfully convert date strings', (string: string, expected: DateTime<Integer>) => {
       expect(DateTime.fromString(string)).toEqual(expected)
+    })
+    it.each([
+      ['2026-01-05T15:36:42ZZ', 'DateTime could not be parsed from string']
+    ])('should thrown when converting invalid string', (string: string, expected: string) => {
+      expect(() => DateTime.fromString(string)).toThrow(expected)
     })
   })
 })
@@ -236,24 +257,73 @@ describe('Duration', () => {
     expect(duration.seconds).toEqual(seconds)
     expect(duration.nanoseconds).toEqual(nanos)
   })
+
   describe('fromString', () => {
     it.each([
-      ['PT1S', new Duration(0, 0, 1, 0)],
-      ['PT-1.001S', new Duration(0, 0, -2, 999000000)],
-      ['PT3H-1.001S', new Duration(0, 0, 3600 * 3 - 2, 999000000)],
-      ['PT-3H-1.001S', new Duration(0, 0, 3600 * -3 - 2, 999000000)],
-      ['P1Y4M2D', new Duration(16, 2, 0, 0)],
-      ['P4M', new Duration(4, 0, 0, 0)],
-      ['PT4M', new Duration(0, 0, 240, 0)],
-      ['P0.5Y', new Duration(6, 0, 0, 0)]
-    ])('should successfully convert duration strings', (string: string, expected: Duration<number>) => {
+      ['PT1S', new Duration(int(0), int(0), int(1), int(0))],
+      ['PT-1.001S', new Duration(int(0), int(0), int(-2), int(999000000))],
+      ['PT3H-1.001S', new Duration(int(0), int(0), int(3600 * 3 - 2), int(999000000))],
+      ['PT-3H-1.001S', new Duration(int(0), int(0), int(3600 * -3 - 2), int(999000000))],
+      ['P1Y4M2D', new Duration(int(16), int(2), int(0), int(0))],
+      ['P4M', new Duration(int(4), int(0), int(0), int(0))],
+      ['PT4M', new Duration(int(0), int(0), int(240), int(0))],
+      ['P0.5Y', new Duration(int(6), int(0), int(0), int(0))],
+      ['PT2147483648.1S', new Duration(int(0), int(0), int(2147483648), int(100000000))],
+      ['PT1s', new Duration(int(0), int(0), int(1), int(0))],
+      ['PT1,1S', new Duration(int(0), int(0), int(1), int(100000000))],
+      ['PT1.1S', new Duration(int(0), int(0), int(1), int(100000000))]
+    ])('should successfully convert duration strings', (string: string, expected: Duration<Integer>) => {
       expect(Duration.fromString(string)).toEqual(expected)
     })
     it.each([
       ['P0.5M', 'Parsing Duration field: Months resulted in a non-integer value. Bolt protocol can only send durations which can be simplified to integer values of months, days, seconds and nanoseconds.'],
-      ['P..0.2..25M', 'Failed to parse duration field Months. Got string: ..0.2..25.']
+      ['P..0.2..25M', 'Duration could not be parsed from string: P..0.2..25M'],
+      ['PT0.3.3S', 'Duration could not be parsed from string: PT0.3.3'],
+      ['ok... so somewhere in here is a PT1S duration...', 'Duration could not be parsed from string'],
+      ['P', 'Duration could not be parsed from string: P'],
+      ['PT', 'Duration could not be parsed from string: PT'],
+      ['P1S', 'Duration could not be parsed from string: P1S']
     ])('should fail to parse invalid duration strings', (string: string, expected: string) => {
       expect(() => Duration.fromString(string)).toThrow(expected)
+    })
+  })
+})
+
+describe('Time', () => {
+  describe('.fromString', () => {
+    it.each([
+      ['23:59:00Z', new Time(int(23), int(59), int(0), int(0), int(0))],
+      ['23:59:00+1010', new Time(int(23), int(59), int(0), int(0), int(10 * 3600 + 10 * 60))],
+      ['23:59:00+1', new Time(int(23), int(59), int(0), int(0), int(3600))],
+      ['23:59:00-01:01', new Time(int(23), int(59), int(0), int(0), int(-3660))]
+    ])('should successfully convert time strings', (string: string, expected: Time<Integer>) => {
+      expect(Time.fromString(string)).toEqual(expected)
+    })
+    it.each([
+      ['25:59:00Z', 'Hour is expected to be in range [0, 23] but was: 25']
+    ])('should fail to parse invalid time strings', (string: string, expected: string) => {
+      expect(() => Time.fromString(string)).toThrow(expected)
+    })
+  })
+})
+
+describe('LocalTime', () => {
+  describe('.fromString', () => {
+    it.each([
+      ['23:59:00', new LocalTime(int(23), int(59), int(0), int(0))],
+      ['23:59:00.1', new LocalTime(int(23), int(59), int(0), int(100000000))],
+      ['23', new LocalTime(int(23), int(0), int(0), int(0))],
+      ['23.5', new LocalTime(int(23), int(30), int(0), int(0))]
+    ])('should successfully convert localtime strings', (string: string, expected: LocalTime<Integer>) => {
+      expect(LocalTime.fromString(string)).toEqual(expected)
+    })
+    it.each([
+      ['25:59:00', 'Hour is expected to be in range [0, 23] but was: 25'],
+      ['23 59 00', 'LocalTime could not be parsed from string'],
+      ['23.59:00', 'LocalTime could not be parsed from string'],
+      ['23:00:1', 'LocalTime could not be parsed from string']
+    ])('should fail to parse invalid localtime strings', (string: string, expected: string) => {
+      expect(() => LocalTime.fromString(string)).toThrow(expected)
     })
   })
 })

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -107,6 +107,13 @@ describe('LocalDateTime', () => {
       )
     })
   })
+  describe('fromString', () => {
+    it.each([
+      ['2026-01-05T15:36:42', new LocalDateTime(2026, 1, 5, 15, 36, 42, 0)]
+    ])('should successfully convert date strings', (string: string, expected: LocalDateTime<number>) => {
+      expect(LocalDateTime.fromString(string)).toEqual(expected)
+    })
+  })
 })
 
 describe('DateTime', () => {
@@ -183,6 +190,16 @@ describe('DateTime', () => {
       )
     })
   })
+
+  describe('fromString', () => {
+    it.each([
+      ['2026-01-05T15:36:42.01+01:00', new DateTime(2026, 1, 5, 15, 36, 42, 10000000, 3600)],
+      ['2026-01-05T15:36:42.01-01:00', new DateTime(2026, 1, 5, 15, 36, 42, 10000000, -3600)],
+      ['2026-01-05T15:36:42Z', new DateTime(2026, 1, 5, 15, 36, 42, 0, 0)]
+    ])('should successfully convert date strings', (string: string, expected: DateTime<number>) => {
+      expect(DateTime.fromString(string)).toEqual(expected)
+    })
+  })
 })
 
 describe('Duration', () => {
@@ -217,6 +234,19 @@ describe('Duration', () => {
     expect(duration.days).toEqual(days)
     expect(duration.seconds).toEqual(seconds)
     expect(duration.nanoseconds).toEqual(nanos)
+  })
+  describe('fromString', () => {
+    it.each([
+      ['PT1S', new Duration(0, 0, 1, 0)],
+      ['PT-1.001S', new Duration(0, 0, -2, 999000000)],
+      ['PT3H-1.001S', new Duration(0, 0, 3600 * 3 - 2, 999000000)],
+      ['PT-3H-1.001S', new Duration(0, 0, 3600 * -3 - 2, 999000000)],
+      ['P1Y4M2D', new Duration(16, 2, 0, 0)],
+      ['P4M', new Duration(4, 0, 0, 0)],
+      ['PT4M', new Duration(0, 0, 240, 0)]
+    ])('should successfully convert duration strings', (string: string, expected: Duration<number>) => {
+      expect(Duration.fromString(string)).toEqual(expected)
+    })
   })
 })
 

--- a/packages/core/test/temporal-types.test.ts
+++ b/packages/core/test/temporal-types.test.ts
@@ -195,7 +195,8 @@ describe('DateTime', () => {
     it.each([
       ['2026-01-05T15:36:42.01+01:00', new DateTime(2026, 1, 5, 15, 36, 42, 10000000, 3600)],
       ['2026-01-05T15:36:42.01-01:00', new DateTime(2026, 1, 5, 15, 36, 42, 10000000, -3600)],
-      ['2026-01-05T15:36:42Z', new DateTime(2026, 1, 5, 15, 36, 42, 0, 0)]
+      ['2026-01-05T15:36:42Z', new DateTime(2026, 1, 5, 15, 36, 42, 0, 0)],
+      ['2026-01-05T15:36:42[America/Anchorage]', new DateTime(2026, 1, 5, 15, 36, 42, 0, undefined, 'America/Anchorage')]
     ])('should successfully convert date strings', (string: string, expected: DateTime<number>) => {
       expect(DateTime.fromString(string)).toEqual(expected)
     })
@@ -249,9 +250,9 @@ describe('Duration', () => {
       expect(Duration.fromString(string)).toEqual(expected)
     })
     it.each([
-      ['P0.5M', 'Parsing Duration field: Months resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds.'],
+      ['P0.5M', 'Parsing Duration field: Months resulted in a non-integer value. Bolt protocol can only send durations which can be simplified to integer values of months, days, seconds and nanoseconds.'],
       ['P..0.2..25M', 'Failed to parse duration field Months. Got string: ..0.2..25.']
-    ])('should successfully convert duration strings', (string: string, expected: string) => {
+    ])('should fail to parse invalid duration strings', (string: string, expected: string) => {
       expect(() => Duration.fromString(string)).toThrow(expected)
     })
   })

--- a/packages/neo4j-driver-deno/deno.lock
+++ b/packages/neo4j-driver-deno/deno.lock
@@ -1,5 +1,5 @@
 {
-  "version": "4",
+  "version": "5",
   "remote": {
     "https://deno.land/std@0.119.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
     "https://deno.land/std@0.119.0/_util/os.ts": "dfb186cc4e968c770ab6cc3288bd65f4871be03b93beecae57d657232ecffcac",
@@ -87,6 +87,10 @@
     "https://deno.land/std@0.157.0/bytes/equals.ts": "3c3558c3ae85526f84510aa2b48ab2ad7bdd899e2e0f5b7a8ffc85acb3a6043a",
     "https://deno.land/std@0.157.0/bytes/mod.ts": "763f97d33051cc3f28af1a688dfe2830841192a9fea0cbaa55f927b49d49d0bf",
     "https://deno.land/std@0.157.0/io/buffer.ts": "fae02290f52301c4e0188670e730cd902f9307fb732d79c4aa14ebdc82497289",
-    "https://deno.land/std@0.157.0/streams/conversion.ts": "fc4eb76a14148c43f0b85e903a5a1526391aa40ed9434dc21e34f88304eb823e"
+    "https://deno.land/std@0.157.0/streams/conversion.ts": "fc4eb76a14148c43f0b85e903a5a1526391aa40ed9434dc21e34f88304eb823e",
+    "https://deno.land/std@0.182.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.182.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.182.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.182.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
   }
 }

--- a/packages/neo4j-driver-deno/deno.lock
+++ b/packages/neo4j-driver-deno/deno.lock
@@ -1,5 +1,5 @@
 {
-  "version": "5",
+  "version": "4",
   "remote": {
     "https://deno.land/std@0.119.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
     "https://deno.land/std@0.119.0/_util/os.ts": "dfb186cc4e968c770ab6cc3288bd65f4871be03b93beecae57d657232ecffcac",
@@ -87,10 +87,6 @@
     "https://deno.land/std@0.157.0/bytes/equals.ts": "3c3558c3ae85526f84510aa2b48ab2ad7bdd899e2e0f5b7a8ffc85acb3a6043a",
     "https://deno.land/std@0.157.0/bytes/mod.ts": "763f97d33051cc3f28af1a688dfe2830841192a9fea0cbaa55f927b49d49d0bf",
     "https://deno.land/std@0.157.0/io/buffer.ts": "fae02290f52301c4e0188670e730cd902f9307fb732d79c4aa14ebdc82497289",
-    "https://deno.land/std@0.157.0/streams/conversion.ts": "fc4eb76a14148c43f0b85e903a5a1526391aa40ed9434dc21e34f88304eb823e",
-    "https://deno.land/std@0.182.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.182.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.182.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.182.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
+    "https://deno.land/std@0.157.0/streams/conversion.ts": "fc4eb76a14148c43f0b85e903a5a1526391aa40ed9434dc21e34f88304eb823e"
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -49,6 +49,7 @@ import NotificationFilter from './notification-filter.ts'
 import HomeDatabaseCache from './internal/homedb-cache.ts'
 import { cacheKey } from './internal/auth-util.ts'
 import { ProtocolVersion } from './protocol-version.ts'
+import { Rules } from './mapping.highlevel.ts'
 
 const DEFAULT_MAX_CONNECTION_LIFETIME: number = 60 * 60 * 1000 // 1 hour
 
@@ -368,6 +369,7 @@ class QueryConfig<T = EagerResult> {
   transactionConfig?: TransactionConfig
   auth?: AuthToken
   signal?: AbortSignal
+  parameterRules?: Rules
 
   /**
    * @constructor
@@ -630,7 +632,7 @@ class Driver {
       transactionConfig: config.transactionConfig,
       auth: config.auth,
       signal: config.signal
-    }, query, parameters)
+    }, query, parameters, config.parameterRules)
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -607,7 +607,7 @@ class Driver {
    * }
    *
    * @public
-   * @param {string | {text: string, parameters?: object}} query - Cypher query to execute
+   * @param {string | {text: string, parameters?: object, parameterRules?: Rules}} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in the query
    * @param {QueryConfig<T>} config - The query configuration
    * @returns {Promise<T>}

--- a/packages/neo4j-driver-deno/lib/core/driver.ts
+++ b/packages/neo4j-driver-deno/lib/core/driver.ts
@@ -369,7 +369,6 @@ class QueryConfig<T = EagerResult> {
   transactionConfig?: TransactionConfig
   auth?: AuthToken
   signal?: AbortSignal
-  parameterRules?: Rules
 
   /**
    * @constructor
@@ -610,11 +609,12 @@ class Driver {
    * @param {string | {text: string, parameters?: object, parameterRules?: Rules}} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in the query
    * @param {QueryConfig<T>} config - The query configuration
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @returns {Promise<T>}
    *
    * @see {@link resultTransformers} for provided result transformers.
    */
-  async executeQuery<T = EagerResult> (query: Query, parameters?: any, config: QueryConfig<T> = {}): Promise<T> {
+  async executeQuery<T = EagerResult> (query: Query, parameters?: any, config: QueryConfig<T> = {}, parameterRules?: Rules): Promise<T> {
     const bookmarkManager = config.bookmarkManager === null ? undefined : (config.bookmarkManager ?? this.executeQueryBookmarkManager)
     const resultTransformer = (config.resultTransformer ?? resultTransformers.eager()) as ResultTransformer<T>
     const routingConfig: string = config.routing ?? routing.WRITE
@@ -632,7 +632,7 @@ class Driver {
       transactionConfig: config.transactionConfig,
       auth: config.auth,
       signal: config.signal
-    }, query, parameters, config.parameterRules)
+    }, query, parameters, parameterRules)
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/graph-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/graph-types.ts
@@ -90,8 +90,6 @@ class Node<T extends NumberOrInteger = Integer, P extends Properties = Propertie
    * @param {GenericConstructor<T> | Rules} constructorOrRules Constructor for the desired type or {@link Rules} for the hydration
    * @param {Rules} [rules] {@link Rules} for the hydration
    * @returns {T}
-   *
-   * @experimental Part of the Record Object Mapping preview feature
    */
   as <T extends {} = Object>(rules: Rules): T
   as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
@@ -225,8 +223,6 @@ class Relationship<T extends NumberOrInteger = Integer, P extends Properties = P
    * @param {GenericConstructor<T> | Rules} constructorOrRules Constructor for the desired type or {@link Rules} for the hydration
    * @param {Rules} [rules] {@link Rules} for the hydration
    * @returns {T}
-   *
-   * @experimental Part of the Record Object Mapping preview feature
    */
   as <T extends {} = Object>(rules: Rules): T
   as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T
@@ -364,8 +360,6 @@ class UnboundRelationship<T extends NumberOrInteger = Integer, P extends Propert
    * @param {GenericConstructor<T> | Rules} constructorOrRules Constructor for the desired type or {@link Rules} for the hydration
    * @param {Rules} [rules] {@link Rules} for the hydration
    * @returns {T}
-   *
-   * @experimental Part of the Record Object Mapping preview feature
    */
   as <T extends {} = Object>(rules: Rules): T
   as <T extends {} = Object>(genericConstructor: GenericConstructor<T>): T

--- a/packages/neo4j-driver-deno/lib/core/graph-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/graph-types.ts
@@ -18,6 +18,7 @@ import Integer from './integer.ts'
 import { stringify } from './json.ts'
 import { Rules, GenericConstructor, as } from './mapping.highlevel.ts'
 
+export const StandardDateClass = Date
 type StandardDate = Date
 /**
  * @typedef {number | Integer | bigint} NumberOrInteger

--- a/packages/neo4j-driver-deno/lib/core/graph-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/graph-types.ts
@@ -18,7 +18,7 @@ import Integer from './integer.ts'
 import { stringify } from './json.ts'
 import { Rules, GenericConstructor, as } from './mapping.highlevel.ts'
 
-export const StandardDateClass = Date
+export const JSDate = Date
 type StandardDate = Date
 /**
  * @typedef {number | Integer | bigint} NumberOrInteger

--- a/packages/neo4j-driver-deno/lib/core/graph-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/graph-types.ts
@@ -18,7 +18,6 @@ import Integer from './integer.ts'
 import { stringify } from './json.ts'
 import { Rules, GenericConstructor, as } from './mapping.highlevel.ts'
 
-export const JSDate = Date
 type StandardDate = Date
 /**
  * @typedef {number | Integer | bigint} NumberOrInteger

--- a/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/query-executor.ts
@@ -21,6 +21,7 @@ import Result from '../result.ts'
 import ManagedTransaction from '../transaction-managed.ts'
 import { AuthToken, Query } from '../types.ts'
 import { TELEMETRY_APIS } from './constants.ts'
+import { Rules } from '../mapping.highlevel.ts'
 
 type SessionFactory = (config: { database?: string, bookmarkManager?: BookmarkManager, impersonatedUser?: string, auth?: AuthToken }) => Session
 
@@ -42,7 +43,7 @@ export default class QueryExecutor {
 
   }
 
-  public async execute<T>(config: ExecutionConfig<T>, query: Query, parameters?: any): Promise<T> {
+  public async execute<T>(config: ExecutionConfig<T>, query: Query, parameters?: any, parameterRules?: Rules): Promise<T> {
     const session = this._createSession({
       database: config.database,
       bookmarkManager: config.bookmarkManager,
@@ -65,7 +66,7 @@ export default class QueryExecutor {
         : session.executeWrite.bind(session)
 
       return await executeInTransaction(async (tx: ManagedTransaction) => {
-        const result = tx.run(query, parameters)
+        const result = tx.run(query, parameters, parameterRules)
         return await config.resultTransformer(result)
       }, config.transactionConfig)
     } finally {

--- a/packages/neo4j-driver-deno/lib/core/internal/util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/util.ts
@@ -19,7 +19,7 @@ import Integer, { isInt, int } from '../integer.ts'
 import { NumberOrInteger } from '../graph-types.ts'
 import { EncryptionLevel } from '../types.ts'
 import { stringify } from '../json.ts'
-import { Rules, validateAndCleanParams } from '../mapping.highlevel.ts'
+import { Rules, validateAndcleanParameters } from '../mapping.highlevel.ts'
 
 const ENCRYPTION_ON: EncryptionLevel = 'ENCRYPTION_ON'
 const ENCRYPTION_OFF: EncryptionLevel = 'ENCRYPTION_OFF'
@@ -85,7 +85,7 @@ function validateQueryAndParameters (
   }
 
   if (!skipAsserts) {
-    params = validateAndCleanParams(params, parameterRules)
+    params = validateAndcleanParameters(params, parameterRules)
     assertCypherQuery(validatedQuery)
     assertQueryParameters(params)
   }

--- a/packages/neo4j-driver-deno/lib/core/internal/util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/util.ts
@@ -63,7 +63,7 @@ function isObject (obj: any): boolean {
  * @throws TypeError when either given query or parameters are invalid.
  */
 function validateQueryAndParameters (
-  query: string | String | { text: string, parameters?: any, parameterRules?: Rules},
+  query: string | String | { text: string, parameters?: any, parameterRules?: Rules },
   parameters?: any,
   opt?: { skipAsserts?: boolean, parameterRules?: Rules }
 ): {
@@ -83,7 +83,7 @@ function validateQueryAndParameters (
     params = query.parameters ?? {}
     parameterRules = query.parameterRules
   }
-  
+
   if (!skipAsserts) {
     params = validateAndCleanParams(params, parameterRules)
     assertCypherQuery(validatedQuery)

--- a/packages/neo4j-driver-deno/lib/core/internal/util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/util.ts
@@ -19,7 +19,7 @@ import Integer, { isInt, int } from '../integer.ts'
 import { NumberOrInteger } from '../graph-types.ts'
 import { EncryptionLevel } from '../types.ts'
 import { stringify } from '../json.ts'
-import { Rules, validateAndcleanParameters } from '../mapping.highlevel.ts'
+import { Rules, validateAndCleanParameters } from '../mapping.highlevel.ts'
 
 const ENCRYPTION_ON: EncryptionLevel = 'ENCRYPTION_ON'
 const ENCRYPTION_OFF: EncryptionLevel = 'ENCRYPTION_OFF'
@@ -86,7 +86,7 @@ function validateQueryAndParameters (
   }
 
   if (!skipAsserts) {
-    params = validateAndcleanParameters(params, parameterRules)
+    params = validateAndCleanParameters(params, parameterRules)
     assertCypherQuery(validatedQuery)
     assertQueryParameters(params)
   }

--- a/packages/neo4j-driver-deno/lib/core/internal/util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/util.ts
@@ -19,6 +19,7 @@ import Integer, { isInt, int } from '../integer.ts'
 import { NumberOrInteger } from '../graph-types.ts'
 import { EncryptionLevel } from '../types.ts'
 import { stringify } from '../json.ts'
+import { Rules, validateAndCleanParams } from '../mapping.highlevel.ts'
 
 const ENCRYPTION_ON: EncryptionLevel = 'ENCRYPTION_ON'
 const ENCRYPTION_OFF: EncryptionLevel = 'ENCRYPTION_OFF'
@@ -62,17 +63,17 @@ function isObject (obj: any): boolean {
  * @throws TypeError when either given query or parameters are invalid.
  */
 function validateQueryAndParameters (
-  query: string | String | { text: string, parameters?: any },
+  query: string | String | { text: string, parameters?: any, parameterRules?: Rules},
   parameters?: any,
-  opt?: { skipAsserts: boolean }
+  opt?: { skipAsserts?: boolean, parameterRules?: Rules }
 ): {
     validatedQuery: string
     params: any
   } {
   let validatedQuery: string = ''
   let params = parameters ?? {}
+  let parameterRules = opt?.parameterRules
   const skipAsserts: boolean = opt?.skipAsserts ?? false
-
   if (typeof query === 'string') {
     validatedQuery = query
   } else if (query instanceof String) {
@@ -80,9 +81,11 @@ function validateQueryAndParameters (
   } else if (typeof query === 'object' && query.text != null) {
     validatedQuery = query.text
     params = query.parameters ?? {}
+    parameterRules = query.parameterRules
   }
-
+  
   if (!skipAsserts) {
+    params = validateAndCleanParams(params, parameterRules)
     assertCypherQuery(validatedQuery)
     assertQueryParameters(params)
   }

--- a/packages/neo4j-driver-deno/lib/core/internal/util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/util.ts
@@ -74,6 +74,7 @@ function validateQueryAndParameters (
   let params = parameters ?? {}
   let parameterRules = opt?.parameterRules
   const skipAsserts: boolean = opt?.skipAsserts ?? false
+
   if (typeof query === 'string') {
     validatedQuery = query
   } else if (query instanceof String) {

--- a/packages/neo4j-driver-deno/lib/core/internal/util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/util.ts
@@ -20,6 +20,7 @@ import { NumberOrInteger } from '../graph-types.ts'
 import { EncryptionLevel } from '../types.ts'
 import { stringify } from '../json.ts'
 import { Rules, validateAndCleanParameters } from '../mapping.highlevel.ts'
+import { newError } from '../error.ts'
 
 const ENCRYPTION_ON: EncryptionLevel = 'ENCRYPTION_ON'
 const ENCRYPTION_OFF: EncryptionLevel = 'ENCRYPTION_OFF'
@@ -57,8 +58,9 @@ function isObject (obj: any): boolean {
 
 /**
  * Check and normalize given query and parameters.
- * @param {string|{text: string, parameters: Object}} query the query to check.
- * @param {Object} parameters
+ * @param {string|{text: string, parameters: Object, parameterRules: Rules}} query the query to check.
+ * @param {Object} parameters the parameters to validate
+ * @param {{skipAsserts: boolean, parameterRules: Rules}} opt options to skip assertions, and parameterRules to check if query is not an object.
  * @return {{validatedQuery: string|{text: string, parameters: Object}, params: Object}} the normalized query with parameters.
  * @throws TypeError when either given query or parameters are invalid.
  */
@@ -80,9 +82,15 @@ function validateQueryAndParameters (
   } else if (query instanceof String) {
     validatedQuery = query.toString()
   } else if (typeof query === 'object' && query.text != null) {
+    if (!skipAsserts) {
+      // TODO: in 7.0 throw error if parameters put in a separate argument when using Query object.
+      if (opt?.parameterRules != null) {
+        throw newError('When using a Query object, parameterRules should be present in the object and not in a separate argument.')
+      }
+    }
     validatedQuery = query.text
     params = query.parameters ?? {}
-    parameterRules = query.parameterRules ?? parameterRules
+    parameterRules = query.parameterRules
   }
 
   if (!skipAsserts) {

--- a/packages/neo4j-driver-deno/lib/core/internal/util.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/util.ts
@@ -82,7 +82,7 @@ function validateQueryAndParameters (
   } else if (typeof query === 'object' && query.text != null) {
     validatedQuery = query.text
     params = query.parameters ?? {}
-    parameterRules = query.parameterRules
+    parameterRules = query.parameterRules ?? parameterRules
   }
 
   if (!skipAsserts) {

--- a/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
@@ -124,7 +124,7 @@ function pointProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Duration.
  *
- * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
  * @returns {Function} Property Decorator
  */
 function durationProperty (config?: Rule & { stringify?: boolean }) {
@@ -136,7 +136,7 @@ function durationProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalTime
  *
- * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function localTimeProperty (config?: Rule & { stringify?: boolean }) {
@@ -148,7 +148,7 @@ function localTimeProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Time
  *
- * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
  * @returns {Function} Property Decorator
  */
 function timeProperty (config?: Rule & { stringify?: boolean }) {
@@ -160,7 +160,7 @@ function timeProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Date
  *
- * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
  * @returns {Function} Property Decorator
  */
 function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -172,7 +172,7 @@ function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boo
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalDateTIme
  *
- * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -184,7 +184,7 @@ function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeD
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a DateTIme
  *
- * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the applied rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function dateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -208,7 +208,7 @@ function listProperty (config?: Rule & { apply?: Rule }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Vector
  *
- * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
+ * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64" }} config Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
  * @returns {Function} Property Decorator
  */
 function vectorProperty (config?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }) {

--- a/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
@@ -39,7 +39,7 @@ function stringProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a number.
  *
- * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule.
+ * @param {Rule & { isInteger?: boolean }} config Configurations for the rule.
  * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
  * @returns {Function} Property Decorator
  */
@@ -134,6 +134,66 @@ function durationProperty (config?: Rule & { stringify?: boolean }) {
 }
 
 /**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalTime
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function localTimeProperty (config?: Rule & { stringify?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asLocalTime(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a Time
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function timeProperty (config?: Rule & { stringify?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asTime(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a Date
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asDate(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalDateTIme
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asLocalDateTime(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to a DateTIme
+ *
+ * @param {Rule & { apply?: Rule }} config
+ * @returns {Function} Property Decorator
+ */
+function dateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asDateTime(config)
+  }
+}
+
+/**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a List
  *
  * @param {Rule & { apply?: Rule }} config
@@ -148,10 +208,10 @@ function listProperty (config?: Rule & { apply?: Rule }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Vector
  *
- * @param {Rule & { asTypedList?: boolean }} config
+ * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config
  * @returns {Function} Property Decorator
  */
-function vectorProperty (config?: Rule & { asTypedList?: boolean }) {
+function vectorProperty (config?: Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64" }) {
   return (_: any, context: any) => {
     context.metadata[context.name] = rule.asVector(config)
   }
@@ -161,7 +221,6 @@ function vectorProperty (config?: Rule & { asTypedList?: boolean }) {
  * Property Decorator Factory that sets this property to optional.
  * NOTE: Should be put above a type decorator.
  *
- * @param {Rule} config
  * @returns {Function} Property Decorator
  */
 function optionalProperty () {
@@ -174,7 +233,7 @@ function optionalProperty () {
  * Property Decorator Factory that sets a custom parameter name to map this property to.
  * NOTE: Should be put above a type decorator.
  *
- * @param {Rule} config
+ * @param {string} name
  * @returns {Function} Property Decorator
  */
 function mapPropertyFromName (name: string) {
@@ -187,7 +246,7 @@ function mapPropertyFromName (name: string) {
  * Property Decorator Factory that sets the Neo4j Driver to convert this property to another type.
  * NOTE: Should be put above a type decorator of type Node or Relationship.
  *
- * @param {Rule} config
+ * @param {any} type
  * @returns {Function} Property Decorator
  */
 function convertPropertyToType (type: any) {
@@ -207,6 +266,11 @@ const forExport = {
   pathProperty,
   pointProperty,
   durationProperty,
+  localTimeProperty,
+  timeProperty,
+  dateProperty,
+  localDateTimeProperty,
+  dateTimeProperty,
   listProperty,
   vectorProperty,
   optionalProperty,

--- a/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
@@ -5,7 +5,6 @@ import { rule } from './mapping.rulesfactories.ts'
  * Class Decorator Factory that enables the Neo4j Driver to map result records to this class
  *
  * @returns {Function} Class Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function mappedClass () {
   return (_: any, context: any) => {
@@ -18,7 +17,6 @@ function mappedClass () {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function booleanProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -31,7 +29,6 @@ function booleanProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function stringProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -44,7 +41,6 @@ function stringProperty (config?: Rule) {
  *
  * @param {Rule & { acceptBigInt?: boolean }} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function numberProperty (config?: Rule & { acceptBigInt?: boolean }) {
   return (_: any, context: any) => {
@@ -57,7 +53,6 @@ function numberProperty (config?: Rule & { acceptBigInt?: boolean }) {
  *
  * @param {Rule & { acceptNumber?: boolean }} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function bigIntProperty (config?: Rule & { acceptNumber?: boolean }) {
   return (_: any, context: any) => {
@@ -70,7 +65,6 @@ function bigIntProperty (config?: Rule & { acceptNumber?: boolean }) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function nodeProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -83,7 +77,6 @@ function nodeProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function relationshipProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -96,7 +89,6 @@ function relationshipProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function pathProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -109,7 +101,6 @@ function pathProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function pointProperty (config?: Rule) {
   return (_: any, context: any) => {
@@ -122,7 +113,6 @@ function pointProperty (config?: Rule) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function durationProperty (config?: Rule & { stringify?: boolean }) {
   return (_: any, context: any) => {
@@ -135,7 +125,6 @@ function durationProperty (config?: Rule & { stringify?: boolean }) {
  *
  * @param {Rule & { apply?: Rule }} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function listProperty (config?: Rule & { apply?: Rule }) {
   return (_: any, context: any) => {
@@ -148,7 +137,6 @@ function listProperty (config?: Rule & { apply?: Rule }) {
  *
  * @param {Rule & { asTypedList?: boolean }} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function vectorProperty (config?: Rule & { asTypedList?: boolean }) {
   return (_: any, context: any) => {
@@ -162,7 +150,6 @@ function vectorProperty (config?: Rule & { asTypedList?: boolean }) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function optionalProperty () {
   return (_: any, context: any) => {
@@ -176,7 +163,6 @@ function optionalProperty () {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function mapPropertyFromName (name: string) {
   return (_: any, context: any) => {
@@ -190,7 +176,6 @@ function mapPropertyFromName (name: string) {
  *
  * @param {Rule} config
  * @returns {Function} Property Decorator
- * @experimental Part of the Record Object Mapping preview feature
  */
 function convertPropertyToType (type: any) {
   return (_: any, context: any) => {

--- a/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
@@ -211,7 +211,7 @@ function listProperty (config?: Rule & { apply?: Rule }) {
  * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config
  * @returns {Function} Property Decorator
  */
-function vectorProperty (config?: Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64" }) {
+function vectorProperty (config?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }) {
   return (_: any, context: any) => {
     context.metadata[context.name] = rule.asVector(config)
   }

--- a/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
@@ -39,7 +39,7 @@ function stringProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a number.
  *
- * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule. 
+ * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule.
  * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
  * @returns {Function} Property Decorator
  */

--- a/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
@@ -39,10 +39,11 @@ function stringProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a number.
  *
- * @param {Rule & { acceptBigInt?: boolean }} config
+ * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule. 
+ * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
  * @returns {Function} Property Decorator
  */
-function numberProperty (config?: Rule & { acceptBigInt?: boolean }) {
+function numberProperty (config?: Rule & { isInteger?: boolean }) {
   return (_: any, context: any) => {
     context.metadata[context.name] = rule.asNumber(config)
   }
@@ -51,12 +52,24 @@ function numberProperty (config?: Rule & { acceptBigInt?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a BigInt.
  *
- * @param {Rule & { acceptNumber?: boolean }} config
+ * @param {Rule & { acceptNumber?: boolean }} config Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the convert function will turn Numbers into BigInts.
  * @returns {Function} Property Decorator
  */
 function bigIntProperty (config?: Rule & { acceptNumber?: boolean }) {
   return (_: any, context: any) => {
     context.metadata[context.name] = rule.asBigInt(config)
+  }
+}
+
+/**
+ * Property Decorator Factory that enables the Neo4j Driver to map this property to an Integer.
+ *
+ * @param {Rule & { acceptNumber?: boolean }} config Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the convert function will turn Numbers into BigInts.
+ * @returns {Function} Property Decorator
+ */
+function integerProperty (config?: Rule & { acceptNumber?: boolean }) {
+  return (_: any, context: any) => {
+    context.metadata[context.name] = rule.asInteger(config)
   }
 }
 
@@ -188,6 +201,7 @@ const forExport = {
   stringProperty,
   numberProperty,
   bigIntProperty,
+  integerProperty,
   nodeProperty,
   relationshipProperty,
   pathProperty,

--- a/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.decorators.ts
@@ -15,7 +15,7 @@ function mappedClass () {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a boolean.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule
  * @returns {Function} Property Decorator
  */
 function booleanProperty (config?: Rule) {
@@ -27,7 +27,7 @@ function booleanProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a string.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule
  * @returns {Function} Property Decorator
  */
 function stringProperty (config?: Rule) {
@@ -76,7 +76,7 @@ function integerProperty (config?: Rule & { acceptNumber?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Node.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule
  * @returns {Function} Property Decorator
  */
 function nodeProperty (config?: Rule) {
@@ -88,7 +88,7 @@ function nodeProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Relationship.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule.
  * @returns {Function} Property Decorator
  */
 function relationshipProperty (config?: Rule) {
@@ -100,7 +100,7 @@ function relationshipProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Path.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule.
  * @returns {Function} Property Decorator
  */
 function pathProperty (config?: Rule) {
@@ -112,7 +112,7 @@ function pathProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Point.
  *
- * @param {Rule} config
+ * @param {Rule} config Configurations for the rule.
  * @returns {Function} Property Decorator
  */
 function pointProperty (config?: Rule) {
@@ -124,7 +124,7 @@ function pointProperty (config?: Rule) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Duration.
  *
- * @param {Rule} config
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
  * @returns {Function} Property Decorator
  */
 function durationProperty (config?: Rule & { stringify?: boolean }) {
@@ -136,7 +136,7 @@ function durationProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalTime
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function localTimeProperty (config?: Rule & { stringify?: boolean }) {
@@ -148,7 +148,7 @@ function localTimeProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Time
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean }} config Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
  * @returns {Function} Property Decorator
  */
 function timeProperty (config?: Rule & { stringify?: boolean }) {
@@ -160,7 +160,7 @@ function timeProperty (config?: Rule & { stringify?: boolean }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Date
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
  * @returns {Function} Property Decorator
  */
 function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -172,7 +172,7 @@ function dateProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boo
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a LocalDateTIme
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -184,7 +184,7 @@ function localDateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeD
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a DateTIme
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean }} config Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
  * @returns {Function} Property Decorator
  */
 function dateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?: boolean }) {
@@ -196,7 +196,7 @@ function dateTimeProperty (config?: Rule & { stringify?: boolean, jsNativeDate?:
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a List
  *
- * @param {Rule & { apply?: Rule }} config
+ * @param {Rule & { apply?: Rule }} config Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
  * @returns {Function} Property Decorator
  */
 function listProperty (config?: Rule & { apply?: Rule }) {
@@ -208,7 +208,7 @@ function listProperty (config?: Rule & { apply?: Rule }) {
 /**
  * Property Decorator Factory that enables the Neo4j Driver to map this property to a Vector
  *
- * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config
+ * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64"; }} config Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
  * @returns {Function} Property Decorator
  */
 function vectorProperty (config?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }) {

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -245,8 +245,7 @@ export function validateAndCleanParameters (params: Record<string, any>, supplie
             check provided parameters and parameter rules.`
           )
         }
-      }
-      else if (parameterRules[key].validate != null) {
+      } else if (parameterRules[key].validate != null) {
         parameterRules[key].validate(param, key)
       }
       cleanedParams[mappedKey] = param

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -25,12 +25,40 @@ import { nameConventions } from './mapping.nameconventions.ts'
  */
 export type GenericConstructor<T extends {}> = new (...args: any[]) => T
 
+/**
+ * Rule used to provide mapping and type validation of parameters and records.
+ */
 export interface Rule {
+  /**
+   * Whether or not the field is optional. If true, an undefined or null value will not fail validation.
+   */
   optional?: boolean
+  /**
+   * The string used to identify this value in the database. For when parameters or returned fields do not match the name of your domain objects fields.
+   */
   from?: string
+  /**
+   * A function to convert the value from a result after it has been validated.
+   *
+   * @param recordValue The value from the raw result.
+   * @param {string} field name of the field.
+   * @returns {any} The converted value.
+   */
   convert?: (recordValue: any, field: string) => any
+  /**
+   * A function to convert a parameter before validation and transmission to the database.
+   *
+   * @param objectValue The value provided as a parameter.
+   * @returns The converted value, this value will be passed to the validate function before transmission to the database.
+   */
   parameterConversion?: (objectValue: any) => any
-  validate?: (recordValue: any, field: string) => void
+  /**
+   * A function to validate the value, should throw an error if it is invalid.
+   *
+   * @param value The value to validate.
+   * @param {string} field The name of the field with the value.
+   */
+  validate?: (value: any, field: string) => void
 }
 
 export type Rules = Record<string, Rule>
@@ -159,10 +187,10 @@ export function as <T extends {} = Object> (gettable: Gettable, constructorOrRul
 }
 
 function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: Rule): void {
-  const mappedkey = defaultNameMapping(key)
+  const mappedKey = defaultNameMapping(key)
   let value
   try {
-    value = gettable.get(rule?.from ?? mappedkey)
+    value = gettable.get(rule?.from ?? mappedKey)
   } catch (e) {
     if (rule?.optional === true && e instanceof Neo4jError && e.message.includes('This record has no field with key')) {
       return
@@ -191,7 +219,7 @@ export function optionalParameterConversion (value: unknown, rule: Rule): unknow
   if (rule.optional === true && value == null) {
     return value
   }
-  return ((rule?.parameterConversion) != null) ? rule.parameterConversion(value) : value
+  return (rule.parameterConversion != null) ? rule.parameterConversion(value) : value
 }
 
 export function validateAndCleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
@@ -200,20 +228,17 @@ export function validateAndCleanParameters (params: Record<string, any>, supplie
   if (parameterRules != null) {
     for (const key in parameterRules) {
       let param = params[key]
-      if (param == null && parameterRules[key].optional === true) {
-        continue
-      }
-      if (parameterRules[key].parameterConversion != null) {
+      if (param != null && parameterRules[key].parameterConversion != null) {
         param = parameterRules[key].parameterConversion(param)
-        if (param == null) {
-          if (parameterRules[key].optional !== true) {
-            throw newError(
-              `Mapped Parameter object did not include required parameter with key ${key}, 
-              check provided parameters and parameter rules.`
-            )
-          } else {
-            continue
-          }
+      }
+      if (param == null) {
+        if (parameterRules[key].optional !== true) {
+          throw newError(
+            `Mapped Parameter object did not include required parameter with key ${key}, 
+            check provided parameters and parameter rules.`
+          )
+        } else {
+          continue
         }
       }
       if (parameterRules[key].validate != null) {

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -30,7 +30,7 @@ export type GenericConstructor<T extends {}> = new (...args: any[]) => T
  */
 export interface Rule {
   /**
-   * Whether or not the field is optional. If true, an undefined or null value will not fail validation.
+   * Whether or not the field is optional. If true, an undefined or null value will not fail validation, these will not be passed to conversion functions.
    */
   optional?: boolean
   /**
@@ -52,14 +52,14 @@ export interface Rule {
    *
    * NOTE: This function will not be called on null-ish values on optional parameters
    *
-   * @param objectValue The value provided as a parameter.
+   * @param {any} objectValue The value provided as a parameter.
    * @returns The converted value, this value will be passed to the validate function before transmission to the database.
    */
   parameterConversion?: (objectValue: any) => any
   /**
    * A function to validate the value, should throw an error if it is invalid.
    *
-   * @param value The value to validate.
+   * @param {any} value The value to validate.
    * @param {string} field The name of the field with the value.
    */
   validate?: (value: any, field: string) => void
@@ -203,8 +203,10 @@ function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: R
   }
   const field = `${obj.constructor.name}#${key}`
   const processedValue = valueAs(value, field, rule)
-  // @ts-expect-error
-  obj[key] = processedValue ?? obj[key]
+  if (processedValue != null || rule?.optional === true) {
+    // @ts-expect-error
+    obj[key] = processedValue
+  }
 }
 
 export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
@@ -232,6 +234,7 @@ export function validateAndCleanParameters (params: Record<string, any>, supplie
   if (parameterRules != null) {
     for (const key in parameterRules) {
       let param = params[key]
+      const mappedKey = parameterRules[key].from ?? defaultNameMapping(key)
       if (param != null && parameterRules[key].parameterConversion != null) {
         param = parameterRules[key].parameterConversion(param)
       }
@@ -241,15 +244,11 @@ export function validateAndCleanParameters (params: Record<string, any>, supplie
             `Mapped Parameter object did not include required parameter with key ${key}, 
             check provided parameters and parameter rules.`
           )
-        } else {
-          continue
         }
       }
-      if (parameterRules[key].validate != null) {
+      else if (parameterRules[key].validate != null) {
         parameterRules[key].validate(param, key)
       }
-      const mappedKey = parameterRules[key].from ?? defaultNameMapping(key)
-
       cleanedParams[mappedKey] = param
     }
     return cleanedParams

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -29,7 +29,7 @@ export interface Rule {
   optional?: boolean
   from?: string
   convert?: (recordValue: any, field: string) => any
-  convertToParam?: (objectValue: any) => any
+  parameterConversion?: (objectValue: any) => any
   validate?: (recordValue: any, field: string) => void
 }
 
@@ -181,14 +181,14 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
 
-export function valueAsParam (value: unknown, rule?: Rule): unknown {
+export function optionalParameterConversion (value: unknown, rule?: Rule): unknown {
   if (rule?.optional === true && value == null) {
     return value
   }
-  return ((rule?.convertToParam) != null) ? rule.convertToParam(value) : value
+  return ((rule?.parameterConversion) != null) ? rule.parameterConversion(value) : value
 }
 
-export function validateAndCleanParams (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
+export function validateAndcleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
   const cleanedParams: Record<string, any> = {}
   // @ts-expect-error
   const parameterRules = getRules(params.constructor, suppliedRules)
@@ -196,8 +196,8 @@ export function validateAndCleanParams (params: Record<string, any>, suppliedRul
     for (const key in parameterRules) {
       if (!(parameterRules?.[key]?.optional === true)) {
         let param = params[key]
-        if (parameterRules[key]?.convertToParam !== undefined) {
-          param = parameterRules[key].convertToParam(params[key])
+        if (parameterRules[key]?.parameterConversion !== undefined) {
+          param = parameterRules[key].parameterConversion(params[key])
         }
         if (param === undefined) {
           throw newError('Parameter object did not include required parameter.')

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -182,37 +182,36 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
 }
 
 export function validateAndCleanParams (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
-  let cleanedParams: Record<string, any> = {}
-  // @ts-ignore
+  const cleanedParams: Record<string, any> = {}
+  // @ts-expect-error
   const parameterRules = getRules(params.constructor, suppliedRules)
   if (parameterRules !== undefined) {
-    for(const key in parameterRules) {
-      if(!(parameterRules?.[key]?.optional === true)) {
+    for (const key in parameterRules) {
+      if (!(parameterRules?.[key]?.optional === true)) {
         let param = params[key]
         if (parameterRules[key]?.convertToParam !== undefined) {
           param = parameterRules[key].convertToParam(params[key])
         }
-        if(param === undefined) {
-          throw newError("Parameter object did not include required parameter.")
+        if (param === undefined) {
+          throw newError('Parameter object did not include required parameter.')
         }
-        if(parameterRules[key].validate) {
+        if (parameterRules[key].validate != null) {
           parameterRules[key].validate(param, key)
-          // @ts-ignore
-          if(parameterRules[key].apply !== undefined) {
-            for(const entryKey in param){
-              // @ts-ignore
+          // @ts-expect-error
+          if (parameterRules[key].apply !== undefined) {
+            for (const entryKey in param) {
+              // @ts-expect-error
               parameterRules[key].apply.validate(param[entryKey], entryKey)
             }
           }
         }
         const mappedKey = parameterRules[key].from ?? nameMapping(key)
-        
+
         cleanedParams[mappedKey] = param
       }
     }
     return cleanedParams
-  }
-  else {
+  } else {
     return params
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -39,7 +39,7 @@ export interface Rule {
   from?: string
   /**
    * A function to convert the value from a result after it has been validated.
-   * 
+   *
    * NOTE: This function will not be called on null-ish values on optional fields
    *
    * @param {any} recordValue The value from the raw result.
@@ -49,7 +49,7 @@ export interface Rule {
   convert?: (recordValue: any, field: string) => any
   /**
    * A function to convert a parameter before validation and transmission to the database.
-   * 
+   *
    * NOTE: This function will not be called on null-ish values on optional parameters
    *
    * @param objectValue The value provided as a parameter.

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -29,6 +29,7 @@ export interface Rule {
   optional?: boolean
   from?: string
   convert?: (recordValue: any, field: string) => any
+  convertToParam?: (objectValue: any) => any
   validate?: (recordValue: any, field: string) => void
 }
 
@@ -36,7 +37,7 @@ export type Rules = Record<string, Rule>
 
 export let rulesRegistry: Record<string, Rules> = {}
 
-let nameMapping: (name: string) => string = (name) => name
+export let nameMapping: (name: string) => string = (name) => name
 
 function register <T extends {} = Object> (constructor: GenericConstructor<T>, rules: Rules): void {
   rulesRegistry[constructor.name] = rules
@@ -179,6 +180,43 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
 
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
+
+export function validateAndCleanParams (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
+  let cleanedParams: Record<string, any> = {}
+  // @ts-ignore
+  const parameterRules = getRules(params.constructor, suppliedRules)
+  if (parameterRules !== undefined) {
+    for(const key in parameterRules) {
+      if(!(parameterRules?.[key]?.optional === true)) {
+        let param = params[key]
+        if (parameterRules[key]?.convertToParam !== undefined) {
+          param = parameterRules[key].convertToParam(params[key])
+        }
+        if(param === undefined) {
+          throw newError("Parameter object did not include required parameter.")
+        }
+        if(parameterRules[key].validate) {
+          parameterRules[key].validate(param, key)
+          // @ts-ignore
+          if(parameterRules[key].apply !== undefined) {
+            for(const entryKey in param){
+              // @ts-ignore
+              parameterRules[key].apply.validate(param[entryKey], entryKey)
+            }
+          }
+        }
+        const mappedKey = parameterRules[key].from ?? nameMapping(key)
+        
+        cleanedParams[mappedKey] = param
+      }
+    }
+    return cleanedParams
+  }
+  else {
+    return params
+  }
+}
+
 function getRules<T extends {} = Object> (constructorOrRules: Rules | GenericConstructor<T>, rules: Rules | undefined): Rules | undefined {
   const rulesDefined = typeof constructorOrRules === 'object' ? constructorOrRules : rules
   if (rulesDefined != null) {

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -181,6 +181,13 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
 
+export function valueAsParam (value: unknown, rule?: Rule): unknown {
+  if (rule?.optional === true && value == null) {
+    return value
+  }
+  return ((rule?.convertToParam) != null) ? rule.convertToParam(value) : value
+}
+
 export function validateAndCleanParams (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
   const cleanedParams: Record<string, any> = {}
   // @ts-expect-error

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -190,10 +190,7 @@ export function validateAndcleanParameters (params: Record<string, any>, supplie
   const parameterRules = getRules(params.constructor, suppliedRules)
   if (parameterRules !== undefined) {
     for (const key in parameterRules) {
-      if (parameterRules?.[key]?.optional === true && params[key] == null) {
-        cleanedParams[key] = params[key]
-      }
-      else {
+      if (!(parameterRules?.[key]?.optional === true)) {
         let param = params[key]
         if (parameterRules[key]?.parameterConversion !== undefined) {
           param = parameterRules[key].parameterConversion(params[key])

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -163,9 +163,8 @@ function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: R
   let value
   try {
     value = gettable.get(rule?.from ?? mappedkey)
-  }
-  catch (e) {
-    if (rule?.optional === true && e instanceof Neo4jError && e.message.includes("This record has no field with key")) {
+  } catch (e) {
+    if (rule?.optional === true && e instanceof Neo4jError && e.message.includes('This record has no field with key')) {
       return
     }
     throw e

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -202,11 +202,8 @@ function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: R
     throw e
   }
   const field = `${obj.constructor.name}#${key}`
-  const processedValue = valueAs(value, field, rule)
-  if (processedValue != null || rule?.optional === true) {
-    // @ts-expect-error
-    obj[key] = processedValue
-  }
+  // @ts-expect-error
+  obj[key] = valueAs(value, field, rule)
 }
 
 export function valueAs (value: unknown, field: string, rule?: Rule): unknown {

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -107,7 +107,7 @@ export const RecordObjectMapping = Object.freeze({
   /**
  * Sets a default name translation from record keys to object properties.
  * If providing a function, provide a function that maps FROM your object properties names TO record key names.
- * 
+ *
  * NOTE: The keys of objects inside a record will only be translated if using the asObject rule with it, not by default.
  *
  * The function getCaseTranslator can be used to provide a prewritten translation function between some common naming conventions.
@@ -203,8 +203,7 @@ export function validateAndCleanParameters (params: Record<string, any>, supplie
               `Mapped Parameter object did not include required parameter with key ${key}, 
               check provided parameters and parameter rules.`
             )
-          }
-          else {
+          } else {
             continue
           }
         }

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { newError } from './error.ts'
+import { Neo4jError, newError } from './error.ts'
 import { nameConventions } from './mapping.nameconventions.ts'
 
 /**
@@ -160,7 +160,16 @@ export function as <T extends {} = Object> (gettable: Gettable, constructorOrRul
 
 function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: Rule): void {
   const mappedkey = defaultNameMapping(key)
-  const value = gettable.get(rule?.from ?? mappedkey)
+  let value
+  try {
+    value = gettable.get(rule?.from ?? mappedkey)
+  }
+  catch (e) {
+    if (rule?.optional === true && e instanceof Neo4jError && e.message.includes("This record has no field with key")) {
+      return
+    }
+    throw e
+  }
   const field = `${obj.constructor.name}#${key}`
   const processedValue = valueAs(value, field, rule)
   // @ts-expect-error

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -72,7 +72,6 @@ function getCaseTranslator (databaseConvention: string, codeConvention: string):
 export const RecordObjectMapping = Object.freeze({
   /**
  * Clears all registered type mappings from the record object mapping registry.
- * @experimental Part of the Record Object Mapping preview feature
  */
   clearMappingRegistry,
   /**
@@ -80,7 +79,6 @@ export const RecordObjectMapping = Object.freeze({
  *
  * Recognized naming conventions are "camelCase", "PascalCase", "snake_case", "kebab-case", "SCREAMING_SNAKE_CASE"
  *
- * @experimental Part of the Record Object Mapping preview feature
  * @param {string} databaseConvention The naming convention in use in database result Records
  * @param {string} codeConvention The naming convention in use in JavaScript object properties
  * @returns {function} translation function
@@ -102,7 +100,6 @@ export const RecordObjectMapping = Object.freeze({
  *  resultTransformer: neo4j.resultTransformers.hydrated(Person)
  * })
  *
- * @experimental Part of the Record Object Mapping preview feature
  * @param {GenericConstructor} constructor The constructor function of the class to set rules for
  * @param {Rules} rules The rules to set for the provided class
  */
@@ -131,7 +128,6 @@ export const RecordObjectMapping = Object.freeze({
  * //or by registering them to the mapping registry
  * RecordObjectMapping.register(Person, personRules)
  *
- * @experimental Part of the Record Object Mapping preview feature
  * @param {function} translationFunction A function translating the names of your JS object property names to record key names
  */
   translateIdentifiers

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -190,7 +190,10 @@ export function validateAndcleanParameters (params: Record<string, any>, supplie
   const parameterRules = getRules(params.constructor, suppliedRules)
   if (parameterRules !== undefined) {
     for (const key in parameterRules) {
-      if (!(parameterRules?.[key]?.optional === true)) {
+      if (parameterRules?.[key]?.optional === true && params[key] == null) {
+        cleanedParams[key] = params[key]
+      }
+      else {
         let param = params[key]
         if (parameterRules[key]?.parameterConversion !== undefined) {
           param = parameterRules[key].parameterConversion(params[key])

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -37,7 +37,7 @@ export type Rules = Record<string, Rule>
 
 export let rulesRegistry: Record<string, Rules> = {}
 
-export let nameMapping: (name: string) => string = (name) => name
+export let defaultNameMapping: (name: string) => string = (name) => name
 
 function register <T extends {} = Object> (constructor: GenericConstructor<T>, rules: Rules): void {
   rulesRegistry[constructor.name] = rules
@@ -48,7 +48,7 @@ function clearMappingRegistry (): void {
 }
 
 function translateIdentifiers (translationFunction: (name: string) => string): void {
-  nameMapping = translationFunction
+  defaultNameMapping = translationFunction
 }
 
 function getCaseTranslator (databaseConvention: string, codeConvention: string): ((name: string) => string) {
@@ -107,6 +107,8 @@ export const RecordObjectMapping = Object.freeze({
   /**
  * Sets a default name translation from record keys to object properties.
  * If providing a function, provide a function that maps FROM your object properties names TO record key names.
+ * 
+ * NOTE: The keys of objects inside a record will only be translated if using the asObject rule with it, not by default.
  *
  * The function getCaseTranslator can be used to provide a prewritten translation function between some common naming conventions.
  *
@@ -157,7 +159,7 @@ export function as <T extends {} = Object> (gettable: Gettable, constructorOrRul
 }
 
 function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: Rule): void {
-  const mappedkey = nameMapping(key)
+  const mappedkey = defaultNameMapping(key)
   const value = gettable.get(rule?.from ?? mappedkey)
   const field = `${obj.constructor.name}#${key}`
   const processedValue = valueAs(value, field, rule)
@@ -177,41 +179,42 @@ export function valueAs (value: unknown, field: string, rule?: Rule): unknown {
   return ((rule?.convert) != null) ? rule.convert(value, field) : value
 }
 
-export function optionalParameterConversion (value: unknown, rule?: Rule): unknown {
-  if (rule?.optional === true && value == null) {
+export function optionalParameterConversion (value: unknown, rule: Rule): unknown {
+  if (rule.optional === true && value == null) {
     return value
   }
   return ((rule?.parameterConversion) != null) ? rule.parameterConversion(value) : value
 }
 
-export function validateAndcleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
+export function validateAndCleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {
   const cleanedParams: Record<string, any> = {}
-  // @ts-expect-error
-  const parameterRules = getRules(params.constructor, suppliedRules)
-  if (parameterRules !== undefined) {
+  const parameterRules = getRules(Object.getPrototypeOf(params).constructor, suppliedRules)
+  if (parameterRules != null) {
     for (const key in parameterRules) {
-      if (!(parameterRules?.[key]?.optional === true)) {
-        let param = params[key]
-        if (parameterRules[key]?.parameterConversion !== undefined) {
-          param = parameterRules[key].parameterConversion(params[key])
-        }
-        if (param === undefined) {
-          throw newError('Parameter object did not include required parameter.')
-        }
-        if (parameterRules[key].validate != null) {
-          parameterRules[key].validate(param, key)
-          // @ts-expect-error
-          if (parameterRules[key].apply !== undefined) {
-            for (const entryKey in param) {
-              // @ts-expect-error
-              parameterRules[key].apply.validate(param[entryKey], entryKey)
-            }
+      let param = params[key]
+      if (param == null && parameterRules[key].optional === true) {
+        continue
+      }
+      if (parameterRules[key].parameterConversion != null) {
+        param = parameterRules[key].parameterConversion(param)
+        if (param == null) {
+          if (parameterRules[key].optional !== true) {
+            throw newError(
+              `Mapped Parameter object did not include required parameter with key ${key}, 
+              check provided parameters and parameter rules.`
+            )
+          }
+          else {
+            continue
           }
         }
-        const mappedKey = parameterRules[key].from ?? nameMapping(key)
-
-        cleanedParams[mappedKey] = param
       }
+      if (parameterRules[key].validate != null) {
+        parameterRules[key].validate(param, key)
+      }
+      const mappedKey = parameterRules[key].from ?? defaultNameMapping(key)
+
+      cleanedParams[mappedKey] = param
     }
     return cleanedParams
   } else {

--- a/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.highlevel.ts
@@ -39,14 +39,18 @@ export interface Rule {
   from?: string
   /**
    * A function to convert the value from a result after it has been validated.
+   * 
+   * NOTE: This function will not be called on null-ish values on optional fields
    *
-   * @param recordValue The value from the raw result.
+   * @param {any} recordValue The value from the raw result.
    * @param {string} field name of the field.
    * @returns {any} The converted value.
    */
   convert?: (recordValue: any, field: string) => any
   /**
    * A function to convert a parameter before validation and transmission to the database.
+   * 
+   * NOTE: This function will not be called on null-ish values on optional parameters
    *
    * @param objectValue The value provided as a parameter.
    * @returns The converted value, this value will be passed to the validate function before transmission to the database.
@@ -192,7 +196,7 @@ function _apply<T extends {}> (gettable: Gettable, obj: T, key: string, rule?: R
   try {
     value = gettable.get(rule?.from ?? mappedKey)
   } catch (e) {
-    if (rule?.optional === true && e instanceof Neo4jError && e.message.includes('This record has no field with key')) {
+    if (rule?.optional === true && e instanceof Neo4jError) {
       return
     }
     throw e
@@ -219,7 +223,7 @@ export function optionalParameterConversion (value: unknown, rule: Rule): unknow
   if (rule.optional === true && value == null) {
     return value
   }
-  return (rule.parameterConversion != null) ? rule.parameterConversion(value) : value
+  return (value != null && rule.parameterConversion != null) ? rule.parameterConversion(value) : value
 }
 
 export function validateAndCleanParameters (params: Record<string, any>, suppliedRules?: Rules): Record<string, any> {

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -18,10 +18,10 @@
  */
 
 import { Rule, valueAs } from './mapping.highlevel.ts'
-import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
+import { StandardDateClass, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
-import Vector from './vector.ts'
+import Vector, { vector } from './vector.ts'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -250,6 +250,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Duration) => rule?.stringify === true ? value.toString() : value,
+      convertToParam: rule?.stringify === true ? (str: string) => Duration.fromString(str): undefined,
       ...rule
     }
   },
@@ -268,6 +269,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalTime) => rule?.stringify === true ? value.toString() : value,
+      convertToParam: rule?.stringify  === true ? (str: string) => LocalTime.fromString(str): undefined,
       ...rule
     }
   },
@@ -286,6 +288,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Time) => rule?.stringify === true ? value.toString() : value,
+      convertToParam: rule?.stringify  === true ? (str: string) => Time.fromString(str): undefined,
       ...rule
     }
   },
@@ -304,6 +307,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Date) => convertStdDate(value, rule),
+      convertToParam: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new StandardDateClass(str)): undefined,
       ...rule
     }
   },
@@ -315,6 +319,13 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asLocalDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+    let convertToParam = undefined
+    if(rule?.stringify === true) {
+      convertToParam = (str: string) => LocalDateTime.fromStandardDate(new StandardDateClass(str))
+    }
+    if(rule?.toStandardDate === true) {
+      convertToParam = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isLocalDateTime(value)) {
@@ -322,6 +333,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalDateTime) => convertStdDate(value, rule),
+      convertToParam: convertToParam,
       ...rule
     }
   },
@@ -333,6 +345,13 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+    let convertToParam = undefined
+    if(rule?.stringify === true) {
+      convertToParam = (str: string) => DateTime.fromStandardDate(new StandardDateClass(str))
+    }
+    if(rule?.toStandardDate === true) {
+      convertToParam = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isDateTime(value)) {
@@ -340,6 +359,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: DateTime) => convertStdDate(value, rule),
+      convertToParam: convertToParam,
       ...rule
     }
   },
@@ -386,6 +406,7 @@ export const rule = Object.freeze({
         }
         return value
       },
+      convertToParam: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray): undefined,
       ...rule
     }
   }

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -40,8 +40,6 @@ import Integer, { isInt } from './integer.ts'
  *
  * @property {function(rule: ?Rule)} asRelationship Create a {@link Rule} that validates the value is a {@link Relationship}.
  *
- * @property {function(rule: ?Rule)} asUnboundRelationship Create a {@link Rule} that validates the value is an {@link UnboundRelationship}.
- *
  * @property {function(rule: ?Rule)} asPath Create a {@link Rule} that validates the value is a {@link Path}.
  *
  * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
@@ -52,11 +50,11 @@ import Integer, { isInt } from './integer.ts'
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asTime Create a {@link Rule} that validates the value is a {@link Time}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
  *
  * @property {function(rule: ?Rule & { apply?: Rule })} asList Create a {@link Rule} that validates the value is a List.
  *
@@ -104,7 +102,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { isInteger?: boolean } | undefined } rule Configurations for the rule.
+   * @param {Rule & { isInteger?: boolean } | undefined} rule Configurations for the rule.
    * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -17,11 +17,13 @@
  * limitations under the License.
  */
 
-import { Rule, valueAs } from './mapping.highlevel.ts'
+import { Rule, valueAs, valueAsParam } from './mapping.highlevel.ts'
 import { StandardDateClass, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
 import Vector, { vector } from './vector.ts'
+import { newError } from './error.ts'
+import Integer, { int, isInt } from './integer.ts'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -29,6 +31,8 @@ import Vector, { vector } from './vector.ts'
  * @property {function(rule: ?Rule & { acceptBigInt?: boolean })} asNumber Create a {@link Rule} that validates the value is a Number.
  *
  * @property {function(rule: ?Rule & { acceptNumber?: boolean })} AsBigInt Create a {@link Rule} that validates the value is a BigInt.
+ *
+ * @property {function(rule: ?Rule & { asNumber?: boolean, asBigInt?: boolean })} AsInteger Create a {@link Rule} that validates the value is an Integer.
  *
  * @property {function(rule: ?Rule)} asNode Create a {@link Rule} that validates the value is a {@link Node}.
  *
@@ -136,6 +140,44 @@ export const rule = Object.freeze({
           return BigInt(value)
         }
         return value
+      },
+      ...rule
+    }
+  },
+  /**
+   * Create a {@link Rule} that validates the value is an {@link Integer}.
+   *
+   * @experimental Part of the Record Object Mapping preview feature
+   * @param {Rule & { asNumber?: boolean, asBigInt?: boolean }} rule Configurations for the rule
+   * @returns {Rule} A new rule for the value
+   */
+  asInteger (rule?: Rule & { asNumber?: boolean, asBigInt?: boolean }): Rule {
+    if(rule?.asNumber === true && rule.asBigInt === true) {
+      throw newError("Cannot set both asNumber and asBigInt in a asInteger rule")
+    }
+    return {
+      validate: (value: any, field: string) => {
+        if (isInt(value) !== true) {
+          throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
+        }
+      },
+      convert: (value: Integer) => {
+        if (rule?.asNumber === true) {
+          return value.low
+        }
+        if (rule?.asBigInt === true) {
+          return value.toBigInt()
+        }
+        return value
+      },
+      convertToParam: (objectValue: any) => {
+        if(rule?.asNumber === true) {
+          return int(objectValue)
+        }
+        if(rule?.asBigInt === true) {
+          return int(objectValue)
+        }
+        return objectValue
       },
       ...rule
     }
@@ -380,6 +422,12 @@ export const rule = Object.freeze({
       convert: (list: any[], field: string) => {
         if (rule?.apply != null) {
           return list.map((value, index) => valueAs(value, `${field}[${index}]`, rule.apply))
+        }
+        return list
+      },
+      convertToParam: (list: any[]) => {
+        if (rule?.apply != null) {
+          return list.map((value) => valueAsParam(value, rule.apply))
         }
         return list
       },

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -30,8 +30,6 @@ import Vector, { vector } from './vector.ts'
  *
  * @property {function(rule: ?Rule & { acceptNumber?: boolean })} AsBigInt Create a {@link Rule} that validates the value is a BigInt.
  *
- * @property {function(rule: ?Rule & { asNumber?: boolean, asBigInt?: boolean })} AsInteger Create a {@link Rule} that validates the value is an Integer.
- *
  * @property {function(rule: ?Rule)} asNode Create a {@link Rule} that validates the value is a {@link Node}.
  *
  * @property {function(rule: ?Rule)} asRelationship Create a {@link Rule} that validates the value is a {@link Relationship}.

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -54,13 +54,11 @@ import Vector, { vector } from './vector.ts'
  *
  * @property {function(rule: ?Rule & { asTypedList: boolean })} asVector Create a {@link Rule} that validates the value is a List.
  *
- * @experimental Part of the Record Object Mapping preview feature
  */
 export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Boolean.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -77,7 +75,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a String.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -94,7 +91,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Number}.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule & { acceptBigInt?: boolean }} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -120,7 +116,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link BigInt}.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule & { acceptNumber?: boolean }} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -153,7 +148,6 @@ export const rule = Object.freeze({
    *  movie: neo4j.rule.asNode({}),
    * }
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -170,7 +164,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Relationship}.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule.
    * @returns {Rule} A new rule for the value
    */
@@ -187,7 +180,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is an {@link UnboundRelationship}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -204,7 +196,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Path}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -221,7 +212,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Point}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -238,7 +228,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Duration}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -257,7 +246,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalTime}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -276,7 +264,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Time}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -295,7 +282,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Date}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -314,7 +300,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalDateTime}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -340,7 +325,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -366,7 +350,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a List. Optionally taking a rule for hydrating the contained values.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule & { apply?: Rule }} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -395,7 +378,6 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Vector.
    *
-   * @experimental Part of the Record Object Mapping preview feature
    * @param {Rule & { asTypedList?: boolean }} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -76,6 +76,8 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a String.
    *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -92,10 +94,12 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Number}.
    *
-   * @param {Rule & { acceptBigInt?: boolean }} rule Configurations for the rule
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @param {Rule & { acceptBigInt?: boolean }} rule Configurations for the rule. If `acceptBigInt` is set to true, the created validate function will allow BigInts through and the convert function will turn BigInts into Numbers.
    * @returns {Rule} A new rule for the value
    */
-  asNumber (rule?: Rule & { acceptBigInt?: boolean }): Rule {
+  asNumber (rule?: Rule & { acceptBigInt?: boolean }): Rule { // TODO: RECONSIDER HOW THE NUMBER RULES WORK, GIVEN Integers and Floats. asNumber and asBigInt should probably be asInteger and asFloat
     return {
       validate: (value: any, field: string) => {
         if (typeof value === 'object' && value.low !== undefined && value.high !== undefined && Object.keys(value).length === 2) {
@@ -117,7 +121,9 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link BigInt}.
    *
-   * @param {Rule & { acceptNumber?: boolean }} rule Configurations for the rule
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @param {Rule & { acceptNumber?: boolean } | undefined} rule Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the convert function will turn Numbers into BigInts.
    * @returns {Rule} A new rule for the value
    */
   asBigInt (rule?: Rule & { acceptNumber?: boolean }): Rule {
@@ -138,6 +144,8 @@ export const rule = Object.freeze({
   },
   /**
    * Create a {@link Rule} that validates the value is a {@link Node}.
+   *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
    * @example
    * const actingJobsRules: Rules = {
@@ -165,6 +173,18 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Relationship}.
    *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @example
+   * const actingJobsRules: Rules = {
+   *  // Converts the role relationship to a Role object in accordance with provided rules
+   *  role: neo4j.rule.asRelationship({
+   *    convert: (rel: Relationship) => rel.as(Role, roleRules)
+   *  }),
+   *  // Returns the employment relationship as a Relationship
+   *  employment: neo4j.rule.asRelationship({}),
+   * }
+   *
    * @param {Rule} rule Configurations for the rule.
    * @returns {Rule} A new rule for the value
    */
@@ -180,6 +200,8 @@ export const rule = Object.freeze({
   },
   /**
    * Create a {@link Rule} that validates the value is an {@link UnboundRelationship}
+   *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
@@ -197,6 +219,8 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Path}
    *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
@@ -212,6 +236,8 @@ export const rule = Object.freeze({
   },
   /**
    * Create a {@link Rule} that validates the value is a {@link Point}
+   *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
    * @param {Rule} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
@@ -229,10 +255,15 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Duration}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and Durations in the database.
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asDuration (rule?: Rule & { stringify?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isDuration(value)) {
@@ -247,10 +278,13 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalTime}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and LocalTimes in the database.
+   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asLocalTime (rule?: Rule & { stringify?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isLocalTime(value)) {
@@ -265,10 +299,13 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Time}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and Times in the database.
+   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asTime (rule?: Rule & { stringify?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isTime(value)) {
@@ -283,10 +320,16 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Date}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and Dates in the database.
+   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asDate (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
+    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    }
     if (rule?.stringify === true && rule?.JSNativeDate === true) {
       throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
@@ -311,10 +354,16 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalDateTime}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and LocalDateTimes in the database.
+   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asLocalDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
+    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    }
     if (rule?.stringify === true && rule?.JSNativeDate === true) {
       throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
@@ -339,10 +388,15 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
-   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and DateTimes in the database.
-   * @returns {Rule} A new rule for the value
+   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
    */
   asDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
+    }
+    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    }
     if (rule?.stringify === true && rule?.JSNativeDate === true) {
       throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
@@ -404,6 +458,9 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asVector (rule?: Rule & { asTypedList?: boolean }): Rule {
+    if (rule?.asTypedList != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, asTypedList can not be used in combination with custom conversion functions.')
+    }
     return {
       validate: (value: any, field: string) => {
         if (!(value instanceof Vector)) {
@@ -432,26 +489,33 @@ export const rule = Object.freeze({
     return {
       validate: (value: Record<string, Object>, field: string) => {
         for (const key in rules) {
-          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if (value[mappedkey] == null && rules[key].optional === true) {
-            continue
+          const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          if (value[mappedKey] == null) {
+            if (rules[key].optional === true) {
+              continue
+            } else {
+              throw newError(
+                `Mapped Parameter object did not include required field with key ${mappedKey}, 
+                check provided parameters and parameter rules.`
+              )
+            }
           }
           if (rules[key].validate != null) {
-            rules[key].validate(value[mappedkey], `${field}[${key}]`)
+            rules[key].validate(value[mappedKey], `${field}[${key}]`)
           }
         }
       },
       convert: (value: Record<string, Object>, field: string) => {
         const convertedValue: Record<string, Object> = {}
         for (const key in rules) {
-          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
           if (value[key] == null && rules[key].optional === true) {
             continue
           }
           if (rules[key].convert != null) {
-            convertedValue[key] = rules[key].convert(value[mappedkey], `${field}[${mappedkey}]`)
+            convertedValue[key] = rules[key].convert(value[mappedKey], `${field}[${mappedKey}]`)
           } else {
-            convertedValue[key] = value[mappedkey]
+            convertedValue[key] = value[mappedKey]
           }
         }
         return convertedValue
@@ -459,14 +523,14 @@ export const rule = Object.freeze({
       parameterConversion: (value: Record<string, Object>) => {
         const convertedValue: Record<string, Object> = {}
         for (const key in rules) {
-          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
           if (value[key] == null && rules[key].optional === true) {
             continue
           }
           if (rules[key].parameterConversion != null) {
-            convertedValue[mappedkey] = rules[key].parameterConversion(value[key])
+            convertedValue[mappedKey] = rules[key].parameterConversion(value[key])
           } else {
-            convertedValue[mappedkey] = value[key]
+            convertedValue[mappedKey] = value[key]
           }
         }
         return convertedValue

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -287,8 +287,8 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asDate (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
-    if(rule?.stringify === true && rule?.JSNativeDate === true ) {
-      throw newError("both stringify and JSNativeDate cannot be set; use one or neither")
+    if (rule?.stringify === true && rule?.JSNativeDate === true) {
+      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
@@ -315,8 +315,8 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asLocalDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
-    if(rule?.stringify === true && rule?.JSNativeDate === true ) {
-      throw newError("both stringify and JSNativeDate cannot be set; use one or neither")
+    if (rule?.stringify === true && rule?.JSNativeDate === true) {
+      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
@@ -343,8 +343,8 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
-    if(rule?.stringify === true  && rule?.JSNativeDate === true ) {
-      throw newError("both stringify and JSNativeDate cannot be set; use one or neither")
+    if (rule?.stringify === true && rule?.JSNativeDate === true) {
+      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
@@ -377,7 +377,7 @@ export const rule = Object.freeze({
           throw new TypeError(`${field} should be a list but received ${typeof list}`)
         }
         if (rule?.apply != null && rule.apply.validate != null) {
-          // @ts-ignore
+          // @ts-expect-error
           list.forEach((value, index) => rule.apply.validate(value, `${field}[${index}]`))
         }
       },
@@ -388,7 +388,7 @@ export const rule = Object.freeze({
         return list
       },
       parameterConversion: (list: any[]) => {
-        let apply = rule?.apply
+        const apply = rule?.apply
         if (apply != null) {
           return list.map((value) => optionalParameterConversion(value, apply))
         }
@@ -422,52 +422,50 @@ export const rule = Object.freeze({
   },
   /**
    * Create a {@link Rule} for an object, allowing complex mapping of even nested results
-   * 
+   *
    * NOTE: When using this rule, object identifiers will be mapped according to any name mapping set with neo4j.RecordObjectMapping.translateIdentifiers.
    *
    * @param {Rules} rules rules for the fields of the object.
    * @returns {Rule} A new rule for the value
    */
-  asObject(rules: Rules): Rule {
+  asObject (rules: Rules): Rule {
     return {
       validate: (value: Record<string, Object>, field: string) => {
-        for(const key in rules) {
+        for (const key in rules) {
           const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if(value[mappedkey] == null && rules[key].optional === true) {
-              continue
+          if (value[mappedkey] == null && rules[key].optional === true) {
+            continue
           }
-          if(rules[key].validate != null) {
+          if (rules[key].validate != null) {
             rules[key].validate(value[mappedkey], `${field}[${key}]`)
           }
         }
       },
       convert: (value: Record<string, Object>, field: string) => {
-        let convertedValue: Record<string, Object> = {}
-        for(const key in rules) {
+        const convertedValue: Record<string, Object> = {}
+        for (const key in rules) {
           const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if(value[key] == null && rules[key].optional === true) {
-              continue
+          if (value[key] == null && rules[key].optional === true) {
+            continue
           }
-          if(rules[key].convert != null) {
+          if (rules[key].convert != null) {
             convertedValue[key] = rules[key].convert(value[mappedkey], `${field}[${mappedkey}]`)
-          }
-          else {
+          } else {
             convertedValue[key] = value[mappedkey]
           }
         }
         return convertedValue
       },
       parameterConversion: (value: Record<string, Object>) => {
-        let convertedValue: Record<string, Object> = {}
-        for(const key in rules) {
+        const convertedValue: Record<string, Object> = {}
+        for (const key in rules) {
           const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if(value[key] == null && rules[key].optional === true) {
-              continue
+          if (value[key] == null && rules[key].optional === true) {
+            continue
           }
-          if(rules[key].parameterConversion != null) {
+          if (rules[key].parameterConversion != null) {
             convertedValue[mappedkey] = rules[key].parameterConversion(value[key])
-          }
-          else {
+          } else {
             convertedValue[mappedkey] = value[key]
           }
         }

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -420,6 +420,7 @@ export const rule = Object.freeze({
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
    * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean } | undefined} rule Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
+   * @returns {Rule} A new rule for the value
    */
   asDateTime (rule?: Rule & { stringify?: boolean, jsNativeDate?: boolean }): Rule {
     if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -449,8 +449,8 @@ export const rule = Object.freeze({
     }
   },
   /**
-   * Create a {@link Rule} that validates the value is a List. 
-   * 
+   * Create a {@link Rule} that validates the value is a List.
+   *
    * Optionally taking a rule for hydrating the contained values.
    *
    * @param {Rule & { apply?: Rule }} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
@@ -489,7 +489,7 @@ export const rule = Object.freeze({
    * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
    * @returns {Rule} A new rule for the value
    */
-  asVector (rule?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64'}): Rule {
+  asVector (rule?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }): Rule {
     if (rule?.asTypedList != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, asTypedList can not be used in combination with custom conversion functions.')
     }
@@ -498,10 +498,10 @@ export const rule = Object.freeze({
         if (!isVector(value)) {
           throw new TypeError(`${field} should be a vector but received ${typeof value}`)
         }
-        if(rule?.dimension != null && value.asTypedArray().length !== rule.dimension) {
+        if (rule?.dimension != null && value.asTypedArray().length !== rule.dimension) {
           throw new TypeError(`${field} should be a vector of length ${rule.dimension} but received length ${value.asTypedArray().length}`)
         }
-        if(rule?.type != null && value.getType() !== rule.type) {
+        if (rule?.type != null && value.getType() !== rule.type) {
           throw new TypeError(`${field} should be a vector of type ${rule.type} but received type ${value.getType()}`)
         }
       },

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -18,7 +18,7 @@
  */
 
 import { Rule, valueAs, optionalParameterConversion, Rules, defaultNameMapping } from './mapping.highlevel.ts'
-import { JSDate, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
+import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
 import Vector, { vector } from './vector.ts'
@@ -292,7 +292,7 @@ export const rule = Object.freeze({
     }
     let parameterConversion
     if (rule?.stringify === true) {
-      parameterConversion = (str: string) => Date.fromStandardDateLocal(new JSDate(str))
+      parameterConversion = (str: string) => Date.fromString(str)
     }
     if (rule?.JSNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => Date.fromStandardDateLocal(standardDate)

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -250,7 +250,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Duration) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify === true ? (str: string) => Duration.fromString(str): undefined,
+      convertToParam: rule?.stringify === true ? (str: string) => Duration.fromString(str) : undefined,
       ...rule
     }
   },
@@ -269,7 +269,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalTime) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify  === true ? (str: string) => LocalTime.fromString(str): undefined,
+      convertToParam: rule?.stringify === true ? (str: string) => LocalTime.fromString(str) : undefined,
       ...rule
     }
   },
@@ -288,7 +288,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Time) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify  === true ? (str: string) => Time.fromString(str): undefined,
+      convertToParam: rule?.stringify === true ? (str: string) => Time.fromString(str) : undefined,
       ...rule
     }
   },
@@ -307,7 +307,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Date) => convertStdDate(value, rule),
-      convertToParam: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new StandardDateClass(str)): undefined,
+      convertToParam: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new StandardDateClass(str)) : undefined,
       ...rule
     }
   },
@@ -319,11 +319,11 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asLocalDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
-    let convertToParam = undefined
-    if(rule?.stringify === true) {
+    let convertToParam
+    if (rule?.stringify === true) {
       convertToParam = (str: string) => LocalDateTime.fromStandardDate(new StandardDateClass(str))
     }
-    if(rule?.toStandardDate === true) {
+    if (rule?.toStandardDate === true) {
       convertToParam = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
     }
     return {
@@ -333,7 +333,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalDateTime) => convertStdDate(value, rule),
-      convertToParam: convertToParam,
+      convertToParam,
       ...rule
     }
   },
@@ -345,11 +345,11 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
-    let convertToParam = undefined
-    if(rule?.stringify === true) {
+    let convertToParam
+    if (rule?.stringify === true) {
       convertToParam = (str: string) => DateTime.fromStandardDate(new StandardDateClass(str))
     }
-    if(rule?.toStandardDate === true) {
+    if (rule?.toStandardDate === true) {
       convertToParam = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
     }
     return {
@@ -359,7 +359,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: DateTime) => convertStdDate(value, rule),
-      convertToParam: convertToParam,
+      convertToParam,
       ...rule
     }
   },
@@ -406,7 +406,7 @@ export const rule = Object.freeze({
         }
         return value
       },
-      convertToParam: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray): undefined,
+      convertToParam: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray) : undefined,
       ...rule
     }
   }

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -23,6 +23,7 @@ import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
 import Vector, { vector } from './vector.ts'
 import { newError } from './error.ts'
+import Integer, { isInt } from './integer.ts'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -96,22 +97,35 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { acceptBigInt?: boolean }} rule Configurations for the rule. If `acceptBigInt` is set to true, the created validate function will allow BigInts through and the convert function will turn BigInts into Numbers.
+   * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule. 
+   * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */
-  asNumber (rule?: Rule & { acceptBigInt?: boolean }): Rule { // TODO: RECONSIDER HOW THE NUMBER RULES WORK, GIVEN Integers and Floats. asNumber and asBigInt should probably be asInteger and asFloat
+  asNumber (rule?: Rule & { isInteger?: boolean }): Rule {
     return {
       validate: (value: any, field: string) => {
-        if (typeof value === 'object' && value.low !== undefined && value.high !== undefined && Object.keys(value).length === 2) {
-          throw new TypeError('Number returned as Object. To use asNumber mapping, set disableLosslessIntegers or useBigInt in driver config object')
+        if (isInt(value) && rule?.isInteger !== true) {
+          throw new TypeError('Number returned as Integer Object. To use asNumber mapping with Integers, set "isInteger" in rule configuration.')
         }
-        if (typeof value !== 'number' && (rule?.acceptBigInt !== true || typeof value !== 'bigint')) {
+        if (rule?.isInteger !== true && typeof value === 'bigint') {
+          throw new TypeError('Number returned as BigInt. To use asNumber mapping with integer values, set "isInteger" in rule configuration.')
+        }
+        if (typeof value !== 'number') {
           throw new TypeError(`${field} should be a number but received ${typeof value}`)
         }
       },
-      convert: (value: number | bigint) => {
+      convert: (value: number | bigint | Integer) => {
         if (typeof value === 'bigint') {
           return Number(value)
+        }
+        if (isInt(value)) {
+          return value.toNumber()
+        }
+        return value
+      },
+      parameterConversion: (value: number | bigint | Integer) => {
+        if (rule?.isInteger === true ) {
+          return Integer.fromValue(value)
         }
         return value
       },
@@ -129,13 +143,42 @@ export const rule = Object.freeze({
   asBigInt (rule?: Rule & { acceptNumber?: boolean }): Rule {
     return {
       validate: (value: any, field: string) => {
-        if (typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number')) {
+        if (
+          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !(isInt(value))
+        ) {
           throw new TypeError(`${field} should be a bigint but received ${typeof value}`)
         }
       },
-      convert: (value: number | bigint) => {
+      convert: (value: number | bigint | Integer) => {
         if (typeof value === 'number') {
           return BigInt(value)
+        }
+        if(isInt(value)) {
+          return value.toBigInt()
+        }
+        return value
+      },
+      ...rule
+    }
+  },
+  /**
+   * Create a {@link Rule} that validates the value is an {@link Integer}.
+   *
+   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
+   *
+   * @param {Rule & { acceptNumber?: boolean } | undefined} rule Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the conversion functions will turn Numbers into Integers. 
+   * @returns {Rule} A new rule for the value
+   */
+  asInteger (rule?: Rule & { acceptNumber?: boolean }): Rule {
+    return {
+      validate: (value: any, field: string) => {
+        if (typeof value !== 'bigint' && !isInt(value)) {
+          throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
+        }
+      },
+      convert: (value: number | bigint | Integer) => {
+        if (typeof value === 'bigint') {
+          return Integer.fromValue(value)
         }
         return value
       },

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -97,7 +97,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule. 
+   * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule.
    * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */
@@ -124,7 +124,7 @@ export const rule = Object.freeze({
         return value
       },
       parameterConversion: (value: number | bigint | Integer) => {
-        if (rule?.isInteger === true ) {
+        if (rule?.isInteger === true) {
           return Integer.fromValue(value)
         }
         return value
@@ -153,7 +153,7 @@ export const rule = Object.freeze({
         if (typeof value === 'number') {
           return BigInt(value)
         }
-        if(isInt(value)) {
+        if (isInt(value)) {
           return value.toBigInt()
         }
         return value
@@ -166,7 +166,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { acceptNumber?: boolean } | undefined} rule Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the conversion functions will turn Numbers into Integers. 
+   * @param {Rule & { acceptNumber?: boolean } | undefined} rule Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the conversion functions will turn Numbers into Integers.
    * @returns {Rule} A new rule for the value
    */
   asInteger (rule?: Rule & { acceptNumber?: boolean }): Rule {

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -18,7 +18,7 @@
  */
 
 import { Rule, valueAs, optionalParameterConversion, Rules, defaultNameMapping } from './mapping.highlevel.ts'
-import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
+import { StandardDate, isNode, isPath, isRelationship } from './graph-types.ts'
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
 import Vector, { isVector, vector } from './vector.ts'
@@ -26,11 +26,15 @@ import { newError } from './error.ts'
 import Integer, { isInt } from './integer.ts'
 
 /**
+ * @property {function(rule: ?Rule)} asBoolean Create a {@link Rule} that validates the value is a Boolean.
+ *
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
  *
- * @property {function(rule: ?Rule & { acceptBigInt?: boolean })} asNumber Create a {@link Rule} that validates the value is a Number.
+ * @property {function(rule: ?Rule & { isInteger?: boolean })} asNumber Create a {@link Rule} that validates the value is a {@link Number}.
  *
- * @property {function(rule: ?Rule & { acceptNumber?: boolean })} AsBigInt Create a {@link Rule} that validates the value is a BigInt.
+ * @property {function(rule: ?Rule & { acceptNumber?: boolean })} asBigInt Create a {@link Rule} that validates the value is a {@link BigInt}.
+ *
+ * @property {function(rule: ?Rule & { acceptNumber?: boolean })} asInteger Create a {@link Rule} that validates the value is an {@link Integer}.
  *
  * @property {function(rule: ?Rule)} asNode Create a {@link Rule} that validates the value is a {@link Node}.
  *
@@ -38,24 +42,25 @@ import Integer, { isInt } from './integer.ts'
  *
  * @property {function(rule: ?Rule)} asPath Create a {@link Rule} that validates the value is a {@link Path}.
  *
+ * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
+ *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asDuration Create a {@link Rule} that validates the value is a {@link Duration}.
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asLocalTime Create a {@link Rule} that validates the value is a {@link LocalTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
- *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asTime Create a {@link Rule} that validates the value is a {@link Time}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean})} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean})} asDate Create a {@link Rule} that validates the value is a {@link Date}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
  *
- * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
  *
  * @property {function(rule: ?Rule & { apply?: Rule })} asList Create a {@link Rule} that validates the value is a List.
  *
- * @property {function(rule: ?Rule & { asTypedList: boolean })} asVector Create a {@link Rule} that validates the value is a List.
+ * @property {function(rule: ?Rule & { asTypedList?: boolean })} asVector Create a {@link Rule} that validates the value is a Vector.
  *
+ * @property {function(rules: Rules)} asObject Create a {@link Rule} for an object, allowing complex mapping of even nested results.
  */
 export const rule = Object.freeze({
   /**
@@ -97,7 +102,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { isInteger?: boolean }} rule Configurations for the rule.
+   * @param {Rule & { isInteger?: boolean }| undefined } rule Configurations for the rule.
    * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */
@@ -137,14 +142,14 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { acceptNumber?: boolean } | undefined} rule Configurations for the rule, if `acceptNumber` is set to true, the created validate function will allow Numbers through and the convert function will turn Numbers into BigInts.
+          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !isInt(value)
    * @returns {Rule} A new rule for the value
    */
   asBigInt (rule?: Rule & { acceptNumber?: boolean }): Rule {
     return {
       validate: (value: any, field: string) => {
         if (
-          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !(isInt(value))
+          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !isInt(value)
         ) {
           throw new TypeError(`${field} should be a bigint but received ${typeof value}`)
         }
@@ -172,7 +177,7 @@ export const rule = Object.freeze({
   asInteger (rule?: Rule & { acceptNumber?: boolean }): Rule {
     return {
       validate: (value: any, field: string) => {
-        if (typeof value !== 'bigint' && !isInt(value)) {
+        if (typeof value !== 'bigint' && !isInt(value) && !(typeof value === 'number' && rule?.acceptNumber === true)) {
           throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
         }
       },
@@ -200,8 +205,8 @@ export const rule = Object.freeze({
    *  movie: neo4j.rule.asNode({}),
    * }
    *
-   * @param {Rule} rule Configurations for the rule
-   * @returns {Rule} A new rule for the value
+   * @param {Rule | undefined} rule Configurations for the rule
+   * @returns {Rule | undefined} A new rule for the value
    */
   asNode (rule?: Rule): Rule {
     return {
@@ -228,7 +233,7 @@ export const rule = Object.freeze({
    *  employment: neo4j.rule.asRelationship({}),
    * }
    *
-   * @param {Rule} rule Configurations for the rule.
+   * @param {Rule | undefined} rule Configurations for the rule.
    * @returns {Rule} A new rule for the value
    */
   asRelationship (rule?: Rule): Rule {
@@ -242,29 +247,11 @@ export const rule = Object.freeze({
     }
   },
   /**
-   * Create a {@link Rule} that validates the value is an {@link UnboundRelationship}
-   *
-   * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
-   *
-   * @param {Rule} rule Configurations for the rule
-   * @returns {Rule} A new rule for the value
-   */
-  asUnboundRelationship (rule?: Rule): Rule {
-    return {
-      validate: (value: any, field: string) => {
-        if (!isUnboundRelationship(value)) {
-          throw new TypeError(`${field} should be a UnboundRelationship but received ${typeof value}`)
-        }
-      },
-      ...rule
-    }
-  },
-  /**
    * Create a {@link Rule} that validates the value is a {@link Path}
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule | undefined} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
   asPath (rule?: Rule): Rule {
@@ -282,7 +269,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule | undefined} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
   asPoint (rule?: Rule): Rule {
@@ -300,7 +287,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
+   * @param {Rule & { stringify?: boolean } | undefined} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Duration}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asDuration (rule?: Rule & { stringify?: boolean }): Rule {
@@ -321,7 +308,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalTime}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
+   * @param {Rule & { stringify?: boolean } | undefined} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link LocalTime}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asLocalTime (rule?: Rule & { stringify?: boolean }): Rule {
@@ -342,7 +329,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Time}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
+   * @param {Rule & { stringify?: boolean } | undefined} rule Configurations for the rule. If `stringify` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings in user code and {@link Time}s in the database.
    * @returns {Rule} A new rule for the value
    */
   asTime (rule?: Rule & { stringify?: boolean }): Rule {
@@ -363,24 +350,24 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Date}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
+   * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean } | undefined} rule Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link Date}s in the database.
    * @returns {Rule} A new rule for the value
    */
-  asDate (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+  asDate (rule?: Rule & { stringify?: boolean, jsNativeDate?: boolean }): Rule {
     if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
     }
-    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
-      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    if (rule?.jsNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, jsNativeDate can not be used in combination with custom conversion functions.')
     }
-    if (rule?.stringify === true && rule?.JSNativeDate === true) {
-      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    if (rule?.stringify === true && rule?.jsNativeDate === true) {
+      throw newError('both stringify and jsNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => Date.fromString(str)
     }
-    if (rule?.JSNativeDate === true) {
+    if (rule?.jsNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => Date.fromStandardDateLocal(standardDate)
     }
     return {
@@ -397,24 +384,24 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalDateTime}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
+   * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean } | undefined} rule Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link LocalDateTime}s in the database.
    * @returns {Rule} A new rule for the value
    */
-  asLocalDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+  asLocalDateTime (rule?: Rule & { stringify?: boolean, jsNativeDate?: boolean }): Rule {
     if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
     }
-    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
-      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    if (rule?.jsNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, jsNativeDate can not be used in combination with custom conversion functions.')
     }
-    if (rule?.stringify === true && rule?.JSNativeDate === true) {
-      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    if (rule?.stringify === true && rule?.jsNativeDate === true) {
+      throw newError('both stringify and jsNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => LocalDateTime.fromString(str)
     }
-    if (rule?.JSNativeDate === true) {
+    if (rule?.jsNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
     }
     return {
@@ -431,23 +418,23 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
-   * @param {Rule} rule Configurations for the rule. If `stringify`/`JSNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
+   * @param {Rule & { stringify?: boolean, jsNativeDate?: boolean } | undefined} rule Configurations for the rule. If `stringify`/`jsNativeDate` is set, the returned rule will have `convert` and `parameterConversion` functions which automatically convert between strings/JavaScript Dates in user code and {@link DateTime}s in the database.
    */
-  asDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+  asDateTime (rule?: Rule & { stringify?: boolean, jsNativeDate?: boolean }): Rule {
     if (rule?.stringify != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, stringify can not be used in combination with custom conversion functions.')
     }
-    if (rule?.JSNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
-      throw newError('Provided rule already has convert and/or parameterConversion function, JSNativeDate can not be used in combination with custom conversion functions.')
+    if (rule?.jsNativeDate != null && (rule?.convert != null || rule.parameterConversion != null)) {
+      throw newError('Provided rule already has convert and/or parameterConversion function, jsNativeDate can not be used in combination with custom conversion functions.')
     }
-    if (rule?.stringify === true && rule?.JSNativeDate === true) {
-      throw newError('both stringify and JSNativeDate cannot be set; use one or neither')
+    if (rule?.stringify === true && rule?.jsNativeDate === true) {
+      throw newError('both stringify and jsNativeDate cannot be set; use one or neither')
     }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => DateTime.fromString(str)
     }
-    if (rule?.JSNativeDate === true) {
+    if (rule?.jsNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
     }
     return {
@@ -462,7 +449,9 @@ export const rule = Object.freeze({
     }
   },
   /**
-   * Create a {@link Rule} that validates the value is a List. Optionally taking a rule for hydrating the contained values.
+   * Create a {@link Rule} that validates the value is a List. 
+   * 
+   * Optionally taking a rule for hydrating the contained values.
    *
    * @param {Rule & { apply?: Rule }} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
    * @returns {Rule} A new rule for the value
@@ -473,9 +462,9 @@ export const rule = Object.freeze({
         if (!Array.isArray(list)) {
           throw new TypeError(`${field} should be a list but received ${typeof list}`)
         }
-        if (rule?.apply != null && rule.apply.validate != null) {
-          // @ts-expect-error
-          list.forEach((value, index) => rule.apply.validate(value, `${field}[${index}]`))
+        const validate = rule?.apply?.validate
+        if (validate != null) {
+          list.forEach((value, index) => validate(value, `${field}[${index}]`))
         }
       },
       convert: (list: any[], field: string) => {
@@ -497,10 +486,10 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Vector.
    *
-   * @param {Rule & { asTypedList?: boolean }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
+   * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
    * @returns {Rule} A new rule for the value
    */
-  asVector (rule?: Rule & { asTypedList?: boolean }): Rule {
+  asVector (rule?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64'}): Rule {
     if (rule?.asTypedList != null && (rule?.convert != null || rule.parameterConversion != null)) {
       throw newError('Provided rule already has convert and/or parameterConversion function, asTypedList can not be used in combination with custom conversion functions.')
     }
@@ -508,6 +497,12 @@ export const rule = Object.freeze({
       validate: (value: any, field: string) => {
         if (!isVector(value)) {
           throw new TypeError(`${field} should be a vector but received ${typeof value}`)
+        }
+        if(rule?.dimension != null && value.asTypedArray().length !== rule.dimension) {
+          throw new TypeError(`${field} should be a vector of length ${rule.dimension} but received length ${value.asTypedArray().length}`)
+        }
+        if(rule?.type != null && value.getType() !== rule.type) {
+          throw new TypeError(`${field} should be a vector of type ${rule.type} but received type ${value.getType()}`)
         }
       },
       convert: (value: Vector<any>) => {
@@ -531,6 +526,7 @@ export const rule = Object.freeze({
   asObject (rules: Rules): Rule {
     return {
       validate: (value: Record<string, Object>, field: string) => {
+        console.error(JSON.stringify(value))
         for (const key in rules) {
           const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
           if (value[mappedKey] == null) {
@@ -538,7 +534,7 @@ export const rule = Object.freeze({
               continue
             } else {
               throw newError(
-                `Mapped Parameter object did not include required field with key ${mappedKey}, 
+                `Mapped Parameter object did not include required field ${field} with key ${mappedKey}, 
                 check provided parameters and parameter rules.`
               )
             }
@@ -570,7 +566,7 @@ export const rule = Object.freeze({
           if (value[key] == null && rules[key].optional === true) {
             continue
           }
-          if (rules[key].parameterConversion != null) {
+          if (value[key] != null && rules[key].parameterConversion != null) {
             convertedValue[mappedKey] = rules[key].parameterConversion(value[key])
           } else {
             convertedValue[mappedKey] = value[key]
@@ -585,11 +581,11 @@ export const rule = Object.freeze({
 
 interface ConvertableToStdDateOrStr { toStandardDate: () => StandardDate, toString: () => string }
 
-function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { stringify?: boolean, JSNativeDate?: boolean }): string | V | StandardDate {
+function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { stringify?: boolean, jsNativeDate?: boolean }): string | V | StandardDate {
   if (rule != null) {
     if (rule.stringify === true) {
       return value.toString()
-    } else if (rule.JSNativeDate === true) {
+    } else if (rule.jsNativeDate === true) {
       return value.toStandardDate()
     }
   }

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -40,6 +40,8 @@ import Integer, { isInt } from './integer.ts'
  *
  * @property {function(rule: ?Rule)} asRelationship Create a {@link Rule} that validates the value is a {@link Relationship}.
  *
+ * @property {function(rule: ?Rule)} asUnboundRelationship Create a {@link Rule} that validates the value is an {@link UnboundRelationship}.
+ *
  * @property {function(rule: ?Rule)} asPath Create a {@link Rule} that validates the value is a {@link Path}.
  *
  * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
@@ -50,15 +52,15 @@ import Integer, { isInt } from './integer.ts'
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asTime Create a {@link Rule} that validates the value is a {@link Time}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean, jsNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
  *
  * @property {function(rule: ?Rule & { apply?: Rule })} asList Create a {@link Rule} that validates the value is a List.
  *
- * @property {function(rule: ?Rule & { asTypedList?: boolean })} asVector Create a {@link Rule} that validates the value is a Vector.
+ * @property {function(rule: ?Rule & { asTypedList?: boolean, dimension?: number, type?: "INT8" | "INT16" | "INT32" | "INT64" | "FLOAT32" | "FLOAT64" })} asVector Create a {@link Rule} that validates the value is a Vector.
  *
  * @property {function(rules: Rules)} asObject Create a {@link Rule} for an object, allowing complex mapping of even nested results.
  */
@@ -66,7 +68,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Boolean.
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule | undefined} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
   asBoolean (rule?: Rule): Rule {
@@ -84,7 +86,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule | undefined} rule Configurations for the rule
    * @returns {Rule} A new rule for the value
    */
   asString (rule?: Rule): Rule {
@@ -102,7 +104,7 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-   * @param {Rule & { isInteger?: boolean }| undefined } rule Configurations for the rule.
+   * @param {Rule & { isInteger?: boolean } | undefined } rule Configurations for the rule.
    * If `isInteger` is set to true, the created validate function will allow Integer values through, and the conversion functions will ensure results are return as numbers while parameters are transmitted as integers.
    * @returns {Rule} A new rule for the value
    */
@@ -142,7 +144,6 @@ export const rule = Object.freeze({
    *
    * Optionally takes a {@link Rule}, in which case the returned rule will keep all fields of the one provided.
    *
-          typeof value !== 'bigint' && (rule?.acceptNumber !== true || typeof value !== 'number') && !isInt(value)
    * @returns {Rule} A new rule for the value
    */
   asBigInt (rule?: Rule & { acceptNumber?: boolean }): Rule {
@@ -206,7 +207,7 @@ export const rule = Object.freeze({
    * }
    *
    * @param {Rule | undefined} rule Configurations for the rule
-   * @returns {Rule | undefined} A new rule for the value
+   * @returns {Rule} A new rule for the value
    */
   asNode (rule?: Rule): Rule {
     return {
@@ -453,7 +454,7 @@ export const rule = Object.freeze({
    *
    * Optionally taking a rule for hydrating the contained values.
    *
-   * @param {Rule & { apply?: Rule }} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
+   * @param {Rule & { apply?: Rule } | undefined} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
    * @returns {Rule} A new rule for the value
    */
   asList (rule?: Rule & { apply?: Rule }): Rule {
@@ -486,7 +487,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Vector.
    *
-   * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
+   * @param {Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' } | undefined} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
    * @returns {Rule} A new rule for the value
    */
   asVector (rule?: Rule & { asTypedList?: boolean, dimension?: number, type?: 'INT8' | 'INT16' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' }): Rule {
@@ -526,7 +527,6 @@ export const rule = Object.freeze({
   asObject (rules: Rules): Rule {
     return {
       validate: (value: Record<string, Object>, field: string) => {
-        console.error(JSON.stringify(value))
         for (const key in rules) {
           const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
           if (value[mappedKey] == null) {
@@ -548,10 +548,7 @@ export const rule = Object.freeze({
         const convertedValue: Record<string, Object> = {}
         for (const key in rules) {
           const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if (value[key] == null && rules[key].optional === true) {
-            continue
-          }
-          if (rules[key].convert != null) {
+          if (value[mappedKey] != null && rules[key].convert != null) {
             convertedValue[key] = rules[key].convert(value[mappedKey], `${field}[${mappedKey}]`)
           } else {
             convertedValue[key] = value[mappedKey]
@@ -563,9 +560,6 @@ export const rule = Object.freeze({
         const convertedValue: Record<string, Object> = {}
         for (const key in rules) {
           const mappedKey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
-          if (value[key] == null && rules[key].optional === true) {
-            continue
-          }
           if (value[key] != null && rules[key].parameterConversion != null) {
             convertedValue[mappedKey] = rules[key].parameterConversion(value[key])
           } else {

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -21,7 +21,7 @@ import { Rule, valueAs, optionalParameterConversion, Rules, defaultNameMapping }
 import { StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
-import Vector, { vector } from './vector.ts'
+import Vector, { isVector, vector } from './vector.ts'
 import { newError } from './error.ts'
 import Integer, { isInt } from './integer.ts'
 
@@ -506,7 +506,7 @@ export const rule = Object.freeze({
     }
     return {
       validate: (value: any, field: string) => {
-        if (!(value instanceof Vector)) {
+        if (!isVector(value)) {
           throw new TypeError(`${field} should be a vector but received ${typeof value}`)
         }
       },

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -17,11 +17,12 @@
  * limitations under the License.
  */
 
-import { Rule, valueAs, optionalParameterConversion } from './mapping.highlevel.ts'
+import { Rule, valueAs, optionalParameterConversion, Rules, defaultNameMapping } from './mapping.highlevel.ts'
 import { JSDate, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
 import Vector, { vector } from './vector.ts'
+import { newError } from './error.ts'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -40,13 +41,13 @@ import Vector, { vector } from './vector.ts'
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asLocalTime Create a {@link Rule} that validates the value is a {@link LocalTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean })} asLocalDateTime Create a {@link Rule} that validates the value is a {@link LocalDateTime}.
  *
  * @property {function(rule: ?Rule & { stringify?: boolean })} asTime Create a {@link Rule} that validates the value is a {@link Time}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean })} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean})} asDateTime Create a {@link Rule} that validates the value is a {@link DateTime}.
  *
- * @property {function(rule: ?Rule & { stringify?: boolean })} asDate Create a {@link Rule} that validates the value is a {@link Date}.
+ * @property {function(rule: ?Rule & { stringify?: boolean, JSNativeDate?: boolean})} asDate Create a {@link Rule} that validates the value is a {@link Date}.
  *
  * @property {function(rule: ?Rule)} asPoint Create a {@link Rule} that validates the value is a {@link Point}.
  *
@@ -228,7 +229,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Duration}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and Durations in the database.
    * @returns {Rule} A new rule for the value
    */
   asDuration (rule?: Rule & { stringify?: boolean }): Rule {
@@ -246,7 +247,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalTime}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and LocalTimes in the database.
    * @returns {Rule} A new rule for the value
    */
   asLocalTime (rule?: Rule & { stringify?: boolean }): Rule {
@@ -264,7 +265,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Time}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify will automatically convert between strings in user code and Times in the database.
    * @returns {Rule} A new rule for the value
    */
   asTime (rule?: Rule & { stringify?: boolean }): Rule {
@@ -282,10 +283,20 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link Date}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and Dates in the database.
    * @returns {Rule} A new rule for the value
    */
-  asDate (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+  asDate (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if(rule?.stringify === true && rule?.JSNativeDate === true ) {
+      throw newError("both stringify and JSNativeDate cannot be set; use one or neither")
+    }
+    let parameterConversion
+    if (rule?.stringify === true) {
+      parameterConversion = (str: string) => Date.fromStandardDateLocal(new JSDate(str))
+    }
+    if (rule?.JSNativeDate === true) {
+      parameterConversion = (standardDate: StandardDate) => Date.fromStandardDateLocal(standardDate)
+    }
     return {
       validate: (value: any, field: string) => {
         if (!isDate(value)) {
@@ -293,22 +304,25 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Date) => convertStdDate(value, rule),
-      parameterConversion: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new JSDate(str)) : undefined,
+      parameterConversion,
       ...rule
     }
   },
   /**
    * Create a {@link Rule} that validates the value is a {@link LocalDateTime}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and LocalDateTimes in the database.
    * @returns {Rule} A new rule for the value
    */
-  asLocalDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+  asLocalDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if(rule?.stringify === true && rule?.JSNativeDate === true ) {
+      throw newError("both stringify and JSNativeDate cannot be set; use one or neither")
+    }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => LocalDateTime.fromString(str)
     }
-    if (rule?.toStandardDate === true) {
+    if (rule?.JSNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
     }
     return {
@@ -325,15 +339,18 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a {@link DateTime}
    *
-   * @param {Rule} rule Configurations for the rule
+   * @param {Rule} rule Configurations for the rule. Setting stringify/JSNativeDate will automatically convert between strings/JavaScript Dates in user code and DateTimes in the database.
    * @returns {Rule} A new rule for the value
    */
-  asDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
+  asDateTime (rule?: Rule & { stringify?: boolean, JSNativeDate?: boolean }): Rule {
+    if(rule?.stringify === true  && rule?.JSNativeDate === true ) {
+      throw newError("both stringify and JSNativeDate cannot be set; use one or neither")
+    }
     let parameterConversion
     if (rule?.stringify === true) {
       parameterConversion = (str: string) => DateTime.fromString(str)
     }
-    if (rule?.toStandardDate === true) {
+    if (rule?.JSNativeDate === true) {
       parameterConversion = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
     }
     return {
@@ -350,14 +367,18 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a List. Optionally taking a rule for hydrating the contained values.
    *
-   * @param {Rule & { apply?: Rule }} rule Configurations for the rule
+   * @param {Rule & { apply?: Rule }} rule Configurations for the rule. Setting apply to a rule will apply that rule to all elements of the list.
    * @returns {Rule} A new rule for the value
    */
   asList (rule?: Rule & { apply?: Rule }): Rule {
     return {
-      validate: (value: any, field: string) => {
-        if (!Array.isArray(value)) {
-          throw new TypeError(`${field} should be a list but received ${typeof value}`)
+      validate: (list: any, field: string) => {
+        if (!Array.isArray(list)) {
+          throw new TypeError(`${field} should be a list but received ${typeof list}`)
+        }
+        if (rule?.apply != null && rule.apply.validate != null) {
+          // @ts-ignore
+          list.forEach((value, index) => rule.apply.validate(value, `${field}[${index}]`))
         }
       },
       convert: (list: any[], field: string) => {
@@ -367,8 +388,9 @@ export const rule = Object.freeze({
         return list
       },
       parameterConversion: (list: any[]) => {
-        if (rule?.apply != null) {
-          return list.map((value) => optionalParameterConversion(value, rule.apply))
+        let apply = rule?.apply
+        if (apply != null) {
+          return list.map((value) => optionalParameterConversion(value, apply))
         }
         return list
       },
@@ -378,7 +400,7 @@ export const rule = Object.freeze({
   /**
    * Create a {@link Rule} that validates the value is a Vector.
    *
-   * @param {Rule & { asTypedList?: boolean }} rule Configurations for the rule
+   * @param {Rule & { asTypedList?: boolean }} rule Configurations for the rule. Setting asTypedList will automatically convert between TypedList in user code and Vectors in the database.
    * @returns {Rule} A new rule for the value
    */
   asVector (rule?: Rule & { asTypedList?: boolean }): Rule {
@@ -397,16 +419,72 @@ export const rule = Object.freeze({
       parameterConversion: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray) : undefined,
       ...rule
     }
+  },
+  /**
+   * Create a {@link Rule} for an object, allowing complex mapping of even nested results
+   * 
+   * NOTE: When using this rule, object identifiers will be mapped according to any name mapping set with neo4j.RecordObjectMapping.translateIdentifiers.
+   *
+   * @param {Rules} rules rules for the fields of the object.
+   * @returns {Rule} A new rule for the value
+   */
+  asObject(rules: Rules): Rule {
+    return {
+      validate: (value: Record<string, Object>, field: string) => {
+        for(const key in rules) {
+          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          if(value[mappedkey] == null && rules[key].optional === true) {
+              continue
+          }
+          if(rules[key].validate != null) {
+            rules[key].validate(value[mappedkey], `${field}[${key}]`)
+          }
+        }
+      },
+      convert: (value: Record<string, Object>, field: string) => {
+        let convertedValue: Record<string, Object> = {}
+        for(const key in rules) {
+          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          if(value[key] == null && rules[key].optional === true) {
+              continue
+          }
+          if(rules[key].convert != null) {
+            convertedValue[key] = rules[key].convert(value[mappedkey], `${field}[${mappedkey}]`)
+          }
+          else {
+            convertedValue[key] = value[mappedkey]
+          }
+        }
+        return convertedValue
+      },
+      parameterConversion: (value: Record<string, Object>) => {
+        let convertedValue: Record<string, Object> = {}
+        for(const key in rules) {
+          const mappedkey = rules[key].from != null ? rules[key].from : defaultNameMapping(key)
+          if(value[key] == null && rules[key].optional === true) {
+              continue
+          }
+          if(rules[key].parameterConversion != null) {
+            convertedValue[mappedkey] = rules[key].parameterConversion(value[key])
+          }
+          else {
+            convertedValue[mappedkey] = value[key]
+          }
+        }
+        return convertedValue
+      },
+      ...rule
+    }
   }
 })
 
 interface ConvertableToStdDateOrStr { toStandardDate: () => StandardDate, toString: () => string }
 
-function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { stringify?: boolean, toStandardDate?: boolean }): string | V | StandardDate {
+function convertStdDate<V extends ConvertableToStdDateOrStr> (value: V, rule?: { stringify?: boolean, JSNativeDate?: boolean }): string | V | StandardDate {
   if (rule != null) {
     if (rule.stringify === true) {
       return value.toString()
-    } else if (rule.toStandardDate === true) {
+    } else if (rule.JSNativeDate === true) {
       return value.toStandardDate()
     }
   }

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import { Rule, valueAs, valueAsParam } from './mapping.highlevel.ts'
-import { StandardDateClass, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
+import { Rule, valueAs, optionalParameterConversion } from './mapping.highlevel.ts'
+import { JSDate, StandardDate, isNode, isPath, isRelationship, isUnboundRelationship } from './graph-types.ts'
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
 import Vector, { vector } from './vector.ts'
@@ -250,7 +250,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Duration) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify === true ? (str: string) => Duration.fromString(str) : undefined,
+      parameterConversion: rule?.stringify === true ? (str: string) => Duration.fromString(str) : undefined,
       ...rule
     }
   },
@@ -269,7 +269,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalTime) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify === true ? (str: string) => LocalTime.fromString(str) : undefined,
+      parameterConversion: rule?.stringify === true ? (str: string) => LocalTime.fromString(str) : undefined,
       ...rule
     }
   },
@@ -288,7 +288,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Time) => rule?.stringify === true ? value.toString() : value,
-      convertToParam: rule?.stringify === true ? (str: string) => Time.fromString(str) : undefined,
+      parameterConversion: rule?.stringify === true ? (str: string) => Time.fromString(str) : undefined,
       ...rule
     }
   },
@@ -307,7 +307,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: Date) => convertStdDate(value, rule),
-      convertToParam: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new StandardDateClass(str)) : undefined,
+      parameterConversion: rule?.stringify === true ? (str: string) => Date.fromStandardDateLocal(new JSDate(str)) : undefined,
       ...rule
     }
   },
@@ -319,12 +319,12 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asLocalDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
-    let convertToParam
+    let parameterConversion
     if (rule?.stringify === true) {
-      convertToParam = (str: string) => LocalDateTime.fromStandardDate(new StandardDateClass(str))
+      parameterConversion = (str: string) => LocalDateTime.fromString(str)
     }
     if (rule?.toStandardDate === true) {
-      convertToParam = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
+      parameterConversion = (standardDate: StandardDate) => LocalDateTime.fromStandardDate(standardDate)
     }
     return {
       validate: (value: any, field: string) => {
@@ -333,7 +333,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: LocalDateTime) => convertStdDate(value, rule),
-      convertToParam,
+      parameterConversion,
       ...rule
     }
   },
@@ -345,12 +345,12 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asDateTime (rule?: Rule & { stringify?: boolean, toStandardDate?: boolean }): Rule {
-    let convertToParam
+    let parameterConversion
     if (rule?.stringify === true) {
-      convertToParam = (str: string) => DateTime.fromStandardDate(new StandardDateClass(str))
+      parameterConversion = (str: string) => DateTime.fromString(str)
     }
     if (rule?.toStandardDate === true) {
-      convertToParam = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
+      parameterConversion = (standardDate: StandardDate) => DateTime.fromStandardDate(standardDate)
     }
     return {
       validate: (value: any, field: string) => {
@@ -359,7 +359,7 @@ export const rule = Object.freeze({
         }
       },
       convert: (value: DateTime) => convertStdDate(value, rule),
-      convertToParam,
+      parameterConversion,
       ...rule
     }
   },
@@ -383,9 +383,9 @@ export const rule = Object.freeze({
         }
         return list
       },
-      convertToParam: (list: any[]) => {
+      parameterConversion: (list: any[]) => {
         if (rule?.apply != null) {
-          return list.map((value) => valueAsParam(value, rule.apply))
+          return list.map((value) => optionalParameterConversion(value, rule.apply))
         }
         return list
       },
@@ -412,7 +412,7 @@ export const rule = Object.freeze({
         }
         return value
       },
-      convertToParam: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray) : undefined,
+      parameterConversion: rule?.asTypedList === true ? (typedArray: Int16Array | Int32Array | BigInt64Array | Float32Array | Float64Array) => vector(typedArray) : undefined,
       ...rule
     }
   }

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -152,12 +152,12 @@ export const rule = Object.freeze({
    * @returns {Rule} A new rule for the value
    */
   asInteger (rule?: Rule & { asNumber?: boolean, asBigInt?: boolean }): Rule {
-    if(rule?.asNumber === true && rule.asBigInt === true) {
-      throw newError("Cannot set both asNumber and asBigInt in a asInteger rule")
+    if (rule?.asNumber === true && rule.asBigInt === true) {
+      throw newError('Cannot set both asNumber and asBigInt in a asInteger rule')
     }
     return {
       validate: (value: any, field: string) => {
-        if (isInt(value) !== true) {
+        if (!isInt(value)) {
           throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
         }
       },
@@ -171,10 +171,10 @@ export const rule = Object.freeze({
         return value
       },
       convertToParam: (objectValue: any) => {
-        if(rule?.asNumber === true) {
+        if (rule?.asNumber === true) {
           return int(objectValue)
         }
-        if(rule?.asBigInt === true) {
+        if (rule?.asBigInt === true) {
           return int(objectValue)
         }
         return objectValue

--- a/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
+++ b/packages/neo4j-driver-deno/lib/core/mapping.rulesfactories.ts
@@ -22,8 +22,6 @@ import { StandardDateClass, StandardDate, isNode, isPath, isRelationship, isUnbo
 import { isPoint } from './spatial-types.ts'
 import { Date, DateTime, Duration, LocalDateTime, LocalTime, Time, isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from './temporal-types.ts'
 import Vector, { vector } from './vector.ts'
-import { newError } from './error.ts'
-import Integer, { int, isInt } from './integer.ts'
 
 /**
  * @property {function(rule: ?Rule)} asString Create a {@link Rule} that validates the value is a String.
@@ -140,44 +138,6 @@ export const rule = Object.freeze({
           return BigInt(value)
         }
         return value
-      },
-      ...rule
-    }
-  },
-  /**
-   * Create a {@link Rule} that validates the value is an {@link Integer}.
-   *
-   * @experimental Part of the Record Object Mapping preview feature
-   * @param {Rule & { asNumber?: boolean, asBigInt?: boolean }} rule Configurations for the rule
-   * @returns {Rule} A new rule for the value
-   */
-  asInteger (rule?: Rule & { asNumber?: boolean, asBigInt?: boolean }): Rule {
-    if (rule?.asNumber === true && rule.asBigInt === true) {
-      throw newError('Cannot set both asNumber and asBigInt in a asInteger rule')
-    }
-    return {
-      validate: (value: any, field: string) => {
-        if (!isInt(value)) {
-          throw new TypeError(`${field} should be an Integer but received ${typeof value}`)
-        }
-      },
-      convert: (value: Integer) => {
-        if (rule?.asNumber === true) {
-          return value.low
-        }
-        if (rule?.asBigInt === true) {
-          return value.toBigInt()
-        }
-        return value
-      },
-      convertToParam: (objectValue: any) => {
-        if (rule?.asNumber === true) {
-          return int(objectValue)
-        }
-        if (rule?.asBigInt === true) {
-          return int(objectValue)
-        }
-        return objectValue
       },
       ...rule
     }

--- a/packages/neo4j-driver-deno/lib/core/result-transformers.ts
+++ b/packages/neo4j-driver-deno/lib/core/result-transformers.ts
@@ -294,7 +294,6 @@ class ResultTransformers {
    *
    * @returns {ResultTransformer<ResultSummary<T>>} The result transformer
    * @see {@link Driver#executeQuery}
-   * @experimental Part of the Record Object Mapping preview feature
    */
   hydrated <T extends {} = Object>(constructorOrRules: GenericConstructor<T> | Rules, rules?: Rules): ResultTransformer<{ records: T[], summary: ResultSummary }> {
     return async result => await result.as(constructorOrRules as unknown as GenericConstructor<T>, rules).then()

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -38,6 +38,7 @@ import { RecordShape } from './record.ts'
 import NotificationFilter from './notification-filter.ts'
 import { Logger } from './internal/logger.ts'
 import { cacheKey } from './internal/auth-util.ts'
+import { Rules } from './mapping.highlevel.ts'
 
 type ConnectionConsumer<T> = (connection: Connection) => Promise<T> | T
 type ManagedTransactionWork<T> = (tx: ManagedTransaction) => Promise<T> | T
@@ -45,6 +46,7 @@ type ManagedTransactionWork<T> = (tx: ManagedTransaction) => Promise<T> | T
 interface TransactionConfig {
   timeout?: NumberOrInteger
   metadata?: object
+  parameterRules?: Rules
 }
 
 /**
@@ -186,11 +188,13 @@ class Session {
   run<R extends RecordShape = RecordShape> (
     query: Query,
     parameters?: any,
-    transactionConfig?: TransactionConfig
+    transactionConfig?: TransactionConfig,
+    parameterRules?: Rules
   ): Result<R> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
-      parameters
+      parameters,
+      {parameterRules: parameterRules}
     )
     const autoCommitTxConfig = (transactionConfig != null)
       ? new TxConfig(transactionConfig, this._log)

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -46,7 +46,6 @@ type ManagedTransactionWork<T> = (tx: ManagedTransaction) => Promise<T> | T
 interface TransactionConfig {
   timeout?: NumberOrInteger
   metadata?: object
-  parameterRules?: Rules
 }
 
 /**
@@ -183,7 +182,7 @@ class Session {
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
-   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object .
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @return {Result} New Result.
    */
   run<R extends RecordShape = RecordShape> (

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -183,6 +183,7 @@ class Session {
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object .
    * @return {Result} New Result.
    */
   run<R extends RecordShape = RecordShape> (

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -182,7 +182,7 @@ class Session {
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
    * @param {TransactionConfig} [transactionConfig] - Configuration for the new auto-commit transaction.
-   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
+   * @param {Rules} [parameterRules] - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @return {Result} New Result.
    */
   run<R extends RecordShape = RecordShape> (

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -194,7 +194,7 @@ class Session {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters,
-      {parameterRules: parameterRules}
+      { parameterRules }
     )
     const autoCommitTxConfig = (transactionConfig != null)
       ? new TxConfig(transactionConfig, this._log)

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -99,7 +99,7 @@ export class Duration<T extends NumberOrInteger = Integer> {
    * NOTE: Bolt transmits durations as 4 integers: Months, Days, Seconds and Nanoseconds. Parsing strings like P1.5M4.3D will throw an error. P0.5Y can be sent as it can be simplified as 6 months.
    *
    * @param {string} str The string to convert
-   * @returns {Duration<NumberOrInteger>}
+   * @returns {Duration}
    */
   static fromString (str: string): Duration {
     if (str.slice(-1).toUpperCase() === 'T') {
@@ -120,7 +120,7 @@ export class Duration<T extends NumberOrInteger = Integer> {
       const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
       const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
       const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
-      const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'), 'seconds')
+      const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'))
       const nanos = negativeDuration * parseDurationNanos((matches[9] ?? '') + '0' + (matches[11] ?? ''))
       checkDurationFieldIsInt(months, 'Months')
       checkDurationFieldIsInt(days, 'Days')
@@ -245,10 +245,10 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
    * Creates a {@link LocalTime} from an ISO 8601 string
    *
    * @param {string} str The string to convert
-   * @returns {LocalTime<NumberOrInteger>}
+   * @returns {LocalTime}
    */
   static fromString (str: string): LocalTime {
-    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/)
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       return new LocalTime(
@@ -374,10 +374,10 @@ export class Time<T extends NumberOrInteger = Integer> {
    * Creates a {@link Time} from an ISO 8601 string.
    *
    * @param {string} str The string to convert
-   * @returns {Time<NumberOrInteger>}
+   * @returns {Time}
    */
   static fromString (str: string): Time {
-    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       if (values[5] === 'Z') {
@@ -392,15 +392,15 @@ export class Time<T extends NumberOrInteger = Integer> {
       if (values[6] == null) {
         throw newError('Error parsing timezone offset.')
       }
-      return new Time<Integer>(
+      return new Time(
         hours,
         minutes,
         seconds,
         nanoseconds,
         int((values[5] === '+' ? 1 : -1) * (
-          parseTemporalInt(values[6], 'timezone offset hours').toInt() * 3600 +
-          parseTemporalInt(values[7], 'timezone offset minutes').toInt() * 60 +
-          parseTemporalInt(values[8], 'timezone offset seconds').toInt()
+          parseTemporalInt(values[6]).toInt() * 3600 + //timezone offset hours
+          parseTemporalInt(values[7]).toInt() * 60 + //timezone offset minutes
+          parseTemporalInt(values[8]).toInt() // timezone offset seconds
         ))
       )
     }
@@ -539,15 +539,15 @@ export class Date<T extends NumberOrInteger = Integer> {
    * Creates a {@link Date} from an ISO 8601 string
    *
    * @param {string} str The string to convert
-   * @returns {Date<NumberOrInteger>}
+   * @returns {Date}
    */
   static fromString (str: string): Date {
     const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})$/)
     if (values !== null) {
       return new Date(
-        parseTemporalInt(values[1], 'years'),
-        parseTemporalInt(values[2], 'months'),
-        parseTemporalInt(values[3], 'days')
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]) // days
       )
     }
     throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\' or \'[+|-]YYYYY-MM-DD\'')
@@ -690,16 +690,16 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
    * Creates a {@link LocalDateTime} from an ISO 8601 string
    *
    * @param {string} str The string to convert
-   * @returns {LocalDateTime<NumberOrInteger>}
+   * @returns {LocalDateTime}
    */
   static fromString (str: string): LocalDateTime {
-    const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/)
+    const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       return new LocalDateTime(
-        parseTemporalInt(values[1], 'years'),
-        parseTemporalInt(values[2], 'months'),
-        parseTemporalInt(values[3], 'days'),
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]), // days
         hours,
         minutes,
         seconds,
@@ -888,12 +888,12 @@ export class DateTime<T extends NumberOrInteger = Integer> {
    * Creates a {@link DateTime} from an ISO 8601 string
    *
    * @param {string} str The string to convert
-   * @returns {DateTime<NumberOrInteger>}
+   * @returns {DateTime}
    */
   static fromString (str: string): DateTime {
     const values = String(str.replace(/,/g, '.')).match(
       new RegExp(
-        /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?/.source + // DateTime
+        /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?/.source + // DateTime
         /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?((\[)([^\]]*)(\]))?$/.source // Timezone
       )
     )
@@ -901,9 +901,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       if (values[8] === 'Z') {
         return new DateTime(
-          parseTemporalInt(values[1], 'years'),
-          parseTemporalInt(values[2], 'months'),
-          parseTemporalInt(values[3], 'days'),
+          parseTemporalInt(values[1]), // years
+          parseTemporalInt(values[2]), // months
+          parseTemporalInt(values[3]), // days
           hours,
           minutes,
           seconds,
@@ -912,10 +912,10 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         )
       }
       if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
-        return new DateTime<Integer>(
-          parseTemporalInt(values[1], 'years'),
-          parseTemporalInt(values[2], 'months'),
-          parseTemporalInt(values[3], 'days'),
+        return new DateTime(
+          parseTemporalInt(values[1]), // years
+          parseTemporalInt(values[2]), // months
+          parseTemporalInt(values[3]), // days
           hours,
           minutes,
           seconds,
@@ -925,9 +925,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       }
       if (values[14] !== undefined) {
         return new DateTime(
-          parseTemporalInt(values[1], 'years'),
-          parseTemporalInt(values[2], 'months'),
-          parseTemporalInt(values[3], 'days'),
+          parseTemporalInt(values[1]), // years
+          parseTemporalInt(values[2]), // months
+          parseTemporalInt(values[3]), // days
           hours,
           minutes,
           seconds,
@@ -1065,11 +1065,9 @@ function parseTemporalFloat (str: string | undefined, field: string): number {
   }
 }
 
-function parseTemporalInt (str: string | undefined, field: string, maxLength?: number): Integer {
-  if (str === undefined || str.length === 0 || str === 'undefined') {
+function parseTemporalInt (str: string | undefined): Integer {
+  if (str === undefined || str.length === 0) {
     return int(0)
-  } else if (maxLength != null && str.length > maxLength) {
-    throw newError(`Failed to parse temporal field ${field}. Got string: ${str} which is longer than max length: ${maxLength}.`)
   }
   const result = int(str)
   return result
@@ -1080,22 +1078,22 @@ function handleTimeDecimals (hourString?: string, minuteString?: string, secondS
   let minutes
   let seconds
   let nanoseconds
-  const decimalInt = decimalString !== undefined ? parseFloat('0' + decimalString) : 0
+  const decimalNumber = decimalString !== undefined ? parseFloat('0' + decimalString) : 0
   if (minuteString === undefined || minuteString === '') {
-    hours = parseTemporalInt(hourString, 'hours')
-    minutes = int(decimalInt * 60)
-    seconds = int((decimalInt * 3600) % 60)
-    nanoseconds = int((decimalInt * 3600 * 10 ** 9) % 10 ** 9)
+    hours = parseTemporalInt(hourString)
+    minutes = int(decimalNumber * 60)
+    seconds = int((decimalNumber * 3600) % 60)
+    nanoseconds = int((decimalNumber * 3600 * 10 ** 9) % 10 ** 9)
   } else if (secondString === undefined || secondString === '') {
-    hours = parseTemporalInt(hourString, 'hours')
-    minutes = parseTemporalInt(minuteString, 'minutes')
-    seconds = int((decimalInt * 60) % 60)
-    nanoseconds = int((decimalInt * 60 * (10 ** 9)) % 10 ** 9)
+    hours = parseTemporalInt(hourString)
+    minutes = parseTemporalInt(minuteString)
+    seconds = int((decimalNumber * 60) % 60)
+    nanoseconds = int((decimalNumber * 60 * (10 ** 9)) % 10 ** 9)
   } else {
-    hours = parseTemporalInt(hourString, 'hours')
-    minutes = parseTemporalInt(minuteString, 'minutes')
-    seconds = parseTemporalInt(secondString, 'seconds')
-    nanoseconds = int(decimalInt * 10 ** 9)
+    hours = parseTemporalInt(hourString)
+    minutes = parseTemporalInt(minuteString)
+    seconds = parseTemporalInt(secondString)
+    nanoseconds = int(decimalNumber * 10 ** 9)
   }
   return [hours, minutes, seconds, nanoseconds]
 }

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -1008,6 +1008,6 @@ function parseDurationNanos (str: string): number {
 
 function checkDurationFieldIsInt (value: number, field: string): void {
   if (!Number.isInteger(value)) {
-    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds. `)
+    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds.`)
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -101,20 +101,28 @@ export class Duration<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Duration<NumberOrInteger>}
    */
-  static fromString (str: string): Duration<NumberOrInteger> {
-    const matches = String(str).match(/P(?:([-.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-.,\d]+)W)?(?:([-.,\d]+)D)?T?(?:([-.,\d]+)H)?(?:([-.,\d]+)M)?(?:([-.,\d]+)S)?/)
+  static fromString (str: string): Duration<Integer> {
+    const matches = String(str.replace(/,/g, '.')).match(/^([-|+]?)[P|p](?:(-?[\d]*\.?[\d]*)[Y|y])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-?[\d]*\.?[\d]*)[W|w])?(?:(-?[\d]*\.?[\d]*)[D|d])?([T|t](?:(-?[\d]*\.?[\d]*)[H|h])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-)?([\d]*)(\.[\d]*)?[S|s])?)?$/)
     if (matches !== null) {
-      const months = parseDurationFloat(matches[1], 'Years') * 12 + parseDurationFloat(matches[2], 'Months')
-      const days = parseDurationFloat(matches[3], 'Weeks') * 7 + parseDurationFloat(matches[4], 'Days')
-      const seconds = parseDurationFloat(matches[5], 'Hours') * 3600 + parseDurationFloat(matches[6], 'Minutes') * 60 + ~~parseInt(matches[7])
-      const nanos = parseDurationNanos(matches[7])
+      if(
+        matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null && 
+        matches[7] == null && matches[8] == null && matches[10] == null && matches[11] == null
+      ) {
+        throw newError(`Duration could not be parsed from string: ${str}`)
+      }
+      const negativeDuration = matches[1] === "-" ? -1 : 1
+      const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
+      const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
+      const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
+      const seconds = parseTemporalInt((matches[9] ?? "") + (matches[10] ?? "0"), "seconds")
+      const nanos = negativeDuration * parseDurationNanos((matches[9] ?? "") + "0" + (matches[11] ?? ""))
       checkDurationFieldIsInt(months, 'Months')
       checkDurationFieldIsInt(days, 'Days')
-      checkDurationFieldIsInt(seconds, 'Seconds')
+      checkDurationFieldIsInt(hoursAndMinutes, 'Seconds')
       checkDurationFieldIsInt(nanos, 'Nanoseconds')
-      return new Duration(months, days, seconds, nanos)
+      return new Duration(int(months), int(days), int(BigInt(negativeDuration) * (BigInt(hoursAndMinutes) + seconds.toBigInt())), int(nanos))
     }
-    throw newError('Duration could not be parsed from string')
+    throw newError(`Duration could not be parsed from string: ${str}`)
   }
 
   /**
@@ -233,14 +241,15 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {LocalTime<NumberOrInteger>}
    */
-  static fromString (str: string): LocalTime<NumberOrInteger> {
-    const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
+  static fromString (str: string): LocalTime<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^T?(\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?$/)
     if (values !== null) {
+      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       return new LocalTime(
-        parseInt(values[0]),
-        parseInt(values[1]),
-        parseInt(values[2]),
-        Math.round(parseFloat('0.' + values[3]) * 10 ** 9)
+        hours,
+        minutes,
+        seconds,
+        nanoseconds
       )
     }
     throw newError('LocalTime could not be parsed from string')
@@ -361,24 +370,29 @@ export class Time<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Time<NumberOrInteger>}
    */
-  static fromString (str: string): Time<NumberOrInteger> {
-    const values = String(str).match(/(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+  static fromString (str: string): Time<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?(Z|\+|-)(\d{0,2}):?(\d{0,2}):?(\d{0,2})$/)
     if (values !== null) {
+      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       if (values[5] === 'Z') {
         return new Time(
-          parseInt(values[1]),
-          parseInt(values[2]),
-          parseInt(values[3]),
-          values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
-          0
+          hours,
+          minutes,
+          seconds,
+          nanoseconds,
+          int(0)
         )
       }
-      return new Time(
-        parseInt(values[1]),
-        parseInt(values[2]),
-        parseInt(values[3]),
-        values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
-        (values[5] === '+' ? 1 : -1) * (parseInt(values[6]) * 3600 + parseInt(values[7]) * 60 + parseInt(values[8]))
+      return new Time<Integer>(
+        hours,
+        minutes,
+        seconds,
+        nanoseconds,
+        int((values[5] === '+' ? 1 : -1) * (
+          parseTemporalInt(values[6], "timezone offset hours").toInt() * 3600
+          + parseTemporalInt(values[7], "timezone offset minutes").toInt() * 60
+          + parseTemporalInt(values[8], "timezone offset seconds").toInt()
+        ))
       )
     }
     throw newError('Time could not be parsed from string')
@@ -651,17 +665,18 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {LocalDateTime<NumberOrInteger>}
    */
-  static fromString (str: string): LocalDateTime<NumberOrInteger> {
-    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+  static fromString (str: string): LocalDateTime<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)[T|t](\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?$/)
     if (values !== null) {
+      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       return new LocalDateTime(
-        parseInt(values[1]),
-        parseInt(values[2]),
-        parseInt(values[3]),
-        parseInt(values[4]),
-        parseInt(values[5]),
-        parseInt(values[6]),
-        Math.round(parseFloat('0' + values[7]) * 10 ** 9)
+        parseTemporalInt(values[1], "years"),
+        parseTemporalInt(values[2], "months"),
+        parseTemporalInt(values[3], "days"),
+        hours,
+        minutes,
+        seconds,
+        nanoseconds
       )
     }
     throw newError('LocalDateTime could not be parsed from string')
@@ -848,44 +863,45 @@ export class DateTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {DateTime<NumberOrInteger>}
    */
-  static fromString (str: string): DateTime<NumberOrInteger> {
-    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)?(\[)?([^\]]*)?(\])?/)
+  static fromString (str: string): DateTime<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)[T|t](\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?(Z|\+|-)?(\d{0,2}):?(\d{0,2}):?(\d{0,2})?((\[)([^\]]*)(\]))?$/)
     if (values !== null) {
+      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       if (values[8] === 'Z') {
         return new DateTime(
-          parseInt(values[1]),
-          parseInt(values[2]),
-          parseInt(values[3]),
-          parseInt(values[4]),
-          parseInt(values[5]),
-          parseInt(values[6]),
-          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
-          0
+          parseTemporalInt(values[1], "years"),
+          parseTemporalInt(values[2], "months"),
+          parseTemporalInt(values[3], "days"),
+          hours,
+          minutes,
+          seconds,
+          nanoseconds,
+          int(0)
         )
       }
       if (values[8] === '+' || values[8] === '-') {
-        return new DateTime(
-          parseInt(values[1]),
-          parseInt(values[2]),
-          parseInt(values[3]),
-          parseInt(values[4]),
-          parseInt(values[5]),
-          parseInt(values[6]),
-          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
-          (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))
+        return new DateTime<Integer>(
+          parseTemporalInt(values[1], "years"),
+          parseTemporalInt(values[2], "months"),
+          parseTemporalInt(values[3], "days"),
+          hours,
+          minutes,
+          seconds,
+          nanoseconds,
+          int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
         )
       }
-      if (values[13] !== undefined) {
+      if (values[14] !== undefined) {
         return new DateTime(
-          parseInt(values[1]),
-          parseInt(values[2]),
-          parseInt(values[3]),
-          parseInt(values[4]),
-          parseInt(values[5]),
-          parseInt(values[6]),
-          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+          parseTemporalInt(values[1], "years"),
+          parseTemporalInt(values[2], "months"),
+          parseTemporalInt(values[3], "days"),
+          hours,
+          minutes,
+          seconds,
+          nanoseconds,
           undefined,
-          values[13]
+          values[14]
         )
       }
     }
@@ -1005,20 +1021,57 @@ function verifyStandardDateAndNanos (
   }
 }
 
-function parseDurationFloat (str: string, field: string): number {
+function parseTemporalFloat (str: string, field: string, maxLength?: number): number {
   if (str === undefined || str.length === 0) {
     return 0
   } else {
     const value: number = parseFloat(str)
     if (isNaN(value)) {
-      throw newError(`Failed to parse duration field ${field}. Got string: ${str}.`)
+      throw newError(`Failed to parse temporal field ${field}. Got string: ${str}.`)
     }
     return value
   }
 }
 
+function parseTemporalInt (str: string, field: string, maxLength?: number): Integer {
+  if(str === undefined || str.length === 0 || str === "undefined") {
+    return int(0)
+  }
+  else if (maxLength != null && str.length > maxLength) {
+    throw newError(`Failed to parse temporal field ${field}. Got string: ${str} which is longer than max length: ${maxLength}.`)
+  }
+  const result = int(str)
+  return result
+}
+
+function handleTimeDecimals (hourString: string, minuteString: string, secondString: string, decimalString: string): [Integer, Integer, Integer, Integer] {
+  let hours
+  let minutes
+  let seconds
+  let nanoseconds
+  if (minuteString === undefined || secondString === "") {
+    hours = parseTemporalInt(hourString, "hours")
+    minutes = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) : 0)
+    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600)%60 : 0)
+    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600 * (10 ** 9))%10**9 : 0)
+  }
+  else if (secondString === undefined || secondString === "") {
+    hours = parseTemporalInt(hourString, "hours")
+    minutes = parseTemporalInt(minuteString, "minutes")
+    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60)%60 : 0)
+    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60 * (10 ** 9))%10**9 : 0)
+  }
+  else {
+    hours = parseTemporalInt(hourString, "hours")
+    minutes = parseTemporalInt(minuteString, "minutes")
+    seconds = parseTemporalInt(secondString, "seconds")
+    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 10 ** 9) : 0)
+  }
+  return [hours, minutes, seconds, nanoseconds]
+}
+
 function parseDurationNanos (str: string): number {
-  return Math.round((parseDurationFloat(str, 'Seconds') - ~~parseInt(str)) * 10 ** 9)
+  return Math.round(parseTemporalFloat(str, 'nanoseconds') * 10 ** 9)
 }
 
 function checkDurationFieldIsInt (value: number, field: string): void {

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -894,7 +894,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     const values = String(str.replace(/,/g, '.')).match(
       new RegExp(
         /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?/.source + // DateTime
-        /([Z|z]|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?)?(?:\[([^\]]*)\])?$/.source // Timezone
+        /([Z|z]|\+|-)?(?:(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?)?(?:\[([^\]]*)\])?$/.source // Timezone
       )
     )
     if (values === null) {

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -104,18 +104,18 @@ export class Duration<T extends NumberOrInteger = Integer> {
   static fromString (str: string): Duration<Integer> {
     const matches = String(str.replace(/,/g, '.')).match(/^([-|+]?)[P|p](?:(-?[\d]*\.?[\d]*)[Y|y])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-?[\d]*\.?[\d]*)[W|w])?(?:(-?[\d]*\.?[\d]*)[D|d])?([T|t](?:(-?[\d]*\.?[\d]*)[H|h])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-)?([\d]*)(\.[\d]*)?[S|s])?)?$/)
     if (matches !== null) {
-      if(
-        matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null && 
+      if (
+        matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null &&
         matches[7] == null && matches[8] == null && matches[10] == null && matches[11] == null
       ) {
         throw newError(`Duration could not be parsed from string: ${str}`)
       }
-      const negativeDuration = matches[1] === "-" ? -1 : 1
+      const negativeDuration = matches[1] === '-' ? -1 : 1
       const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
       const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
       const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
-      const seconds = parseTemporalInt((matches[9] ?? "") + (matches[10] ?? "0"), "seconds")
-      const nanos = negativeDuration * parseDurationNanos((matches[9] ?? "") + "0" + (matches[11] ?? ""))
+      const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'), 'seconds')
+      const nanos = negativeDuration * parseDurationNanos((matches[9] ?? '') + '0' + (matches[11] ?? ''))
       checkDurationFieldIsInt(months, 'Months')
       checkDurationFieldIsInt(days, 'Days')
       checkDurationFieldIsInt(hoursAndMinutes, 'Seconds')
@@ -389,9 +389,9 @@ export class Time<T extends NumberOrInteger = Integer> {
         seconds,
         nanoseconds,
         int((values[5] === '+' ? 1 : -1) * (
-          parseTemporalInt(values[6], "timezone offset hours").toInt() * 3600
-          + parseTemporalInt(values[7], "timezone offset minutes").toInt() * 60
-          + parseTemporalInt(values[8], "timezone offset seconds").toInt()
+          parseTemporalInt(values[6], 'timezone offset hours').toInt() * 3600 +
+          parseTemporalInt(values[7], 'timezone offset minutes').toInt() * 60 +
+          parseTemporalInt(values[8], 'timezone offset seconds').toInt()
         ))
       )
     }
@@ -670,9 +670,9 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       return new LocalDateTime(
-        parseTemporalInt(values[1], "years"),
-        parseTemporalInt(values[2], "months"),
-        parseTemporalInt(values[3], "days"),
+        parseTemporalInt(values[1], 'years'),
+        parseTemporalInt(values[2], 'months'),
+        parseTemporalInt(values[3], 'days'),
         hours,
         minutes,
         seconds,
@@ -869,9 +869,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       if (values[8] === 'Z') {
         return new DateTime(
-          parseTemporalInt(values[1], "years"),
-          parseTemporalInt(values[2], "months"),
-          parseTemporalInt(values[3], "days"),
+          parseTemporalInt(values[1], 'years'),
+          parseTemporalInt(values[2], 'months'),
+          parseTemporalInt(values[3], 'days'),
           hours,
           minutes,
           seconds,
@@ -881,9 +881,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       }
       if (values[8] === '+' || values[8] === '-') {
         return new DateTime<Integer>(
-          parseTemporalInt(values[1], "years"),
-          parseTemporalInt(values[2], "months"),
-          parseTemporalInt(values[3], "days"),
+          parseTemporalInt(values[1], 'years'),
+          parseTemporalInt(values[2], 'months'),
+          parseTemporalInt(values[3], 'days'),
           hours,
           minutes,
           seconds,
@@ -893,9 +893,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       }
       if (values[14] !== undefined) {
         return new DateTime(
-          parseTemporalInt(values[1], "years"),
-          parseTemporalInt(values[2], "months"),
-          parseTemporalInt(values[3], "days"),
+          parseTemporalInt(values[1], 'years'),
+          parseTemporalInt(values[2], 'months'),
+          parseTemporalInt(values[3], 'days'),
           hours,
           minutes,
           seconds,
@@ -1034,10 +1034,9 @@ function parseTemporalFloat (str: string, field: string, maxLength?: number): nu
 }
 
 function parseTemporalInt (str: string, field: string, maxLength?: number): Integer {
-  if(str === undefined || str.length === 0 || str === "undefined") {
+  if (str === undefined || str.length === 0 || str === 'undefined') {
     return int(0)
-  }
-  else if (maxLength != null && str.length > maxLength) {
+  } else if (maxLength != null && str.length > maxLength) {
     throw newError(`Failed to parse temporal field ${field}. Got string: ${str} which is longer than max length: ${maxLength}.`)
   }
   const result = int(str)
@@ -1049,22 +1048,20 @@ function handleTimeDecimals (hourString: string, minuteString: string, secondStr
   let minutes
   let seconds
   let nanoseconds
-  if (minuteString === undefined || secondString === "") {
-    hours = parseTemporalInt(hourString, "hours")
+  if (minuteString === undefined || secondString === '') {
+    hours = parseTemporalInt(hourString, 'hours')
     minutes = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) : 0)
-    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600)%60 : 0)
-    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600 * (10 ** 9))%10**9 : 0)
-  }
-  else if (secondString === undefined || secondString === "") {
-    hours = parseTemporalInt(hourString, "hours")
-    minutes = parseTemporalInt(minuteString, "minutes")
-    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60)%60 : 0)
-    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60 * (10 ** 9))%10**9 : 0)
-  }
-  else {
-    hours = parseTemporalInt(hourString, "hours")
-    minutes = parseTemporalInt(minuteString, "minutes")
-    seconds = parseTemporalInt(secondString, "seconds")
+    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600) % 60 : 0)
+    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600 * (10 ** 9)) % 10 ** 9 : 0)
+  } else if (secondString === undefined || secondString === '') {
+    hours = parseTemporalInt(hourString, 'hours')
+    minutes = parseTemporalInt(minuteString, 'minutes')
+    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) % 60 : 0)
+    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60 * (10 ** 9)) % 10 ** 9 : 0)
+  } else {
+    hours = parseTemporalInt(hourString, 'hours')
+    minutes = parseTemporalInt(minuteString, 'minutes')
+    seconds = parseTemporalInt(secondString, 'seconds')
     nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 10 ** 9) : 0)
   }
   return [hours, minutes, seconds, nanoseconds]

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -526,7 +526,7 @@ export class Date<T extends NumberOrInteger = Integer> {
     return util.dateToIsoString(this.year, this.month, this.day)
   }
 
-    /**
+  /**
    * Creates a {@link Date} from an ISO 8601 string
    *
    * @param {string} str The string to convert
@@ -541,7 +541,7 @@ export class Date<T extends NumberOrInteger = Integer> {
         parseTemporalInt(values[3], 'days')
       )
     }
-    throw newError(`Date could not be parsed from string. Expects date in format 'YYYY-MM-DD'`)
+    throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\'')
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -849,7 +849,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
    * @returns {DateTime<NumberOrInteger>}
    */
   static fromString (str: string): DateTime<NumberOrInteger> {
-    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)?(\[)?([^\]]*)?(\])?/)
     if (values !== null) {
       if (values[8] === 'Z') {
         return new DateTime(
@@ -863,16 +863,31 @@ export class DateTime<T extends NumberOrInteger = Integer> {
           0
         )
       }
-      return new DateTime(
-        parseInt(values[1]),
-        parseInt(values[2]),
-        parseInt(values[3]),
-        parseInt(values[4]),
-        parseInt(values[5]),
-        parseInt(values[6]),
-        Math.round(parseFloat('0' + values[7]) * 10 ** 9),
-        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))
-      )
+      if (values[8] === '+' || values[8] === '-') {
+        return new DateTime(
+          parseInt(values[1]),
+          parseInt(values[2]),
+          parseInt(values[3]),
+          parseInt(values[4]),
+          parseInt(values[5]),
+          parseInt(values[6]),
+          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+          (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))
+        )
+      }
+      if (values[13] !== undefined) {
+        return new DateTime(
+          parseInt(values[1]),
+          parseInt(values[2]),
+          parseInt(values[3]),
+          parseInt(values[4]),
+          parseInt(values[5]),
+          parseInt(values[6]),
+          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+          undefined,
+          values[13]
+        )
+      }
     }
     throw newError('DateTime could not be parsed from string')
   }
@@ -1008,6 +1023,6 @@ function parseDurationNanos (str: string): number {
 
 function checkDurationFieldIsInt (value: number, field: string): void {
   if (!Number.isInteger(value)) {
-    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds.`)
+    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can only send durations which can be simplified to integer values of months, days, seconds and nanoseconds.`)
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -94,6 +94,12 @@ export class Duration<T extends NumberOrInteger = Integer> {
     Object.freeze(this)
   }
 
+  /**
+   * Creates a {@link Duration} from an ISO 8601 string
+   * 
+   * @param {string} str The string to convert
+   * @returns {Duration<NumberOrInteger>}
+   */
   static fromString (str: string): Duration<NumberOrInteger> {
     const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
     if (matches !== null) {
@@ -218,6 +224,12 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
     )
   }
 
+  /**
+   * Creates a {@link LocalTime} from an ISO 8601 string
+   * 
+   * @param {string} str The string to convert
+   * @returns {LocalTime<NumberOrInteger>}
+   */
   static fromString (str: string): LocalTime<NumberOrInteger> {
     const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
     if (values !== null) {
@@ -340,6 +352,12 @@ export class Time<T extends NumberOrInteger = Integer> {
     )
   }
 
+  /**
+   * Creates a {@link Time} from an ISO 8601 string.
+   * 
+   * @param {string} str The string to convert
+   * @returns {Time<NumberOrInteger>}
+   */
   static fromString (str: string): Time<NumberOrInteger> {
     const values = String(str).match(/(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
     if (values !== null) {
@@ -624,6 +642,12 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
     )
   }
 
+  /**
+   * Creates a {@link LocalDateTime} from an ISO 8601 string
+   * 
+   * @param {string} str The string to convert
+   * @returns {LocalDateTime<NumberOrInteger>}
+   */
   static fromString (str: string): LocalDateTime<NumberOrInteger> {
     const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
     if (values !== null) {
@@ -815,6 +839,12 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     return localDateTimeStr + timeOffset + timeZoneStr
   }
 
+  /**
+   * Creates a {@link DateTime} from an ISO 8601 string
+   * 
+   * @param {string} str The string to convert
+   * @returns {DateTime<NumberOrInteger>}
+   */
   static fromString (str: string): DateTime<NumberOrInteger> {
     const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
     if (values !== null) {

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -868,7 +868,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         parseInt(values[5]),
         parseInt(values[6]),
         Math.round(parseFloat('0' + values[7]) * 10 ** 9),
-        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt("0" + values[11] ))
+        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))
       )
     }
     throw newError('DateTime could not be parsed from string')

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -101,7 +101,7 @@ export class Duration<T extends NumberOrInteger = Integer> {
    * @returns {Duration<NumberOrInteger>}
    */
   static fromString (str: string): Duration<NumberOrInteger> {
-    const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
+    const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T?(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
     if (matches !== null) {
       const dur = new Duration(
         ~~parseInt(matches[1]) * 12 + ~~parseInt(matches[2]),
@@ -661,7 +661,7 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
         Math.round(parseFloat('0' + values[7]) * 10 ** 9)
       )
     }
-    throw newError('Time could not be parsed from string')
+    throw newError('LocalDateTime could not be parsed from string')
   }
 }
 
@@ -867,11 +867,11 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         parseInt(values[4]),
         parseInt(values[5]),
         parseInt(values[6]),
-        Math.round(parseFloat('0.' + values[7]) * 10 ** 9),
-        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt(values[11]))
+        Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt("0" + values[11] ))
       )
     }
-    throw newError('Time could not be parsed from string')
+    throw newError('DateTime could not be parsed from string')
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -94,18 +94,18 @@ export class Duration<T extends NumberOrInteger = Integer> {
     Object.freeze(this)
   }
 
-  static fromString(str: string): Duration<NumberOrInteger> {
+  static fromString (str: string): Duration<NumberOrInteger> {
     const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
-    if(matches !== null) {
+    if (matches !== null) {
       const dur = new Duration(
         ~~parseInt(matches[1]) * 12 + ~~parseInt(matches[2]),
         ~~parseInt(matches[3]) * 7 + ~~parseInt(matches[4]),
         ~~parseInt(matches[5]) * 3600 + ~~parseInt(matches[6]) * 60 + ~~parseInt(matches[7]),
-        Math.round((parseFloat(matches[7]) - parseInt(matches[7])) * 10**9)
+        Math.round((parseFloat(matches[7]) - parseInt(matches[7])) * 10 ** 9)
       )
       return dur
     }
-    throw newError("Duration could not be parsed from string")
+    throw newError('Duration could not be parsed from string')
   }
 
   /**
@@ -218,19 +218,19 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
     )
   }
 
-  static fromString(str: string): LocalTime<NumberOrInteger> {
+  static fromString (str: string): LocalTime<NumberOrInteger> {
     console.log(str)
     const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
     console.log(values)
-    if(values !== null) {
+    if (values !== null) {
       return new LocalTime(
         parseInt(values[0]),
         parseInt(values[1]),
         parseInt(values[2]),
-        Math.round(parseFloat("0." + values[3]) * 10**9)
+        Math.round(parseFloat('0.' + values[3]) * 10 ** 9)
       )
     }
-    throw newError("LocalTime could not be parsed from string")
+    throw newError('LocalTime could not be parsed from string')
   }
 }
 
@@ -342,21 +342,21 @@ export class Time<T extends NumberOrInteger = Integer> {
     )
   }
 
-  static fromString(str: string): Time<NumberOrInteger> {
+  static fromString (str: string): Time<NumberOrInteger> {
     const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)(Z|\+|-)?(\d*)/)
-    if(values !== null) {
-      if(values[4] === "Z") {
-        return new Time(parseInt(values[0]), parseInt(values[1]), parseInt(values[2]), parseInt(values[3]) * 10**9, 0)
+    if (values !== null) {
+      if (values[4] === 'Z') {
+        return new Time(parseInt(values[0]), parseInt(values[1]), parseInt(values[2]), parseInt(values[3]) * 10 ** 9, 0)
       }
       return new Time(
         parseInt(values[0]),
         parseInt(values[1]),
         parseInt(values[2]),
-        Math.round(parseFloat("0." + values[3]) * 10**9),
-        (values[4] === "+" ? 1 : -1) * parseInt(values[5])
+        Math.round(parseFloat('0.' + values[3]) * 10 ** 9),
+        (values[4] === '+' ? 1 : -1) * parseInt(values[5])
       )
     }
-    throw newError("Time could not be parsed from string")
+    throw newError('Time could not be parsed from string')
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -96,20 +96,23 @@ export class Duration<T extends NumberOrInteger = Integer> {
 
   /**
    * Creates a {@link Duration} from an ISO 8601 string
+   * NOTE: Bolt transmits durations as 4 integers: Months, Days, Seconds and Nanoseconds. Parsing strings like P1.5M4.3D will throw an error. P0.5Y can be sent as it can be simplified as 6 months.
    *
    * @param {string} str The string to convert
    * @returns {Duration<NumberOrInteger>}
    */
   static fromString (str: string): Duration<NumberOrInteger> {
-    const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T?(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
+    const matches = String(str).match(/P(?:([-.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-.,\d]+)W)?(?:([-.,\d]+)D)?T?(?:([-.,\d]+)H)?(?:([-.,\d]+)M)?(?:([-.,\d]+)S)?/)
     if (matches !== null) {
-      const dur = new Duration(
-        ~~parseInt(matches[1]) * 12 + ~~parseInt(matches[2]),
-        ~~parseInt(matches[3]) * 7 + ~~parseInt(matches[4]),
-        ~~parseInt(matches[5]) * 3600 + ~~parseInt(matches[6]) * 60 + ~~parseInt(matches[7]),
-        Math.round((parseFloat(matches[7]) - parseInt(matches[7])) * 10 ** 9)
-      )
-      return dur
+        let months = parseDurationFloat(matches[1], "Years") * 12 + parseDurationFloat(matches[2], "Months")
+        let days = parseDurationFloat(matches[3], "Weeks") * 7 + parseDurationFloat(matches[4], "Days")
+        let seconds = parseDurationFloat(matches[5], "Hours") * 3600 + parseDurationFloat(matches[6], "Minutes") * 60 + ~~parseInt(matches[7])
+        let nanos = parseDurationNanos(matches[7])
+      checkDurationFieldIsInt(months, "Months")
+      checkDurationFieldIsInt(days, "Days")
+      checkDurationFieldIsInt(seconds, "Seconds")
+      checkDurationFieldIsInt(nanos, "Nanoseconds")
+      return new Duration(months, days, seconds, nanos)
     }
     throw newError('Duration could not be parsed from string')
   }
@@ -984,5 +987,28 @@ function verifyStandardDateAndNanos (
   assertValidDate(standardDate, 'Standard date')
   if (nanosecond !== null && nanosecond !== undefined) {
     assertNumberOrInteger(nanosecond, 'Nanosecond')
+  }
+}
+
+function parseDurationFloat(str: string, field: string): number {
+  if (str === undefined || str.length === 0) {
+    return 0
+  }
+  else {
+    let value: number =  parseFloat(str)
+    if(isNaN(value) === true) {
+      throw newError(`Failed to parse duration field ${field}. Got string: ${str}.`)
+    }
+    return value
+  }
+}
+
+function parseDurationNanos(str: string): number {
+  return Math.round((parseDurationFloat(str, "Seconds") - ~~parseInt(str)) * 10 ** 9)
+}
+
+function checkDurationFieldIsInt(value: number, field: string): void {
+  if(!Number.isInteger(value)) {
+    throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds. `)
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -94,6 +94,20 @@ export class Duration<T extends NumberOrInteger = Integer> {
     Object.freeze(this)
   }
 
+  static fromString(str: string): Duration<NumberOrInteger> {
+    const matches = String(str).match(/P(?:([-?.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)W)?(?:([-?.,\d]+)D)?T(?:([-?.,\d]+)H)?(?:([-?.,\d]+)M)?(?:([-?.,\d]+)S)?/)
+    if(matches !== null) {
+      const dur = new Duration(
+        ~~parseInt(matches[1]) * 12 + ~~parseInt(matches[2]),
+        ~~parseInt(matches[3]) * 7 + ~~parseInt(matches[4]),
+        ~~parseInt(matches[5]) * 3600 + ~~parseInt(matches[6]) * 60 + ~~parseInt(matches[7]),
+        Math.round((parseFloat(matches[7]) - parseInt(matches[7])) * 10**9)
+      )
+      return dur
+    }
+    throw newError("Duration could not be parsed from string")
+  }
+
   /**
    * @ignore
    */
@@ -203,6 +217,21 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
       this.nanosecond
     )
   }
+
+  static fromString(str: string): LocalTime<NumberOrInteger> {
+    console.log(str)
+    const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
+    console.log(values)
+    if(values !== null) {
+      return new LocalTime(
+        parseInt(values[0]),
+        parseInt(values[1]),
+        parseInt(values[2]),
+        Math.round(parseFloat("0." + values[3]) * 10**9)
+      )
+    }
+    throw newError("LocalTime could not be parsed from string")
+  }
 }
 
 Object.defineProperty(
@@ -311,6 +340,23 @@ export class Time<T extends NumberOrInteger = Integer> {
         this.nanosecond
       ) + util.timeZoneOffsetToIsoString(this.timeZoneOffsetSeconds)
     )
+  }
+
+  static fromString(str: string): Time<NumberOrInteger> {
+    const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)(Z|\+|-)?(\d*)/)
+    if(values !== null) {
+      if(values[4] === "Z") {
+        return new Time(parseInt(values[0]), parseInt(values[1]), parseInt(values[2]), parseInt(values[3]) * 10**9, 0)
+      }
+      return new Time(
+        parseInt(values[0]),
+        parseInt(values[1]),
+        parseInt(values[2]),
+        Math.round(parseFloat("0." + values[3]) * 10**9),
+        (values[4] === "+" ? 1 : -1) * parseInt(values[5])
+      )
+    }
+    throw newError("Time could not be parsed from string")
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -894,7 +894,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     const values = String(str.replace(/,/g, '.')).match(
       new RegExp(
         /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?/.source + // DateTime
-        /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?((\[)([^\]]*)(\]))?$/.source // Timezone
+        /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?(?:\[([^\]]*)\])?$/.source // Timezone
       )
     )
     if (values === null) {
@@ -925,7 +925,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
       )
     }
-    if (values[14] !== undefined) {
+    if (values[12] !== undefined) {
       return new DateTime(
         parseTemporalInt(values[1]), // years
         parseTemporalInt(values[2]), // months
@@ -935,7 +935,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         seconds,
         nanoseconds,
         undefined,
-        values[14]
+        values[12]
       )
     }
     throw newError('DateTime could not be parsed from string, provided string needs either timezoneId or offset')
@@ -1070,8 +1070,7 @@ function parseTemporalInt (str: string | undefined): Integer {
   if (str === undefined || str.length === 0) {
     return int(0)
   }
-  const result = int(str)
-  return result
+  return int(str)
 }
 
 function handleTimeDecimals (hourString?: string, minuteString?: string, secondString?: string, decimalString?: string): [Integer, Integer, Integer, Integer] {

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -398,8 +398,8 @@ export class Time<T extends NumberOrInteger = Integer> {
         seconds,
         nanoseconds,
         int((values[5] === '+' ? 1 : -1) * (
-          parseTemporalInt(values[6]).toInt() * 3600 + //timezone offset hours
-          parseTemporalInt(values[7]).toInt() * 60 + //timezone offset minutes
+          parseTemporalInt(values[6]).toInt() * 3600 + // timezone offset hours
+          parseTemporalInt(values[7]).toInt() * 60 + // timezone offset minutes
           parseTemporalInt(values[8]).toInt() // timezone offset seconds
         ))
       )

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -375,7 +375,7 @@ export class Time<T extends NumberOrInteger = Integer> {
    *
    * @param {string} str The string to convert
    * @returns {Time}
-  */
+   */
   static fromString (str: string): Time {
     const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
     if (values === null) {
@@ -894,7 +894,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     const values = String(str.replace(/,/g, '.')).match(
       new RegExp(
         /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?/.source + // DateTime
-        /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?(?:\[([^\]]*)\])?$/.source // Timezone
+        /([Z|z]|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?)?(?:\[([^\]]*)\])?$/.source // Timezone
       )
     )
     if (values === null) {
@@ -910,10 +910,14 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         minutes,
         seconds,
         nanoseconds,
-        int(0)
+        int(0),
+        values[12]
       )
     }
-    if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
+    if (values[8] === '+' || values[8] === '-') {
+      if(values[9] == null) {
+        throw newError(`DateTime could not be parsed from string, could not parse an offset after ${values[8]} sign.`)
+      }
       return new DateTime(
         parseTemporalInt(values[1]), // years
         parseTemporalInt(values[2]), // months
@@ -922,7 +926,8 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         minutes,
         seconds,
         nanoseconds,
-        int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
+        int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11]))),
+        values[12]
       )
     }
     if (values[12] !== undefined) {

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -219,9 +219,7 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
   }
 
   static fromString (str: string): LocalTime<NumberOrInteger> {
-    console.log(str)
     const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)/)
-    console.log(values)
     if (values !== null) {
       return new LocalTime(
         parseInt(values[0]),
@@ -343,17 +341,23 @@ export class Time<T extends NumberOrInteger = Integer> {
   }
 
   static fromString (str: string): Time<NumberOrInteger> {
-    const values = String(str).match(/(\d+):(\d+):(\d+).(\d+)(Z|\+|-)?(\d*)/)
+    const values = String(str).match(/(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
     if (values !== null) {
-      if (values[4] === 'Z') {
-        return new Time(parseInt(values[0]), parseInt(values[1]), parseInt(values[2]), parseInt(values[3]) * 10 ** 9, 0)
+      if (values[5] === 'Z') {
+        return new Time(
+          parseInt(values[1]),
+          parseInt(values[2]),
+          parseInt(values[3]),
+          values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
+          0
+        )
       }
       return new Time(
-        parseInt(values[0]),
         parseInt(values[1]),
         parseInt(values[2]),
-        Math.round(parseFloat('0.' + values[3]) * 10 ** 9),
-        (values[4] === '+' ? 1 : -1) * parseInt(values[5])
+        parseInt(values[3]),
+        values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
+        (values[5] === '+' ? 1 : -1) * ( parseInt(values[6]) * 3600 + parseInt(values[7]) * 60 + parseInt(values[8])) 
       )
     }
     throw newError('Time could not be parsed from string')
@@ -619,6 +623,22 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
       this.nanosecond
     )
   }
+
+  static fromString (str: string): LocalDateTime<NumberOrInteger> {
+    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+    if (values !== null) {
+      return new LocalDateTime(
+        parseInt(values[1]),
+        parseInt(values[2]),
+        parseInt(values[3]),
+        parseInt(values[4]),
+        parseInt(values[5]),
+        parseInt(values[6]),
+        Math.round(parseFloat('0' + values[7]) * 10 ** 9)
+      )
+    }
+    throw newError('Time could not be parsed from string')
+  }
 }
 
 Object.defineProperty(
@@ -793,6 +813,35 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       : ''
 
     return localDateTimeStr + timeOffset + timeZoneStr
+  }
+
+  static fromString (str: string): DateTime<NumberOrInteger> {
+    const values = String(str).match(/(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)(\.\d+)?(Z|\+|-)?(\d*):?(\d*):?(\d*)/)
+    if (values !== null) {
+      if (values[8] === 'Z') {
+        return new DateTime(
+          parseInt(values[1]),
+          parseInt(values[2]),
+          parseInt(values[3]),
+          parseInt(values[4]),
+          parseInt(values[5]),
+          parseInt(values[6]), 
+          Math.round(parseFloat('0' + values[7]) * 10 ** 9),
+          0
+        )
+      }
+      return new DateTime(
+        parseInt(values[1]),
+        parseInt(values[2]),
+        parseInt(values[3]),
+        parseInt(values[4]),
+        parseInt(values[5]),
+        parseInt(values[6]),
+        Math.round(parseFloat('0.' + values[7]) * 10 ** 9),
+        (values[8] === '+' ? 1 : -1) * ( parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt(values[11])) 
+      )
+    }
+    throw newError('Time could not be parsed from string')
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -525,6 +525,24 @@ export class Date<T extends NumberOrInteger = Integer> {
   toString (): string {
     return util.dateToIsoString(this.year, this.month, this.day)
   }
+
+    /**
+   * Creates a {@link Date} from an ISO 8601 string
+   *
+   * @param {string} str The string to convert
+   * @returns {Date<NumberOrInteger>}
+   */
+  static fromString (str: string): Date<Integer> {
+    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)$/)
+    if (values !== null) {
+      return new Date(
+        parseTemporalInt(values[1], 'years'),
+        parseTemporalInt(values[2], 'months'),
+        parseTemporalInt(values[3], 'days')
+      )
+    }
+    throw newError(`Date could not be parsed from string. Expects date in format 'YYYY-MM-DD'`)
+  }
 }
 
 Object.defineProperty(

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -915,7 +915,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
       )
     }
     if (values[8] === '+' || values[8] === '-') {
-      if(values[9] == null) {
+      if (values[9] == null) {
         throw newError(`DateTime could not be parsed from string, could not parse an offset after ${values[8]} sign.`)
       }
       return new DateTime(

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -902,6 +902,9 @@ export class DateTime<T extends NumberOrInteger = Integer> {
     }
     const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
     if (values[8] === 'Z') {
+      if (values[9] != null) {
+        throw newError('DateTime could not be parsed from string, can not parse string with offset after Z')
+      }
       return new DateTime(
         parseTemporalInt(values[1]), // years
         parseTemporalInt(values[2]), // months

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -109,26 +109,26 @@ export class Duration<T extends NumberOrInteger = Integer> {
       /^([-|+]?)[P|p](?:(-?\d*\.?\d*)[Y|y])?(?:(-?\d*\.?\d*)[M|m])?(?:(-?\d*\.?\d*)[W|w])?(?:(-?\d*\.?\d*)[D|d])?/.source + // Date portion
       /([T|t](?:(-?\d*\.?\d*)[H|h])?(?:(-?\d*\.?\d*)[M|m])?(?:(-)?(\d*)(\.\d*)?[S|s])?)?$/.source // Time portion
     ))
-    if (matches !== null) {
-      if (
-        matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null &&
-        matches[7] == null && matches[8] == null && matches[10] == null && matches[11] == null
-      ) {
-        throw newError(`Duration could not be parsed from string: ${str}`)
-      }
-      const negativeDuration = matches[1] === '-' ? -1 : 1
-      const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
-      const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
-      const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
-      const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'))
-      const nanos = negativeDuration * parseDurationNanos((matches[9] ?? '') + '0' + (matches[11] ?? ''))
-      checkDurationFieldIsInt(months, 'Months')
-      checkDurationFieldIsInt(days, 'Days')
-      checkDurationFieldIsInt(hoursAndMinutes, 'Seconds')
-      checkDurationFieldIsInt(nanos, 'Nanoseconds')
-      return new Duration(int(months), int(days), int(BigInt(negativeDuration) * (BigInt(hoursAndMinutes) + seconds.toBigInt())), int(nanos))
+    if (matches === null) {
+      throw newError(`Duration could not be parsed from string: ${str}`)
     }
-    throw newError(`Duration could not be parsed from string: ${str}`)
+    if (
+      matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null &&
+      matches[7] == null && matches[8] == null && matches[10] == null && matches[11] == null
+    ) {
+      throw newError(`Duration could not be parsed from string: ${str}`)
+    }
+    const negativeDuration = matches[1] === '-' ? -1 : 1
+    const months = negativeDuration * parseTemporalFloat(matches[2], 'Years') * 12 + parseTemporalFloat(matches[3], 'Months')
+    const days = negativeDuration * parseTemporalFloat(matches[4], 'Weeks') * 7 + parseTemporalFloat(matches[5], 'Days')
+    const hoursAndMinutes = (parseTemporalFloat(matches[7], 'Hours') * 3600 + parseTemporalFloat(matches[8], 'Minutes') * 60)
+    const seconds = parseTemporalInt((matches[9] ?? '') + (matches[10] ?? '0'))
+    const nanos = negativeDuration * parseDurationNanos((matches[9] ?? '') + '0' + (matches[11] ?? ''))
+    checkDurationFieldIsInt(months, 'Months')
+    checkDurationFieldIsInt(days, 'Days')
+    checkDurationFieldIsInt(hoursAndMinutes, 'Seconds')
+    checkDurationFieldIsInt(nanos, 'Nanoseconds')
+    return new Duration(int(months), int(days), int(BigInt(negativeDuration) * (BigInt(hoursAndMinutes) + seconds.toBigInt())), int(nanos))
   }
 
   /**
@@ -249,16 +249,16 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
    */
   static fromString (str: string): LocalTime {
     const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?$/)
-    if (values !== null) {
-      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
-      return new LocalTime(
-        hours,
-        minutes,
-        seconds,
-        nanoseconds
-      )
+    if (values === null) {
+      throw newError('LocalTime could not be parsed from string')
     }
-    throw newError('LocalTime could not be parsed from string')
+    const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
+    return new LocalTime(
+      hours,
+      minutes,
+      seconds,
+      nanoseconds
+    )
   }
 }
 
@@ -375,36 +375,36 @@ export class Time<T extends NumberOrInteger = Integer> {
    *
    * @param {string} str The string to convert
    * @returns {Time}
-   */
-  static fromString (str: string): Time {
-    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
-    if (values !== null) {
-      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
-      if (values[5] === 'Z') {
-        return new Time(
-          hours,
-          minutes,
-          seconds,
-          nanoseconds,
-          int(0)
-        )
-      }
-      if (values[6] == null) {
-        throw newError('Error parsing timezone offset.')
-      }
+  */
+ static fromString (str: string): Time {
+   const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
+   if (values === null) {
+      throw newError('Time could not be parsed from string')
+    }
+    const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
+    if (values[5] === 'Z') {
       return new Time(
         hours,
         minutes,
         seconds,
         nanoseconds,
-        int((values[5] === '+' ? 1 : -1) * (
-          parseTemporalInt(values[6]).toInt() * 3600 + // timezone offset hours
-          parseTemporalInt(values[7]).toInt() * 60 + // timezone offset minutes
-          parseTemporalInt(values[8]).toInt() // timezone offset seconds
-        ))
+        int(0)
       )
     }
-    throw newError('Time could not be parsed from string')
+    if (values[6] == null) {
+      throw newError('Error parsing timezone offset.')
+    }
+    return new Time(
+      hours,
+      minutes,
+      seconds,
+      nanoseconds,
+      int((values[5] === '+' ? 1 : -1) * (
+        parseTemporalInt(values[6]).toInt() * 3600 + // timezone offset hours
+        parseTemporalInt(values[7]).toInt() * 60 + // timezone offset minutes
+        parseTemporalInt(values[8]).toInt() // timezone offset seconds
+      ))
+    )
   }
 }
 
@@ -543,14 +543,14 @@ export class Date<T extends NumberOrInteger = Integer> {
    */
   static fromString (str: string): Date {
     const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})$/)
-    if (values !== null) {
-      return new Date(
-        parseTemporalInt(values[1]), // years
-        parseTemporalInt(values[2]), // months
-        parseTemporalInt(values[3]) // days
-      )
+    if (values === null) {
+      throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\' or \'[+|-]YYYYY-MM-DD\'')
     }
-    throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\' or \'[+|-]YYYYY-MM-DD\'')
+    return new Date(
+      parseTemporalInt(values[1]), // years
+      parseTemporalInt(values[2]), // months
+      parseTemporalInt(values[3]) // days
+    )
   }
 }
 
@@ -694,19 +694,19 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
    */
   static fromString (str: string): LocalDateTime {
     const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?$/)
-    if (values !== null) {
-      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
-      return new LocalDateTime(
-        parseTemporalInt(values[1]), // years
-        parseTemporalInt(values[2]), // months
-        parseTemporalInt(values[3]), // days
-        hours,
-        minutes,
-        seconds,
-        nanoseconds
-      )
+    if (values === null) {
+      throw newError('LocalDateTime could not be parsed from string')
     }
-    throw newError('LocalDateTime could not be parsed from string')
+    const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
+    return new LocalDateTime(
+      parseTemporalInt(values[1]), // years
+      parseTemporalInt(values[2]), // months
+      parseTemporalInt(values[3]), // days
+      hours,
+      minutes,
+      seconds,
+      nanoseconds
+    )
   }
 }
 
@@ -897,47 +897,48 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?((\[)([^\]]*)(\]))?$/.source // Timezone
       )
     )
-    if (values !== null) {
-      const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
-      if (values[8] === 'Z') {
-        return new DateTime(
-          parseTemporalInt(values[1]), // years
-          parseTemporalInt(values[2]), // months
-          parseTemporalInt(values[3]), // days
-          hours,
-          minutes,
-          seconds,
-          nanoseconds,
-          int(0)
-        )
-      }
-      if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
-        return new DateTime(
-          parseTemporalInt(values[1]), // years
-          parseTemporalInt(values[2]), // months
-          parseTemporalInt(values[3]), // days
-          hours,
-          minutes,
-          seconds,
-          nanoseconds,
-          int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
-        )
-      }
-      if (values[14] !== undefined) {
-        return new DateTime(
-          parseTemporalInt(values[1]), // years
-          parseTemporalInt(values[2]), // months
-          parseTemporalInt(values[3]), // days
-          hours,
-          minutes,
-          seconds,
-          nanoseconds,
-          undefined,
-          values[14]
-        )
-      }
+    if (values === null) {
+      throw newError('DateTime could not be parsed from string')
     }
-    throw newError('DateTime could not be parsed from string')
+    const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
+    if (values[8] === 'Z') {
+      return new DateTime(
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]), // days
+        hours,
+        minutes,
+        seconds,
+        nanoseconds,
+        int(0)
+      )
+    }
+    if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
+      return new DateTime(
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]), // days
+        hours,
+        minutes,
+        seconds,
+        nanoseconds,
+        int((values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt('0' + values[11])))
+      )
+    }
+    if (values[14] !== undefined) {
+      return new DateTime(
+        parseTemporalInt(values[1]), // years
+        parseTemporalInt(values[2]), // months
+        parseTemporalInt(values[3]), // days
+        hours,
+        minutes,
+        seconds,
+        nanoseconds,
+        undefined,
+        values[14]
+      )
+    }
+    throw newError('DateTime could not be parsed from string, provided string needs either timezoneId or offset')
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -101,8 +101,14 @@ export class Duration<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Duration<NumberOrInteger>}
    */
-  static fromString (str: string): Duration<Integer> {
-    const matches = String(str.replace(/,/g, '.')).match(/^([-|+]?)[P|p](?:(-?[\d]*\.?[\d]*)[Y|y])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-?[\d]*\.?[\d]*)[W|w])?(?:(-?[\d]*\.?[\d]*)[D|d])?([T|t](?:(-?[\d]*\.?[\d]*)[H|h])?(?:(-?[\d]*\.?[\d]*)[M|m])?(?:(-)?([\d]*)(\.[\d]*)?[S|s])?)?$/)
+  static fromString (str: string): Duration {
+    if (str.slice(-1).toUpperCase() === 'T') {
+      throw newError(`Duration string '${str}' ends with 'T', time delimiter must be excluded if Duration contains no time components`)
+    }
+    const matches = String(str.replace(/,/g, '.')).match(new RegExp(
+      /^([-|+]?)[P|p](?:(-?\d*\.?\d*)[Y|y])?(?:(-?\d*\.?\d*)[M|m])?(?:(-?\d*\.?\d*)[W|w])?(?:(-?\d*\.?\d*)[D|d])?/.source + // Date portion
+      /([T|t](?:(-?\d*\.?\d*)[H|h])?(?:(-?\d*\.?\d*)[M|m])?(?:(-)?(\d*)(\.\d*)?[S|s])?)?$/.source // Time portion
+    ))
     if (matches !== null) {
       if (
         matches[2] == null && matches[3] == null && matches[4] == null && matches[5] == null &&
@@ -241,8 +247,8 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {LocalTime<NumberOrInteger>}
    */
-  static fromString (str: string): LocalTime<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^T?(\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?$/)
+  static fromString (str: string): LocalTime {
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       return new LocalTime(
@@ -370,8 +376,8 @@ export class Time<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Time<NumberOrInteger>}
    */
-  static fromString (str: string): Time<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?(Z|\+|-)(\d{0,2}):?(\d{0,2}):?(\d{0,2})$/)
+  static fromString (str: string): Time {
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])
       if (values[5] === 'Z') {
@@ -382,6 +388,9 @@ export class Time<T extends NumberOrInteger = Integer> {
           nanoseconds,
           int(0)
         )
+      }
+      if (values[6] == null) {
+        throw newError('Error parsing timezone offset.')
       }
       return new Time<Integer>(
         hours,
@@ -532,8 +541,8 @@ export class Date<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Date<NumberOrInteger>}
    */
-  static fromString (str: string): Date<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)$/)
+  static fromString (str: string): Date {
+    const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})$/)
     if (values !== null) {
       return new Date(
         parseTemporalInt(values[1], 'years'),
@@ -541,7 +550,7 @@ export class Date<T extends NumberOrInteger = Integer> {
         parseTemporalInt(values[3], 'days')
       )
     }
-    throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\'')
+    throw newError('Date could not be parsed from string. Expects date in format \'YYYY-MM-DD\' or \'[+|-]YYYYY-MM-DD\'')
   }
 }
 
@@ -683,8 +692,8 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {LocalDateTime<NumberOrInteger>}
    */
-  static fromString (str: string): LocalDateTime<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)[T|t](\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?$/)
+  static fromString (str: string): LocalDateTime {
+    const values = String(str.replace(/,/g, '.')).match(/^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/)
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       return new LocalDateTime(
@@ -881,8 +890,13 @@ export class DateTime<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {DateTime<NumberOrInteger>}
    */
-  static fromString (str: string): DateTime<Integer> {
-    const values = String(str.replace(/,/g, '.')).match(/^(\d+)-(\d+)-(\d+)[T|t](\d{2}):?(\d{2})?:?(\d{2})?(\.\d+)?(Z|\+|-)?(\d{0,2}):?(\d{0,2}):?(\d{0,2})?((\[)([^\]]*)(\]))?$/)
+  static fromString (str: string): DateTime {
+    const values = String(str.replace(/,/g, '.')).match(
+      new RegExp(
+        /^([+|-]\d{5,}|\d{4})-(\d{2})-(\d{2})[T|t](\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?/.source + // DateTime
+        /([Z|z]$|\+|-)?(?:(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$)?((\[)([^\]]*)(\]))?$/.source // Timezone
+      )
+    )
     if (values !== null) {
       const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[4], values[5], values[6], values[7])
       if (values[8] === 'Z') {
@@ -897,7 +911,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
           int(0)
         )
       }
-      if (values[8] === '+' || values[8] === '-') {
+      if ((values[8] === '+' || values[8] === '-') && values[9] != null) {
         return new DateTime<Integer>(
           parseTemporalInt(values[1], 'years'),
           parseTemporalInt(values[2], 'months'),
@@ -1039,7 +1053,7 @@ function verifyStandardDateAndNanos (
   }
 }
 
-function parseTemporalFloat (str: string, field: string, maxLength?: number): number {
+function parseTemporalFloat (str: string | undefined, field: string): number {
   if (str === undefined || str.length === 0) {
     return 0
   } else {
@@ -1051,7 +1065,7 @@ function parseTemporalFloat (str: string, field: string, maxLength?: number): nu
   }
 }
 
-function parseTemporalInt (str: string, field: string, maxLength?: number): Integer {
+function parseTemporalInt (str: string | undefined, field: string, maxLength?: number): Integer {
   if (str === undefined || str.length === 0 || str === 'undefined') {
     return int(0)
   } else if (maxLength != null && str.length > maxLength) {
@@ -1061,26 +1075,27 @@ function parseTemporalInt (str: string, field: string, maxLength?: number): Inte
   return result
 }
 
-function handleTimeDecimals (hourString: string, minuteString: string, secondString: string, decimalString: string): [Integer, Integer, Integer, Integer] {
+function handleTimeDecimals (hourString?: string, minuteString?: string, secondString?: string, decimalString?: string): [Integer, Integer, Integer, Integer] {
   let hours
   let minutes
   let seconds
   let nanoseconds
-  if (minuteString === undefined || secondString === '') {
+  const decimalInt = decimalString !== undefined ? parseFloat('0' + decimalString) : 0
+  if (minuteString === undefined || minuteString === '') {
     hours = parseTemporalInt(hourString, 'hours')
-    minutes = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) : 0)
-    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600) % 60 : 0)
-    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 3600 * (10 ** 9)) % 10 ** 9 : 0)
+    minutes = int(decimalInt * 60)
+    seconds = int((decimalInt * 3600) % 60)
+    nanoseconds = int((decimalInt * 3600 * 10 ** 9) % 10 ** 9)
   } else if (secondString === undefined || secondString === '') {
     hours = parseTemporalInt(hourString, 'hours')
     minutes = parseTemporalInt(minuteString, 'minutes')
-    seconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60) % 60 : 0)
-    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 60 * (10 ** 9)) % 10 ** 9 : 0)
+    seconds = int((decimalInt * 60) % 60)
+    nanoseconds = int((decimalInt * 60 * (10 ** 9)) % 10 ** 9)
   } else {
     hours = parseTemporalInt(hourString, 'hours')
     minutes = parseTemporalInt(minuteString, 'minutes')
     seconds = parseTemporalInt(secondString, 'seconds')
-    nanoseconds = int(decimalString !== undefined ? Math.round(parseFloat('0' + decimalString) * 10 ** 9) : 0)
+    nanoseconds = int(decimalInt * 10 ** 9)
   }
   return [hours, minutes, seconds, nanoseconds]
 }

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -104,14 +104,14 @@ export class Duration<T extends NumberOrInteger = Integer> {
   static fromString (str: string): Duration<NumberOrInteger> {
     const matches = String(str).match(/P(?:([-.,\d]+)Y)?(?:([-?.,\d]+)M)?(?:([-.,\d]+)W)?(?:([-.,\d]+)D)?T?(?:([-.,\d]+)H)?(?:([-.,\d]+)M)?(?:([-.,\d]+)S)?/)
     if (matches !== null) {
-        let months = parseDurationFloat(matches[1], "Years") * 12 + parseDurationFloat(matches[2], "Months")
-        let days = parseDurationFloat(matches[3], "Weeks") * 7 + parseDurationFloat(matches[4], "Days")
-        let seconds = parseDurationFloat(matches[5], "Hours") * 3600 + parseDurationFloat(matches[6], "Minutes") * 60 + ~~parseInt(matches[7])
-        let nanos = parseDurationNanos(matches[7])
-      checkDurationFieldIsInt(months, "Months")
-      checkDurationFieldIsInt(days, "Days")
-      checkDurationFieldIsInt(seconds, "Seconds")
-      checkDurationFieldIsInt(nanos, "Nanoseconds")
+      const months = parseDurationFloat(matches[1], 'Years') * 12 + parseDurationFloat(matches[2], 'Months')
+      const days = parseDurationFloat(matches[3], 'Weeks') * 7 + parseDurationFloat(matches[4], 'Days')
+      const seconds = parseDurationFloat(matches[5], 'Hours') * 3600 + parseDurationFloat(matches[6], 'Minutes') * 60 + ~~parseInt(matches[7])
+      const nanos = parseDurationNanos(matches[7])
+      checkDurationFieldIsInt(months, 'Months')
+      checkDurationFieldIsInt(days, 'Days')
+      checkDurationFieldIsInt(seconds, 'Seconds')
+      checkDurationFieldIsInt(nanos, 'Nanoseconds')
       return new Duration(months, days, seconds, nanos)
     }
     throw newError('Duration could not be parsed from string')
@@ -990,25 +990,24 @@ function verifyStandardDateAndNanos (
   }
 }
 
-function parseDurationFloat(str: string, field: string): number {
+function parseDurationFloat (str: string, field: string): number {
   if (str === undefined || str.length === 0) {
     return 0
-  }
-  else {
-    let value: number =  parseFloat(str)
-    if(isNaN(value) === true) {
+  } else {
+    const value: number = parseFloat(str)
+    if (isNaN(value)) {
       throw newError(`Failed to parse duration field ${field}. Got string: ${str}.`)
     }
     return value
   }
 }
 
-function parseDurationNanos(str: string): number {
-  return Math.round((parseDurationFloat(str, "Seconds") - ~~parseInt(str)) * 10 ** 9)
+function parseDurationNanos (str: string): number {
+  return Math.round((parseDurationFloat(str, 'Seconds') - ~~parseInt(str)) * 10 ** 9)
 }
 
-function checkDurationFieldIsInt(value: number, field: string): void {
-  if(!Number.isInteger(value)) {
+function checkDurationFieldIsInt (value: number, field: string): void {
+  if (!Number.isInteger(value)) {
     throw newError(`Parsing Duration field: ${field} resulted in a non-integer value. Bolt protocol can onlue send durations which can be simplified to integer values of months, days, seconds and nanoseconds. `)
   }
 }

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -96,7 +96,7 @@ export class Duration<T extends NumberOrInteger = Integer> {
 
   /**
    * Creates a {@link Duration} from an ISO 8601 string
-   * 
+   *
    * @param {string} str The string to convert
    * @returns {Duration<NumberOrInteger>}
    */
@@ -226,7 +226,7 @@ export class LocalTime<T extends NumberOrInteger = Integer> {
 
   /**
    * Creates a {@link LocalTime} from an ISO 8601 string
-   * 
+   *
    * @param {string} str The string to convert
    * @returns {LocalTime<NumberOrInteger>}
    */
@@ -354,7 +354,7 @@ export class Time<T extends NumberOrInteger = Integer> {
 
   /**
    * Creates a {@link Time} from an ISO 8601 string.
-   * 
+   *
    * @param {string} str The string to convert
    * @returns {Time<NumberOrInteger>}
    */
@@ -644,7 +644,7 @@ export class LocalDateTime<T extends NumberOrInteger = Integer> {
 
   /**
    * Creates a {@link LocalDateTime} from an ISO 8601 string
-   * 
+   *
    * @param {string} str The string to convert
    * @returns {LocalDateTime<NumberOrInteger>}
    */
@@ -841,7 +841,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
 
   /**
    * Creates a {@link DateTime} from an ISO 8601 string
-   * 
+   *
    * @param {string} str The string to convert
    * @returns {DateTime<NumberOrInteger>}
    */

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -357,7 +357,7 @@ export class Time<T extends NumberOrInteger = Integer> {
         parseInt(values[2]),
         parseInt(values[3]),
         values[4] !== undefined ? Math.round(parseFloat('0.' + values[4]) * 10 ** 9) : 0,
-        (values[5] === '+' ? 1 : -1) * ( parseInt(values[6]) * 3600 + parseInt(values[7]) * 60 + parseInt(values[8])) 
+        (values[5] === '+' ? 1 : -1) * (parseInt(values[6]) * 3600 + parseInt(values[7]) * 60 + parseInt(values[8]))
       )
     }
     throw newError('Time could not be parsed from string')
@@ -825,7 +825,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
           parseInt(values[3]),
           parseInt(values[4]),
           parseInt(values[5]),
-          parseInt(values[6]), 
+          parseInt(values[6]),
           Math.round(parseFloat('0' + values[7]) * 10 ** 9),
           0
         )
@@ -838,7 +838,7 @@ export class DateTime<T extends NumberOrInteger = Integer> {
         parseInt(values[5]),
         parseInt(values[6]),
         Math.round(parseFloat('0.' + values[7]) * 10 ** 9),
-        (values[8] === '+' ? 1 : -1) * ( parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt(values[11])) 
+        (values[8] === '+' ? 1 : -1) * (parseInt(values[9]) * 3600 + parseInt(values[10]) * 60 + parseInt(values[11]))
       )
     }
     throw newError('Time could not be parsed from string')

--- a/packages/neo4j-driver-deno/lib/core/temporal-types.ts
+++ b/packages/neo4j-driver-deno/lib/core/temporal-types.ts
@@ -376,9 +376,9 @@ export class Time<T extends NumberOrInteger = Integer> {
    * @param {string} str The string to convert
    * @returns {Time}
   */
- static fromString (str: string): Time {
-   const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
-   if (values === null) {
+  static fromString (str: string): Time {
+    const values = String(str.replace(/,/g, '.')).match(/^[T|t]?(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(\.\d+)?([Z|z]$|\+|-)(\d{2})?(?::?(\d{2}))?(?::?(\d{2}))?$/)
+    if (values === null) {
       throw newError('Time could not be parsed from string')
     }
     const [hours, minutes, seconds, nanoseconds] = handleTimeDecimals(values[1], values[2], values[3], values[4])

--- a/packages/neo4j-driver-deno/lib/core/transaction-managed.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction-managed.ts
@@ -58,6 +58,7 @@ class ManagedTransaction {
    * or with the query and parameters as separate arguments.
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @return {Result} New Result
    */
   run<R extends RecordShape = RecordShape> (query: Query, parameters?: any, parameterRules?: Rules): Result<R> {

--- a/packages/neo4j-driver-deno/lib/core/transaction-managed.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction-managed.ts
@@ -19,8 +19,9 @@ import Result from './result.ts'
 import Transaction from './transaction.ts'
 import { Query } from './types.ts'
 import { RecordShape } from './record.ts'
+import { Rules } from './mapping.highlevel.ts'
 
-type Run<R extends RecordShape = RecordShape> = (query: Query, parameters?: any) => Result<R>
+type Run<R extends RecordShape = RecordShape> = (query: Query, parameters?: any, parameterRules?: Rules) => Result<R>
 
 /**
  * Represents a transaction that is managed by the transaction executor.
@@ -59,8 +60,8 @@ class ManagedTransaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run<R extends RecordShape = RecordShape> (query: Query, parameters?: any): Result<R> {
-    return this._run(query, parameters)
+  run<R extends RecordShape = RecordShape> (query: Query, parameters?: any, parameterRules?: Rules): Result<R> {
+    return this._run(query, parameters, parameterRules)
   }
 }
 

--- a/packages/neo4j-driver-deno/lib/core/transaction.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction.ts
@@ -195,6 +195,7 @@ class Transaction {
    * or with the query and parameters as separate arguments.
    * @param {mixed} query - Cypher query to execute
    * @param {Object} parameters - Map with parameters to use in query
+   * @param {Rules} parameterRules - Rules to typecheck and/or map the parameter object. Must not be provided as a separate argument if an Object is passed as first argument
    * @return {Result} New Result
    */
   run<R extends RecordShape = RecordShape> (query: Query, parameters?: any, parameterRules?: Rules): Result<R> {

--- a/packages/neo4j-driver-deno/lib/core/transaction.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction.ts
@@ -201,7 +201,7 @@ class Transaction {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
       parameters,
-      {parameterRules: parameterRules}
+      { parameterRules }
     )
 
     const result = this._state.run(validatedQuery, params, {

--- a/packages/neo4j-driver-deno/lib/core/transaction.ts
+++ b/packages/neo4j-driver-deno/lib/core/transaction.ts
@@ -38,6 +38,7 @@ import { Query } from './types.ts'
 import { RecordShape } from './record.ts'
 import NotificationFilter from './notification-filter.ts'
 import { TelemetryApis, TELEMETRY_APIS } from './internal/constants.ts'
+import { Rules } from './mapping.highlevel.ts'
 
 type NonAutoCommitTelemetryApis = Exclude<TelemetryApis, typeof TELEMETRY_APIS.AUTO_COMMIT_TRANSACTION>
 type NonAutoCommitApiTelemetryConfig = ApiTelemetryConfig<NonAutoCommitTelemetryApis>
@@ -196,10 +197,11 @@ class Transaction {
    * @param {Object} parameters - Map with parameters to use in query
    * @return {Result} New Result
    */
-  run<R extends RecordShape = RecordShape> (query: Query, parameters?: any): Result<R> {
+  run<R extends RecordShape = RecordShape> (query: Query, parameters?: any, parameterRules?: Rules): Result<R> {
     const { validatedQuery, params } = validateQueryAndParameters(
       query,
-      parameters
+      parameters,
+      {parameterRules: parameterRules}
     )
 
     const result = this._state.run(validatedQuery, params, {

--- a/packages/neo4j-driver-deno/lib/core/types.ts
+++ b/packages/neo4j-driver-deno/lib/core/types.ts
@@ -16,12 +16,13 @@
  */
 
 import ClientCertificate, { ClientCertificateProvider } from './client-certificate.ts'
+import { Rules } from './mapping.highlevel.ts'
 import NotificationFilter from './notification-filter.ts'
 
 /**
  * @private
  */
-export type Query = string | String | { text: string, parameters?: any }
+export type Query = string | String | { text: string, parameters?: any, parameterRules?: Rules }
 
 export type EncryptionLevel = 'ENCRYPTION_ON' | 'ENCRYPTION_OFF'
 

--- a/packages/neo4j-driver/package.json
+++ b/packages/neo4j-driver/package.json
@@ -96,8 +96,5 @@
     "neo4j-driver-bolt-connection": "6.0.0-dev",
     "neo4j-driver-core": "6.0.0-dev",
     "rxjs": "^7.8.2"
-  },
-  "overrides": {
-    "graceful-fs": "^4.2.11"
   }
 }

--- a/packages/neo4j-driver/package.json
+++ b/packages/neo4j-driver/package.json
@@ -96,5 +96,8 @@
     "neo4j-driver-bolt-connection": "6.0.0-dev",
     "neo4j-driver-core": "6.0.0-dev",
     "rxjs": "^7.8.2"
+  },
+  "overrides": {
+    "graceful-fs": "^4.2.11"
   }
 }

--- a/packages/neo4j-driver/test/bolt-v3.test.js
+++ b/packages/neo4j-driver/test/bolt-v3.test.js
@@ -209,8 +209,7 @@ describe('#integration Bolt V3 API', () => {
     try {
       await tx.run(
         'MATCH (n:Node) SET n.prop = $newValue',
-        { newValue: 2 },
-        { timeout: 1 }
+        { newValue: 2 }
       )
     } catch (e) {
       // ClientError on 4.1 and later

--- a/packages/neo4j-driver/test/examples.test.js
+++ b/packages/neo4j-driver/test/examples.test.js
@@ -1566,7 +1566,7 @@ describe('#integration examples', () => {
 
   describe('Record Object Mapping', () => {
     it('Record mapping', async () => {
-      const driver = neo4j.driver(uri, sharedNeo4j.authToken, { disableLosslessIntegers: true })
+      const driver = neo4j.driver(uri, sharedNeo4j.authToken)
 
       // Setting up the contents of the database for the test.
       await driver.executeQuery(
@@ -1633,12 +1633,12 @@ describe('#integration examples', () => {
       // Create rules for the hydration of the created types
       const personRules = {
         Name: neo4j.rule.asString(),
-        Born: neo4j.rule.asNumber({ acceptBigInt: true, optional: true })
+        Born: neo4j.rule.asNumber({ optional: true })
       }
 
       const movieRules = {
         Title: neo4j.rule.asString(),
-        Released: neo4j.rule.asNumber({ acceptBigInt: true, optional: true, from: 'release' }),
+        Released: neo4j.rule.asNumber({ isInteger: true, optional: true, from: 'release' }),
         Tagline: neo4j.rule.asString({ optional: true })
       }
 

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -480,4 +480,31 @@ describe('#integration record object mapping', () => {
     await session.close()
     await driver.close()
   })
+
+  it('should not alter undefined or null in optional fields', async () => {
+    const session = driverGlobal.session()
+
+    const rules = {
+      undefined: neo4j.rule.asString({ optional: true }),
+      null: neo4j.rule.asString({ optional: true })
+    }
+
+    const obj = {
+      undefined,
+      null: null
+    }
+
+    try {
+      await session.run('RETURN $undefined', obj, {}, rules)
+      expect(true).toBe(false)
+    } catch (e) {
+      expect(e.gqlStatus).toBe('42001')
+    }
+    // THIS DOES NOT WORK YET
+    let result = await session.run('RETURN $null as null', obj, {}, rules)
+    expect(result.records[0].get('null')).toEqual(null)
+    result = await session.run('RETURN NULL as null').as(rules)
+    expect(result.records[0].undefined).toEqual(undefined)
+    expect(result.records[0].null).toEqual(null)
+  })
 })

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -313,12 +313,16 @@ describe('#integration record object mapping', () => {
     const rules = {
       number: neo4j.rule.asNumber(),
       string: neo4j.rule.asString(),
-      bigint: neo4j.rule.asBigInt(),
+      bigint: neo4j.rule.asBigInt({ acceptNumber: true }),
       date: neo4j.rule.asDate(),
       dateTime: neo4j.rule.asDateTime(),
       duration: neo4j.rule.asDuration(),
-      time: neo4j.rule.asTime({ from: 'heyaaaa' }),
+      time: neo4j.rule.asTime({ from: 'wakeup' }),
       list: neo4j.rule.asList({ apply: neo4j.rule.asString() })
+    }
+
+    const nodeRule = {
+      n: neo4j.rule.asNode({ convert: (node) => node.as(rules) })
     }
 
     const obj = {
@@ -334,8 +338,15 @@ describe('#integration record object mapping', () => {
 
     neo4j.RecordObjectMapping.translateIdentifiers(neo4j.RecordObjectMapping.getCaseTranslator('snake_case', 'camelCase'))
 
-    const res = await session.run('MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, date_time: $date_time, duration: $duration, time: $heyaaaa, list: $list}) RETURN n', obj, {}, rules)
-
-    expect(res.records[0].get('n').properties.date_time).toEqual(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1))
+    const res = await session.run('MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, date_time: $date_time, duration: $duration, wakeup: $wakeup, list: $list}) RETURN n', obj, {}, rules).as(nodeRule)
+    const node = res.records[0].n
+    expect(node.string).toEqual('hi')
+    expect(node.number).toEqual(1)
+    expect(node.bigint).toEqual(BigInt(1))
+    expect(node.date).toEqual(new neo4j.Date(1, 1, 1))
+    expect(node.dateTime).toEqual(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1))
+    expect(node.duration).toEqual(new neo4j.Duration(1, 1, 1, 1))
+    expect(node.time).toEqual(new neo4j.Time(1, 1, 1, 1, 1))
+    expect(node.list).toEqual(['hi'])
   })
 })

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import neo4j, { Date, Duration, Time, Point, DateTime, LocalDateTime, LocalTime } from '../src'
+import neo4j, { Date, Duration, Time, Point, DateTime, LocalDateTime, LocalTime, Integer } from '../src'
 import sharedNeo4j from './internal/shared-neo4j'
 
 describe('#integration record object mapping', () => {
@@ -336,6 +336,7 @@ describe('#integration record object mapping', () => {
       number: neo4j.rule.asNumber(),
       string: neo4j.rule.asString(),
       bigint: neo4j.rule.asBigInt({ acceptNumber: true }),
+      integer: neo4j.rule.asInteger(),
       date: neo4j.rule.asDate({ stringify: true }),
       dateTime: neo4j.rule.asDateTime({ stringify: true }),
       standardDateTime: neo4j.rule.asDateTime({ JSNativeDate: true }),
@@ -353,6 +354,7 @@ describe('#integration record object mapping', () => {
       string: 'hi',
       number: 1,
       bigint: BigInt(1),
+      integer: Integer.fromValue(1),
       date: (new neo4j.Date(1, 1, 1)).toString(),
       dateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString(),
       standardDateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate(),
@@ -367,6 +369,7 @@ describe('#integration record object mapping', () => {
     expect(node.string).toEqual('hi')
     expect(node.number).toEqual(1)
     expect(node.bigint).toEqual(BigInt(1))
+    expect(node.integer).toEqual(Integer.fromValue(1))
     expect(node.date).toEqual((new neo4j.Date(1, 1, 1)).toString())
     expect(node.dateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString())
     expect(node.standardDateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate())

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -314,9 +314,9 @@ describe('#integration record object mapping', () => {
       number: neo4j.rule.asNumber(),
       string: neo4j.rule.asString(),
       bigint: neo4j.rule.asBigInt({ acceptNumber: true }),
-      date: neo4j.rule.asDate(),
-      dateTime: neo4j.rule.asDateTime(),
-      duration: neo4j.rule.asDuration(),
+      date: neo4j.rule.asDate({ stringify: true }),
+      dateTime: neo4j.rule.asDateTime({ stringify: true }),
+      duration: neo4j.rule.asDuration({ stringify: true }),
       time: neo4j.rule.asTime({ from: 'wakeup' }),
       list: neo4j.rule.asList({ apply: neo4j.rule.asString() })
     }
@@ -329,23 +329,21 @@ describe('#integration record object mapping', () => {
       string: 'hi',
       number: 1,
       bigint: BigInt(1),
-      date: new neo4j.Date(1, 1, 1),
-      dateTime: new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1),
-      duration: new neo4j.Duration(1, 1, 1, 1),
+      date: (new neo4j.Date(1, 1, 1)).toString(),
+      dateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString(),
+      duration: (new neo4j.Duration(1, 1, 1, 1)).toString(),
       time: new neo4j.Time(1, 1, 1, 1, 1),
       list: ['hi']
     }
 
-    neo4j.RecordObjectMapping.translateIdentifiers(neo4j.RecordObjectMapping.getCaseTranslator('snake_case', 'camelCase'))
-
-    const res = await session.run('MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, date_time: $date_time, duration: $duration, wakeup: $wakeup, list: $list}) RETURN n', obj, {}, rules).as(nodeRule)
+    const res = await session.run('MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, dateTime: $dateTime, duration: $duration, wakeup: $wakeup, list: $list}) RETURN n', obj, {}, rules).as(nodeRule)
     const node = res.records[0].n
     expect(node.string).toEqual('hi')
     expect(node.number).toEqual(1)
     expect(node.bigint).toEqual(BigInt(1))
-    expect(node.date).toEqual(new neo4j.Date(1, 1, 1))
-    expect(node.dateTime).toEqual(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1))
-    expect(node.duration).toEqual(new neo4j.Duration(1, 1, 1, 1))
+    expect(node.date).toEqual((new neo4j.Date(1, 1, 1)).toString())
+    expect(node.dateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString())
+    expect(node.duration).toEqual((new neo4j.Duration(1, 1, 1, 1)).toString())
     expect(node.time).toEqual(new neo4j.Time(1, 1, 1, 1, 1))
     expect(node.list).toEqual(['hi'])
   })

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -316,9 +316,11 @@ describe('#integration record object mapping', () => {
       bigint: neo4j.rule.asBigInt({ acceptNumber: true }),
       date: neo4j.rule.asDate({ stringify: true }),
       dateTime: neo4j.rule.asDateTime({ stringify: true }),
+      standardDateTime: neo4j.rule.asDateTime({ toStandardDate: true }),
       duration: neo4j.rule.asDuration({ stringify: true }),
       time: neo4j.rule.asTime({ from: 'wakeup' }),
-      list: neo4j.rule.asList({ apply: neo4j.rule.asString() })
+      list: neo4j.rule.asList({ apply: neo4j.rule.asString() }),
+      dateList: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ toStandardDate: true }) })
     }
 
     const nodeRule = {
@@ -331,20 +333,39 @@ describe('#integration record object mapping', () => {
       bigint: BigInt(1),
       date: (new neo4j.Date(1, 1, 1)).toString(),
       dateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString(),
+      standardDateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate(),
       duration: (new neo4j.Duration(1, 1, 1, 1)).toString(),
       time: new neo4j.Time(1, 1, 1, 1, 1),
-      list: ['hi']
+      list: ['hi'],
+      dateList: [(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]
     }
 
-    const res = await session.run('MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, dateTime: $dateTime, duration: $duration, wakeup: $wakeup, list: $list}) RETURN n', obj, {}, rules).as(nodeRule)
+    const res = await session.run('MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, dateTime: $dateTime, standardDateTime: $standardDateTime, duration: $duration, wakeup: $wakeup, list: $list, dateList: $dateList}) RETURN n', obj, {}, rules).as(nodeRule)
     const node = res.records[0].n
     expect(node.string).toEqual('hi')
     expect(node.number).toEqual(1)
     expect(node.bigint).toEqual(BigInt(1))
     expect(node.date).toEqual((new neo4j.Date(1, 1, 1)).toString())
     expect(node.dateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString())
+    expect(node.standardDateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate())
     expect(node.duration).toEqual((new neo4j.Duration(1, 1, 1, 1)).toString())
     expect(node.time).toEqual(new neo4j.Time(1, 1, 1, 1, 1))
     expect(node.list).toEqual(['hi'])
+    expect(node.dateList).toEqual([(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()])
+  })
+
+  it('map nestedList as mapped parameter', async () => {
+    const session = driverGlobal.session()
+
+    const rules = {
+      nestedList: neo4j.rule.asList({ apply: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ toStandardDate: true }) }) })
+    }
+
+    const obj = {
+      nestedList: [[(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]]
+    }
+
+    const res = await session.run('return {nestedList: $nestedList', obj, {}, rules).as(rules)
+    expect(res.records[0].n.nestedList).toEqual([[(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]])
   })
 })

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -306,4 +306,36 @@ describe('#integration record object mapping', () => {
 
     session.close()
   })
+
+  it('map input', async () => {
+    const session = driverGlobal.session()
+
+    const rules = {
+      number: neo4j.rule.asNumber(),
+      string: neo4j.rule.asString(),
+      bigint: neo4j.rule.asBigInt(),
+      date: neo4j.rule.asDate(),
+      dateTime: neo4j.rule.asDateTime(),
+      duration: neo4j.rule.asDuration(),
+      time: neo4j.rule.asTime({ from: 'heyaaaa' }),
+      list: neo4j.rule.asList({ apply: neo4j.rule.asString() })
+    }
+
+    const obj = {
+      string: 'hi',
+      number: 1,
+      bigint: BigInt(1),
+      date: new neo4j.Date(1, 1, 1),
+      dateTime: new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1),
+      duration: new neo4j.Duration(1, 1, 1, 1),
+      time: new neo4j.Time(1, 1, 1, 1, 1),
+      list: ['hi']
+    }
+
+    neo4j.RecordObjectMapping.translateIdentifiers(neo4j.RecordObjectMapping.getCaseTranslator('snake_case', 'camelCase'))
+
+    const res = await session.run('MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, date_time: $date_time, duration: $duration, time: $heyaaaa, list: $list}) RETURN n', obj, {}, rules)
+
+    expect(res.records[0].get('n').properties.date_time).toEqual(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1))
+  })
 })

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -498,9 +498,12 @@ describe('#integration record object mapping', () => {
       await session.run('RETURN $undefined', obj, {}, rules)
       expect(true).toBe(false)
     } catch (e) {
-      expect(e.gqlStatus).toBe('42001')
+      if (protocolVersion.isGreaterOrEqualTo({ major: 6, minor: 0 })) {
+        expect(e.gqlStatus).toBe('42001')
+      } else {
+        expect(e.code).toBe('Neo.ClientError.Statement.ParameterMissing')
+      }
     }
-    // THIS DOES NOT WORK YET
     let result = await session.run('RETURN $null as null', obj, {}, rules)
     expect(result.records[0].get('null')).toEqual(null)
     result = await session.run('RETURN NULL as null').as(rules)

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -306,6 +306,24 @@ describe('#integration record object mapping', () => {
 
     session.close()
   })
+  it('should be able to map result with missing optional key', async () => {
+    const session = driverGlobal.session()
+
+    const res = await session.executeRead(async (tx) => {
+      const txres = tx.run(
+        'RETURN $obj as obj',
+        {
+          obj: new Point(4326, 32.812493, 42.983216)
+        }
+      )
+      return txres.as({ obj: neo4j.rule.asPoint(), notHere: neo4j.rule.asPoint({ optional: true }) })
+    })
+    expect(res.records[0].obj.x).toBe(32.812493)
+    expect(res.records[0].obj.srid).toBe(4326)
+    expect(res.records[0].notHere).toBe(undefined)
+
+    session.close()
+  })
 
   it('map input', async () => {
     const session = driverGlobal.session()

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -329,20 +329,24 @@ describe('#integration record object mapping', () => {
     session.close()
   })
 
-  it('map input', async () => {
+  it('map simple input', async () => {
     const session = driverGlobal.session()
 
     const rules = {
-      number: neo4j.rule.asNumber(),
+      bool: neo4j.rule.asBoolean(),
       string: neo4j.rule.asString(),
+      number: neo4j.rule.asNumber(),
       bigint: neo4j.rule.asBigInt({ acceptNumber: true }),
-      date: neo4j.rule.asDate({ stringify: true }),
-      dateTime: neo4j.rule.asDateTime({ stringify: true }),
-      standardDateTime: neo4j.rule.asDateTime({ JSNativeDate: true }),
+      point: neo4j.rule.asPoint(),
       duration: neo4j.rule.asDuration({ stringify: true }),
-      time: neo4j.rule.asTime({ from: 'wakeup' }),
+      localTime: neo4j.rule.asLocalTime(),
+      time: neo4j.rule.asTime({ from: 'timeToWakeup' }),
+      date: neo4j.rule.asDate({ stringify: true }),
+      localDateTime: neo4j.rule.asLocalDateTime(),
+      dateTime: neo4j.rule.asDateTime({ stringify: true }),
+      standardDateTime: neo4j.rule.asDateTime({ jsNativeDate: true }),
       list: neo4j.rule.asList({ apply: neo4j.rule.asString() }),
-      dateList: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ JSNativeDate: true }) })
+      dateList: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ jsNativeDate: true }) })
     }
 
     const nodeRule = {
@@ -350,28 +354,36 @@ describe('#integration record object mapping', () => {
     }
 
     const obj = {
+      bool: true,
       string: 'hi',
       number: 1,
       bigint: BigInt(1),
+      point: new neo4j.Point(4326, 1, 1),
+      duration: (new neo4j.Duration(1, 1, 1, 1)).toString(),
+      localTime: new neo4j.LocalTime(1, 1, 1, 1),
+      time: new neo4j.Time(1, 1, 1, 1, 1),
       date: (new neo4j.Date(1, 1, 1)).toString(),
+      localDateTime: new neo4j.LocalDateTime(1, 1, 1, 1, 1, 1, 1),
       dateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString(),
       standardDateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate(),
-      duration: (new neo4j.Duration(1, 1, 1, 1)).toString(),
-      time: new neo4j.Time(1, 1, 1, 1, 1),
       list: ['hi'],
       dateList: [(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]
     }
 
-    const res = await session.run('MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, dateTime: $dateTime, standardDateTime: $standardDateTime, duration: $duration, wakeup: $wakeup, list: $list, dateList: $dateList}) RETURN n', obj, {}, rules).as(nodeRule)
+    const res = await session.run('MERGE (n {bool: $bool, string: $string, number: $number, bigint: $bigint, point: $point, duration: $duration, localTime: $localTime, timeToWakeup: $timeToWakeup, date: $date, localDateTime: $localDateTime, dateTime: $dateTime, standardDateTime: $standardDateTime, list: $list, dateList: $dateList}) RETURN n', obj, {}, rules).as(nodeRule)
     const node = res.records[0].n
+    expect(node.bool).toEqual(true)
     expect(node.string).toEqual('hi')
     expect(node.number).toEqual(1)
     expect(node.bigint).toEqual(BigInt(1))
+    expect(node.point).toEqual(new neo4j.Point(4326, 1, 1))
+    expect(node.duration).toEqual((new neo4j.Duration(1, 1, 1, 1)).toString())
+    expect(node.localTime).toEqual(new neo4j.LocalTime(1, 1, 1, 1))
+    expect(node.time).toEqual(new neo4j.Time(1, 1, 1, 1, 1))
     expect(node.date).toEqual((new neo4j.Date(1, 1, 1)).toString())
+    expect(node.localDateTime).toEqual(new neo4j.LocalDateTime(1, 1, 1, 1, 1, 1, 1))
     expect(node.dateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString())
     expect(node.standardDateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate())
-    expect(node.duration).toEqual((new neo4j.Duration(1, 1, 1, 1)).toString())
-    expect(node.time).toEqual(new neo4j.Time(1, 1, 1, 1, 1))
     expect(node.list).toEqual(['hi'])
     expect(node.dateList).toEqual([(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()])
   })
@@ -380,7 +392,7 @@ describe('#integration record object mapping', () => {
     const session = driverGlobal.session()
 
     const rules = {
-      nestedList: neo4j.rule.asList({ apply: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ JSNativeDate: true }) }) })
+      nestedList: neo4j.rule.asList({ apply: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ jsNativeDate: true }) }) })
     }
 
     const obj = {
@@ -415,6 +427,19 @@ describe('#integration record object mapping', () => {
     await integerDriver.close()
   })
 
+  it('map vector as input and output', async () => {
+    if (protocolVersion.isGreaterOrEqualTo({ major: 6, minor: 0 }) && edition === 'enterprise') {
+      const session = driverGlobal.session()
+
+      const rules = { vec: neo4j.rule.asVector({ from: 'vector' }), typedListVector: neo4j.rule.asVector({ asTypedList: true }) }
+      const parameters = { vec: neo4j.vector(Int16Array.from([4, 8])), typedListVector: Int16Array.from([4, 8]) }
+
+      const res = await session.run('return $vector as vector, $typedListVector as typedListVector', parameters, {}, rules).as(rules)
+      expect(res.records[0].vec).toEqual(parameters.vec)
+      expect(res.records[0].typedListVector).toEqual(parameters.typedListVector)
+    }
+  })
+
   it('map object with internal rules', async () => {
     if (protocolVersion.isGreaterOrEqualTo({ major: 6, minor: 0 }) && edition === 'enterprise') {
       const session = driverGlobal.session()
@@ -441,5 +466,18 @@ describe('#integration record object mapping', () => {
     }
 
     expect(() => session.run('RETURN $string', obj, {}, rules).then()).toThrow()
+  })
+
+  it('map integer as input and output', async () => {
+    const driver = neo4j.driver(uri, sharedNeo4j.authToken)
+    const session = driver.session()
+
+    const rules = { int: neo4j.rule.asInteger() }
+    const parameters = { int: neo4j.int(1) }
+
+    const res = await session.run('return $int as int', parameters, {}, rules).as(rules)
+    expect(res.records[0].int).toEqual(parameters.int)
+    await session.close()
+    await driver.close()
   })
 })

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -386,4 +386,30 @@ describe('#integration record object mapping', () => {
     const res = await session.run('return $nestedList as nestedList', obj, {}, rules).as(rules)
     expect(res.records[0].nestedList).toEqual([[(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]])
   })
+
+  it('map object with internal rules', async () => {
+    const session = driverGlobal.session()
+
+    const rules = { obj: neo4j.rule.asObject({ date: neo4j.rule.asDate({ stringify: true }), vec: neo4j.rule.asVector({ asTypedList: true, from: 'vector' }) }) }
+    const parameters = { obj: { date: '2024-01-12', vec: Int16Array.from([4, 8]) } }
+
+    const res = await session.run('return $obj as obj', parameters, {}, rules).as(rules)
+    expect(res.records[0].obj.date).toEqual(parameters.obj.date)
+    expect(res.records[0].obj.vec).toEqual(parameters.obj.vec)
+  })
+
+  it('should fail parameterMapping non-optional parameter is missing', async () => {
+    const session = driverGlobal.session()
+
+    const rules = {
+      number: neo4j.rule.asNumber(),
+      string: neo4j.rule.asString()
+    }
+
+    const obj = {
+      string: 'hi'
+    }
+
+    expect(() => session.run('RETURN $string', obj, {}, rules).then()).toThrow()
+  })
 })

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -336,7 +336,6 @@ describe('#integration record object mapping', () => {
       number: neo4j.rule.asNumber(),
       string: neo4j.rule.asString(),
       bigint: neo4j.rule.asBigInt({ acceptNumber: true }),
-      integer: neo4j.rule.asInteger(),
       date: neo4j.rule.asDate({ stringify: true }),
       dateTime: neo4j.rule.asDateTime({ stringify: true }),
       standardDateTime: neo4j.rule.asDateTime({ JSNativeDate: true }),
@@ -354,7 +353,6 @@ describe('#integration record object mapping', () => {
       string: 'hi',
       number: 1,
       bigint: BigInt(1),
-      integer: Integer.fromValue(1),
       date: (new neo4j.Date(1, 1, 1)).toString(),
       dateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString(),
       standardDateTime: (new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate(),
@@ -369,7 +367,6 @@ describe('#integration record object mapping', () => {
     expect(node.string).toEqual('hi')
     expect(node.number).toEqual(1)
     expect(node.bigint).toEqual(BigInt(1))
-    expect(node.integer).toEqual(Integer.fromValue(1))
     expect(node.date).toEqual((new neo4j.Date(1, 1, 1)).toString())
     expect(node.dateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toString())
     expect(node.standardDateTime).toEqual((new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate())
@@ -392,6 +389,30 @@ describe('#integration record object mapping', () => {
 
     const res = await session.run('return $nestedList as nestedList', obj, {}, rules).as(rules)
     expect(res.records[0].nestedList).toEqual([[(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]])
+  })
+
+  it('map integer with rule', async () => {
+    const integerDriver = neo4j.driver(uri, sharedNeo4j.authToken)
+
+    const session = integerDriver.session()
+
+    const rules = {
+      integer: neo4j.rule.asInteger()
+    }
+
+    const nodeRule = {
+      n: neo4j.rule.asNode({ convert: (node) => node.as(rules) })
+    }
+
+    const obj = {
+      integer: Integer.fromValue(1)
+    }
+
+    const res = await session.run('MERGE (n {integer: $integer}) RETURN n', obj, {}, rules).as(nodeRule)
+    const node = res.records[0].n
+    expect(node.integer).toEqual(Integer.fromValue(1))
+    await session.close()
+    await integerDriver.close()
   })
 
   it('map object with internal rules', async () => {

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -43,12 +43,12 @@ describe('#integration record object mapping', () => {
   // Create rules for the hydration of the created types
   const personRules = {
     name: neo4j.rule.asString(),
-    born: neo4j.rule.asNumber({ acceptBigInt: true, optional: true })
+    born: neo4j.rule.asNumber({ optional: true })
   }
 
   const movieRules = {
     title: neo4j.rule.asString(),
-    released: neo4j.rule.asNumber({ acceptBigInt: true, optional: true, from: 'release' }),
+    released: neo4j.rule.asNumber({ isInteger: true, optional: true, from: 'release' }),
     tagline: neo4j.rule.asString({ optional: true })
   }
 
@@ -90,9 +90,13 @@ describe('#integration record object mapping', () => {
     })
   }
   const uri = `bolt://${sharedNeo4j.hostnameWithBoltPort}`
+  let protocolVersion
+  let edition
 
-  beforeAll(() => {
+  beforeAll(async () => {
     driverGlobal = neo4j.driver(uri, sharedNeo4j.authToken, { disableLosslessIntegers: true })
+    protocolVersion = await sharedNeo4j.cleanupAndGetProtocolVersion(driverGlobal)
+    edition = await sharedNeo4j.getEdition(driverGlobal)
   })
 
   afterAll(async () => {
@@ -388,14 +392,16 @@ describe('#integration record object mapping', () => {
   })
 
   it('map object with internal rules', async () => {
-    const session = driverGlobal.session()
+    if (protocolVersion.isGreaterOrEqualTo({ major: 6, minor: 0 }) && edition === 'enterprise') {
+      const session = driverGlobal.session()
 
-    const rules = { obj: neo4j.rule.asObject({ date: neo4j.rule.asDate({ stringify: true }), vec: neo4j.rule.asVector({ asTypedList: true, from: 'vector' }) }) }
-    const parameters = { obj: { date: '2024-01-12', vec: Int16Array.from([4, 8]) } }
+      const rules = { obj: neo4j.rule.asObject({ date: neo4j.rule.asDate({ stringify: true }), vec: neo4j.rule.asVector({ asTypedList: true, from: 'vector' }) }) }
+      const parameters = { obj: { date: '2024-01-12', vec: Int16Array.from([4, 8]) } }
 
-    const res = await session.run('return $obj as obj', parameters, {}, rules).as(rules)
-    expect(res.records[0].obj.date).toEqual(parameters.obj.date)
-    expect(res.records[0].obj.vec).toEqual(parameters.obj.vec)
+      const res = await session.run('return $obj as obj', parameters, {}, rules).as(rules)
+      expect(res.records[0].obj.date).toEqual(parameters.obj.date)
+      expect(res.records[0].obj.vec).toEqual(parameters.obj.vec)
+    }
   })
 
   it('should fail parameterMapping non-optional parameter is missing', async () => {

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -365,7 +365,7 @@ describe('#integration record object mapping', () => {
       nestedList: [[(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]]
     }
 
-    const res = await session.run('return {nestedList: $nestedList', obj, {}, rules).as(rules)
-    expect(res.records[0].n.nestedList).toEqual([[(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]])
+    const res = await session.run('return $nestedList as nestedList', obj, {}, rules).as(rules)
+    expect(res.records[0].nestedList).toEqual([[(new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 1)).toStandardDate()]])
   })
 })

--- a/packages/neo4j-driver/test/record-object-mapping.test.js
+++ b/packages/neo4j-driver/test/record-object-mapping.test.js
@@ -316,11 +316,11 @@ describe('#integration record object mapping', () => {
       bigint: neo4j.rule.asBigInt({ acceptNumber: true }),
       date: neo4j.rule.asDate({ stringify: true }),
       dateTime: neo4j.rule.asDateTime({ stringify: true }),
-      standardDateTime: neo4j.rule.asDateTime({ toStandardDate: true }),
+      standardDateTime: neo4j.rule.asDateTime({ JSNativeDate: true }),
       duration: neo4j.rule.asDuration({ stringify: true }),
       time: neo4j.rule.asTime({ from: 'wakeup' }),
       list: neo4j.rule.asList({ apply: neo4j.rule.asString() }),
-      dateList: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ toStandardDate: true }) })
+      dateList: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ JSNativeDate: true }) })
     }
 
     const nodeRule = {
@@ -358,7 +358,7 @@ describe('#integration record object mapping', () => {
     const session = driverGlobal.session()
 
     const rules = {
-      nestedList: neo4j.rule.asList({ apply: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ toStandardDate: true }) }) })
+      nestedList: neo4j.rule.asList({ apply: neo4j.rule.asList({ apply: neo4j.rule.asDateTime({ JSNativeDate: true }) }) })
     }
 
     const obj = {


### PR DESCRIPTION
closes DRIVERS-107

This PR provides support for typechecking and automatic conversion of parameters, as well as using the object mapping registry to register mapping strategies for classes. This lets users directly pass objects even with problematic properties that can not be sent over bolt (like functions), by automatically converting them or by omitting them from the mapping strategy. 

**This is the 2nd half of the Record Object Mapping feature, which is also marked stabilized and taken out of preview in this PR.**

### Examples
```javascript

class Obj {
    constructor (obj) {
        this.string = obj?.string ?? 'hi'
        this.number = obj?.number ?? 1
        this.bigint = obj?.bigint ?? BigInt(1)
        this.date = obj?.date ?? "2024-01-01"
        this.localDate = obj?.localDate ?? "2024-01-01"
        this.dateTime = obj?.dateTime ?? new neo4j.DateTime(1, 1, 1, 1, 1, 1, 1, 0)._toUTC()
        this.localDateTime = obj?.localDateTime ?? new neo4j.LocalDateTime(1, 1, 1, 1, 1, 1, 1).toString()
        this.duration = obj?.duration ?? "P1DT5.00007S"
        this.time = obj?.time ?? "10:11:12.13Z"
        this.localTime = obj?.localTime ?? "10:11:12.0001"
        this.list = obj?.list ?? ["hi"]
        this.function = () => "function string" // bolt cannot send functions
        this.node = new neo4j.Node("123", [], {}) // nor can it send nodes
    }
}

const session = driver.session()
const rules = {
    number: neo4j.rule.asNumber(),
    string: neo4j.rule.asString(),
    bigint: neo4j.rule.asBigInt({acceptNumber: true}),
    date: neo4j.rule.asDate({stringify: true}), // this will ensure date is stored as a Date in the DB and retrieved as a string 
    localDate: neo4j.rule.asDate({stringify: true}),
    dateTime: neo4j.rule.asDateTime({stringify: true}),
    localDateTime: neo4j.rule.asLocalDateTime({stringify: true}),
    duration: neo4j.rule.asDuration({stringify: true}),
    time: neo4j.rule.asTime({from: "dob", stringify: true}),
    localTime: neo4j.rule.asLocalTime({stringify: true}),
    list: neo4j.rule.asList({ apply: neo4j.rule.asString() }),
} // not including function and node here will make the driver skip sending them. They could alternatively be converted to a bolt-compatible type.

neo4j.RecordObjectMapping.register(Obj, rules)

// This allows us to use camelCase for our object properties and snake_case for the properties on our node in the DB
neo4j.RecordObjectMapping.translateIdentifiers(neo4j.RecordObjectMapping.getCaseTranslator("snake_case", "camelCase"))

session.run(
  'MERGE (n {string: $string, number: $number, bigint: $bigint, date: $date, local_date: $local_date, date_time: $date_time, local_date_time: $local_date_time, duration: $duration, dob: $dob, local_time: $local_time, list: $list}) RETURN n',
  new Obj(),
  {}
).as({n: {convert: (n) => new Obj(n.as(rules))}})
.then((res) => {
    console.log(res.records[0])
    session.close()
    driver.close()
})
``` 