### PR TITLE
Delete .snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,0 @@
-# Snyk (https://snyk.io) policy file
-exclude:
- code:
-  - packages/*/test/**
-  - packages/testkit-backend/**


### PR DESCRIPTION
Closes DRIVERS-296

The driver no longer uses snyk for scanning.