### PR TITLE
Improve error message for starting work on a busy session

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -278,8 +278,8 @@ class Session {
       resultPromise = Promise.reject(
         newError(
           'Queries cannot be run directly on a ' +
-            'session with an open transaction; either run from within the ' +
-            'transaction or use a different session.'
+            'session with ongoing work; either await the previous work, ' +
+            'run in an existing transaction or use a different session.'
         )
       )
     }
@@ -316,8 +316,8 @@ class Session {
     }
     if (this._hasTx) {
       throw newError(
-        'You cannot begin a transaction on a session with an open transaction; ' +
-          'either run from within the transaction or use a different session.'
+        'You cannot begin a transaction on a session with ongoing work; ' +
+          'either run from within an existing transaction or use a different session.'
       )
     }
 

--- a/packages/neo4j-driver-deno/lib/core/session.ts
+++ b/packages/neo4j-driver-deno/lib/core/session.ts
@@ -278,8 +278,8 @@ class Session {
       resultPromise = Promise.reject(
         newError(
           'Queries cannot be run directly on a ' +
-            'session with an open transaction; either run from within the ' +
-            'transaction or use a different session.'
+            'session with ongoing work; either await the previous work, ' +
+            'run in an existing transaction or use a different session.'
         )
       )
     }
@@ -316,8 +316,8 @@ class Session {
     }
     if (this._hasTx) {
       throw newError(
-        'You cannot begin a transaction on a session with an open transaction; ' +
-          'either run from within the transaction or use a different session.'
+        'You cannot begin a transaction on a session with ongoing work; ' +
+          'either run from within an existing transaction or use a different session.'
       )
     }
 

--- a/packages/neo4j-driver/test/nested-statements.test.js
+++ b/packages/neo4j-driver/test/nested-statements.test.js
@@ -89,8 +89,8 @@ describe('#integration session', () => {
           expect(true).toBe(false)
         } catch (e) {
           expect(e.message).toBe(
-            'Queries cannot be run directly on a session with an open transaction; ' +
-            'either run from within the transaction or use a different session.'
+            'Queries cannot be run directly on a session with ongoing work; either ' +
+            'await the previous work, run in an existing transaction or use a different session.'
           )
         }
       },

--- a/packages/neo4j-driver/test/rx/nested-statements.test.js
+++ b/packages/neo4j-driver/test/rx/nested-statements.test.js
@@ -116,6 +116,6 @@ describe('#integration-rx transaction', () => {
       )
       .toPromise()
 
-    expect(result[0].error.message).toMatch(/Queries cannot be run directly on a session with an open transaction/)
+    expect(result[0].error.message).toMatch(/Queries cannot be run directly on a session with ongoing work/)
   })
 })

--- a/packages/neo4j-driver/test/session.test.js
+++ b/packages/neo4j-driver/test/session.test.js
@@ -282,9 +282,8 @@ describe('#integration session', () => {
     // Then
     session.run('RETURN 42').catch(error => {
       expect(error.message).toBe(
-        'Queries cannot be run directly on a ' +
-          'session with an open transaction; either run from within the ' +
-          'transaction or use a different session.'
+        'Queries cannot be run directly on a session with ongoing work; either ' +
+        'await the previous work, run in an existing transaction or use a different session.'
       )
       done()
     })
@@ -296,7 +295,7 @@ describe('#integration session', () => {
 
     // Then
     expect(() => session.beginTransaction()).toThrowError(
-      /You cannot begin a transaction on a session with an open transaction/
+      /You cannot begin a transaction on a session with ongoing work/
     )
   }, 70000)
 


### PR DESCRIPTION
closes DRIVERS-220

The message is unclear for users running into this due to having ongoing `session.run()` work