### PR TITLE
Fix record prototype walkup

### DIFF
--- a/packages/bolt-connection/src/bolt/stream-observers.js
+++ b/packages/bolt-connection/src/bolt/stream-observers.js
@@ -319,7 +319,7 @@ class ResultStreamObserver extends StreamObserver {
       // faster to look up fields in a record by name, rather than by index.
       // Since the records we get back via Bolt are just arrays of values.
       this._fieldKeys = []
-      this._fieldLookup = {}
+      this._fieldLookup = Object.create(null)
       if (meta.fields && meta.fields.length > 0) {
         this._fieldKeys = meta.fields
         for (let i = 0; i < meta.fields.length; i++) {

--- a/packages/core/src/record.ts
+++ b/packages/core/src/record.ts
@@ -38,7 +38,7 @@ function generateFieldLookup<
   Key extends keyof Entries = keyof Entries,
   FieldLookup extends RecordShape<string, number> = RecordShape<string, number>
 > (keys: Key[]): FieldLookup {
-  const lookup: RecordShape<string, number> = {}
+  const lookup: RecordShape<string, number> = Object.create(null)
   keys.forEach((name, idx) => {
     lookup[name as string] = idx
   })

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/stream-observers.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/stream-observers.js
@@ -319,7 +319,7 @@ class ResultStreamObserver extends StreamObserver {
       // faster to look up fields in a record by name, rather than by index.
       // Since the records we get back via Bolt are just arrays of values.
       this._fieldKeys = []
-      this._fieldLookup = {}
+      this._fieldLookup = Object.create(null)
       if (meta.fields && meta.fields.length > 0) {
         this._fieldKeys = meta.fields
         for (let i = 0; i < meta.fields.length; i++) {

--- a/packages/neo4j-driver-deno/lib/core/record.ts
+++ b/packages/neo4j-driver-deno/lib/core/record.ts
@@ -38,7 +38,7 @@ function generateFieldLookup<
   Key extends keyof Entries = keyof Entries,
   FieldLookup extends RecordShape<string, number> = RecordShape<string, number>
 > (keys: Key[]): FieldLookup {
-  const lookup: RecordShape<string, number> = {}
+  const lookup: RecordShape<string, number> = Object.create(null)
   keys.forEach((name, idx) => {
     lookup[name as string] = idx
   })


### PR DESCRIPTION
Part of: DRIVERS-544

`Record.has()` can find properties that are in the base `Object` prototype such as `constructor` and `toString`, and will report them as being present. 