### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    exclude-paths:
+      - "*-lock"


### PR DESCRIPTION
Closes: DRIVERS-249

The only altered setting from defaults is excluding the pnpm-lock file, which causes a huge amount of noise.