### PR TITLE
Revert "bump deno to 5.28.4 (#1371)"

### DIFF
--- a/packages/neo4j-driver-deno/current.version.ts
+++ b/packages/neo4j-driver-deno/current.version.ts
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export default "5.28.4" // Specified using --version when running generate.ts
+export default "5.28.3" // Specified using --version when running generate.ts

--- a/packages/neo4j-driver-deno/lib/version.ts
+++ b/packages/neo4j-driver-deno/lib/version.ts
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export default "5.28.4" // Specified using --version when running generate.ts
+export default "5.28.3" // Specified using --version when running generate.ts


### PR DESCRIPTION
deno version was erroneously bumped twice after last patch release. upcoming version is 5.28.3