### PR TITLE
Derive the AES key from the DEK with HKDF-SHA256

### DIFF
--- a/packages/core/src/encryption/browser/crypto.ts
+++ b/packages/core/src/encryption/browser/crypto.ts
@@ -1,3 +1,5 @@
+const KEY_DERIVATION_INFO = new TextEncoder().encode('neo4j/property-encryption/v1')
+
 export async function encrypt (key: Uint8Array, message: ArrayBuffer, aad: ArrayBuffer | undefined): Promise<{ cyphertext: ArrayBuffer, iv: Uint8Array }> {
   // @ts-expect-error
   const iv = window.crypto.getRandomValues(new Uint8Array(12))
@@ -36,4 +38,16 @@ export async function decrypt (key: Uint8Array, iv: Uint8Array, message: ArrayBu
 export function getRandomValues (length: number): Uint8Array {
   // @ts-expect-error
   return window.crypto.getRandomValues(new Uint8Array(length))
+}
+
+export async function deriveKey (ikm: Uint8Array): Promise<Uint8Array> {
+  // @ts-expect-error
+  const baseKey = await window.crypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits'])
+  // @ts-expect-error
+  const bits = await window.crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: KEY_DERIVATION_INFO },
+    baseKey,
+    256
+  )
+  return new Uint8Array(bits)
 }

--- a/packages/core/src/encryption/encryption.ts
+++ b/packages/core/src/encryption/encryption.ts
@@ -2,7 +2,7 @@ import Integer, { int, isInt } from '../integer'
 import { BoltProvider } from '../internal/bolt-provider'
 import { EncryptedValue } from './encrypted-value'
 import { EncapsulatedKeyManager } from './key-encapsulation/encapsulated-key-manager'
-import { encrypt, decrypt } from './node/crypto'
+import { encrypt, decrypt, deriveKey } from './node/crypto'
 import { isDate, isDateTime, isDuration, isLocalDateTime, isLocalTime, isTime } from '../temporal-types'
 import { isVector } from '../vector'
 import { isPoint } from '../spatial-types'
@@ -33,7 +33,8 @@ export default class EncryptionService {
     }
     const key = await this._getKey(profile.profile, keyOptions)
     const decapsulatedKey = await this.decapsulateKey(profile.profile, key)
-    const { cyphertext, iv } = await encrypt(decapsulatedKey, encodedValue, encodedAAD)
+    const dataKey = await deriveKey(decapsulatedKey)
+    const { cyphertext, iv } = await encrypt(dataKey, encodedValue, encodedAAD)
     const metadata = {
       iv: new Int8Array(iv.buffer),
       aad: encodedAAD,
@@ -49,8 +50,9 @@ export default class EncryptionService {
       encodedAAD = this._boltProvider.encodeValue(usePersistedAad === true ? struct.metadata.aad : aad)
     }
     const profile = this._getProfile(struct.profileName)
-    const key = await this.decapsulateKey(profile.profile, await this._getKey(profile.profile, struct.metadata.key_id))
-    return this._boltProvider.decodeValue(await decrypt(key, struct.metadata.iv, struct.cipherOutput.buffer as ArrayBuffer, encodedAAD), struct.typeProtocolMajor.toString() + '.' + struct.typeProtocolMinor.toString())
+    const decapsulatedKey = await this.decapsulateKey(profile.profile, await this._getKey(profile.profile, struct.metadata.key_id))
+    const dataKey = await deriveKey(decapsulatedKey)
+    return this._boltProvider.decodeValue(await decrypt(dataKey, struct.metadata.iv, struct.cipherOutput.buffer as ArrayBuffer, encodedAAD), struct.typeProtocolMajor.toString() + '.' + struct.typeProtocolMinor.toString())
   }
 
   keyManager (name: string | undefined): EncapsulatedKeyManager {

--- a/packages/core/src/encryption/node/crypto.ts
+++ b/packages/core/src/encryption/node/crypto.ts
@@ -1,6 +1,8 @@
 import * as crypto from 'node:crypto'
 import { newError } from '../../error'
 
+const KEY_DERIVATION_INFO = 'neo4j/property-encryption/v1'
+
 export async function encrypt (key: Uint8Array, message: ArrayBuffer, aad: ArrayBuffer | undefined): Promise<{ cyphertext: ArrayBuffer, iv: Uint8Array }> {
   if (crypto === undefined) {
     throw newError('Your node environment was build without the crypto module, and client side encrytion can therefore not be used')
@@ -36,4 +38,12 @@ export async function decrypt (key: Uint8Array, iv: Uint8Array, message: ArrayBu
 }
 export function getRandomValues (length: number): Uint8Array {
   return crypto.getRandomValues(new Uint8Array(length))
+}
+
+export async function deriveKey (ikm: Uint8Array): Promise<Uint8Array> {
+  if (crypto === undefined) {
+    throw newError('Your node environment was build without the crypto module, and client side encrytion can therefore not be used')
+  }
+  const derived = crypto.hkdfSync('sha256', ikm, new Uint8Array(0), Buffer.from(KEY_DERIVATION_INFO, 'utf8'), 32)
+  return new Uint8Array(derived)
 }


### PR DESCRIPTION
Investigated why the JS and dotnet drivers weren't compatible and discovered that the JS driver was using the decapsulated DEK directly as the AES-GCM key, missing the key derivation step, but the dotnet driver does do that and when it tried to decrypt the JS-generated fixture it failed with an invalid key.  I don't know if this change is idiomatic as Claude helped me find it, but with this change in place and the latest pull to the testkit encryption tests branch, both drivers can decrypt each other's encrypts.

I couldn't figure out how to link to the right part of the ADR so I'm just pasting the relevant bit:

> Rather than using the primary encryption key directly, drivers derive purpose-specific AES keys using HKDF (HMAC-based Extract-and-Expand Key Derivation Function) with HMAC-SHA256. The derivation context (info) is set to neo4j/property-encryption/v1, providing domain separation for property encryption keys and allowing independent keys to be derived from the same master key for different purposes. 