### PR TITLE
Fix jest config for npm run test in neo4j-driver

### DIFF
--- a/packages/neo4j-driver/jest.config.ts
+++ b/packages/neo4j-driver/jest.config.ts
@@ -61,7 +61,7 @@ export default {
     '\\.pnp\\.[^\\/]+$'
   ],
 
-  testNamePattern: '*',
+  testNamePattern: undefined,
 
   testTimeout: 15000
 }


### PR DESCRIPTION
closes DRIVERS-219