### PR TITLE
Disable verifyAccess for lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,10 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.0.0-dev"
+  "version": "6.0.0-dev",
+  "command": {
+    "publish": {
+      "verifyAccess": false
+    }
+  }
 }


### PR DESCRIPTION
Closes DRIVERS-240

The driver still publishes using an old version of lerna, which was not created with the new, mandated, granular access tokens in mind. Publishing now fails as the access token does not grant access to the npm user registry which lerna by default checks to verify access, setting this flag should make publishing function while the migration from lerna is finalized.

An alternative fix would be to update lerna to 5.2.0, where this issue was solved. But the implemented fix was simply setting this flag `false` by default. Since lerna will be removed from the repo soon either way, and we could not upgrade to a properly recent version as lerna functions we rely on have been changed/deprecated/removed, I think this change is simpler and equally valid.