### PR TITLE
Fix buffer reads and remove dead code

### DIFF
--- a/packages/bolt-connection/src/buf/base-buf.js
+++ b/packages/bolt-connection/src/buf/base-buf.js
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { newError } from 'neo4j-driver-core'
 
 /**
  * Common base with default implementation for most buffer methods.
@@ -312,9 +311,6 @@ export default class BaseBuffer {
   }
 
   _updatePos (length) {
-    if (this.position + length > this.length) {
-      throw newError('Unexpected end of buffer')
-    }
     const p = this.position
     this.position += length
     return p

--- a/packages/bolt-connection/src/buf/base-buf.js
+++ b/packages/bolt-connection/src/buf/base-buf.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { newError } from 'neo4j-driver-core'
 
 /**
  * Common base with default implementation for most buffer methods.
@@ -94,26 +95,10 @@ export default class BaseBuffer {
    */
   getUInt32 (p) {
     return (
-      (this.getUInt8(p) << 24) |
+      ((this.getUInt8(p) << 24) |
       (this.getUInt8(p + 1) << 16) |
       (this.getUInt8(p + 2) << 8) |
-      this.getUInt8(p + 3)
-    )
-  }
-
-  /**
-   * @param p
-   */
-  getInt64 (p) {
-    return (
-      (this.getInt8(p) << 56) |
-      (this.getUInt8(p + 1) << 48) |
-      (this.getUInt8(p + 2) << 40) |
-      (this.getUInt8(p + 3) << 32) |
-      (this.getUInt8(p + 4) << 24) |
-      (this.getUInt8(p + 5) << 16) |
-      (this.getUInt8(p + 6) << 8) |
-      this.getUInt8(p + 7)
+      this.getUInt8(p + 3)) >>> 3
     )
   }
 
@@ -165,21 +150,6 @@ export default class BaseBuffer {
     this.putUInt8(p + 1, (val >> 16) & 0xff)
     this.putUInt8(p + 2, (val >> 8) & 0xff)
     this.putUInt8(p + 3, val & 0xff)
-  }
-
-  /**
-   * @param p
-   * @param val
-   */
-  putInt64 (p, val) {
-    this.putInt8(p, val >> 48)
-    this.putUInt8(p + 1, (val >> 42) & 0xff)
-    this.putUInt8(p + 2, (val >> 36) & 0xff)
-    this.putUInt8(p + 3, (val >> 30) & 0xff)
-    this.putUInt8(p + 4, (val >> 24) & 0xff)
-    this.putUInt8(p + 5, (val >> 16) & 0xff)
-    this.putUInt8(p + 6, (val >> 8) & 0xff)
-    this.putUInt8(p + 7, val & 0xff)
   }
 
   putVarInt (p, val) {
@@ -315,14 +285,6 @@ export default class BaseBuffer {
    * Write to state position.
    * @param val
    */
-  writeInt64 (val) {
-    this.putInt64(this._updatePos(8), val)
-  }
-
-  /**
-   * Write to state position.
-   * @param val
-   */
   writeFloat64 (val) {
     this.putFloat64(this._updatePos(8), val)
   }
@@ -350,6 +312,9 @@ export default class BaseBuffer {
   }
 
   _updatePos (length) {
+    if (this.position + length > this.length) {
+      throw newError('Unexpected end of buffer')
+    }
     const p = this.position
     this.position += length
     return p

--- a/packages/bolt-connection/src/buf/base-buf.js
+++ b/packages/bolt-connection/src/buf/base-buf.js
@@ -93,12 +93,12 @@ export default class BaseBuffer {
    * @param p
    */
   getUInt32 (p) {
-    return (
-      ((this.getUInt8(p) << 24) |
-      (this.getUInt8(p + 1) << 16) |
-      (this.getUInt8(p + 2) << 8) |
-      this.getUInt8(p + 3)) >>> 3
-    )
+    const signed = this.getInt32(p)
+    if (signed >= 0) {
+      return signed
+    } else {
+      return 2 ** 32 + signed
+    }
   }
 
   /**

--- a/packages/bolt-connection/src/buf/base-buf.js
+++ b/packages/bolt-connection/src/buf/base-buf.js
@@ -220,13 +220,6 @@ export default class BaseBuffer {
   /**
    * Read from state position.
    */
-  readInt64 () {
-    return this.getInt32(this._updatePos(8))
-  }
-
-  /**
-   * Read from state position.
-   */
   readFloat64 () {
     return this.getFloat64(this._updatePos(8))
   }

--- a/packages/bolt-connection/src/channel/channel-buf.js
+++ b/packages/bolt-connection/src/channel/channel-buf.js
@@ -39,12 +39,13 @@ export default class ChannelBuffer extends BaseBuffer {
 
   getVarInt (position) {
     let i = 0
-    let currentValue = this._buffer.readInt8(position + i)
+    let currentValue = this._buffer.readUint8(position + i)
     let total = currentValue % 128
-    while (currentValue / 128 >= 1) {
+    // TODO: Broken for 4+ byte VarInts, do not wish to throw errors on it as it is only likely to impact capabilities, none of which are currently implemented either way.
+    while (currentValue >= 128 && i <= 3) {
       i += 1
-      currentValue = this._buffer.readInt8(position + i)
-      total += currentValue % 128
+      currentValue = this._buffer.readUint8(position + i)
+      total += (currentValue & 0x7f) << (7 * i)
     }
     return { length: i + 1, value: total }
   }

--- a/packages/bolt-connection/src/channel/combined-buf.js
+++ b/packages/bolt-connection/src/channel/combined-buf.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { newError } from 'neo4j-driver-core'
 import { BaseBuffer } from '../buf'
 import { alloc } from './channel-buf'
 
@@ -42,6 +43,7 @@ export default class CombinedBuffer extends BaseBuffer {
         return buffer.getUInt8(position)
       }
     }
+    throw newError('Read beyond end of CombinedBuffer')
   }
 
   getInt8 (position) {
@@ -55,6 +57,7 @@ export default class CombinedBuffer extends BaseBuffer {
         return buffer.getInt8(position)
       }
     }
+    throw newError('Read beyond end of CombinedBuffer')
   }
 
   getFloat64 (position) {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/buf/base-buf.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/buf/base-buf.js
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { newError } from '../../core/index.ts'
 
 /**
  * Common base with default implementation for most buffer methods.
@@ -312,9 +311,6 @@ export default class BaseBuffer {
   }
 
   _updatePos (length) {
-    if (this.position + length > this.length) {
-      throw newError('Unexpected end of buffer')
-    }
     const p = this.position
     this.position += length
     return p

--- a/packages/neo4j-driver-deno/lib/bolt-connection/buf/base-buf.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/buf/base-buf.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { newError } from '../../core/index.ts'
 
 /**
  * Common base with default implementation for most buffer methods.
@@ -94,26 +95,10 @@ export default class BaseBuffer {
    */
   getUInt32 (p) {
     return (
-      (this.getUInt8(p) << 24) |
+      ((this.getUInt8(p) << 24) |
       (this.getUInt8(p + 1) << 16) |
       (this.getUInt8(p + 2) << 8) |
-      this.getUInt8(p + 3)
-    )
-  }
-
-  /**
-   * @param p
-   */
-  getInt64 (p) {
-    return (
-      (this.getInt8(p) << 56) |
-      (this.getUInt8(p + 1) << 48) |
-      (this.getUInt8(p + 2) << 40) |
-      (this.getUInt8(p + 3) << 32) |
-      (this.getUInt8(p + 4) << 24) |
-      (this.getUInt8(p + 5) << 16) |
-      (this.getUInt8(p + 6) << 8) |
-      this.getUInt8(p + 7)
+      this.getUInt8(p + 3)) >>> 3
     )
   }
 
@@ -165,21 +150,6 @@ export default class BaseBuffer {
     this.putUInt8(p + 1, (val >> 16) & 0xff)
     this.putUInt8(p + 2, (val >> 8) & 0xff)
     this.putUInt8(p + 3, val & 0xff)
-  }
-
-  /**
-   * @param p
-   * @param val
-   */
-  putInt64 (p, val) {
-    this.putInt8(p, val >> 48)
-    this.putUInt8(p + 1, (val >> 42) & 0xff)
-    this.putUInt8(p + 2, (val >> 36) & 0xff)
-    this.putUInt8(p + 3, (val >> 30) & 0xff)
-    this.putUInt8(p + 4, (val >> 24) & 0xff)
-    this.putUInt8(p + 5, (val >> 16) & 0xff)
-    this.putUInt8(p + 6, (val >> 8) & 0xff)
-    this.putUInt8(p + 7, val & 0xff)
   }
 
   putVarInt (p, val) {
@@ -315,14 +285,6 @@ export default class BaseBuffer {
    * Write to state position.
    * @param val
    */
-  writeInt64 (val) {
-    this.putInt64(this._updatePos(8), val)
-  }
-
-  /**
-   * Write to state position.
-   * @param val
-   */
   writeFloat64 (val) {
     this.putFloat64(this._updatePos(8), val)
   }
@@ -350,6 +312,9 @@ export default class BaseBuffer {
   }
 
   _updatePos (length) {
+    if (this.position + length > this.length) {
+      throw newError('Unexpected end of buffer')
+    }
     const p = this.position
     this.position += length
     return p

--- a/packages/neo4j-driver-deno/lib/bolt-connection/buf/base-buf.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/buf/base-buf.js
@@ -93,12 +93,12 @@ export default class BaseBuffer {
    * @param p
    */
   getUInt32 (p) {
-    return (
-      ((this.getUInt8(p) << 24) |
-      (this.getUInt8(p + 1) << 16) |
-      (this.getUInt8(p + 2) << 8) |
-      this.getUInt8(p + 3)) >>> 3
-    )
+    const signed = this.getInt32(p)
+    if (signed >= 0) {
+      return signed
+    } else {
+      return 2 ** 32 + signed
+    }
   }
 
   /**

--- a/packages/neo4j-driver-deno/lib/bolt-connection/buf/base-buf.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/buf/base-buf.js
@@ -220,13 +220,6 @@ export default class BaseBuffer {
   /**
    * Read from state position.
    */
-  readInt64 () {
-    return this.getInt32(this._updatePos(8))
-  }
-
-  /**
-   * Read from state position.
-   */
   readFloat64 () {
     return this.getFloat64(this._updatePos(8))
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/channel-buf.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/channel-buf.js
@@ -39,12 +39,13 @@ export default class ChannelBuffer extends BaseBuffer {
 
   getVarInt (position) {
     let i = 0
-    let currentValue = this._buffer.readInt8(position + i)
+    let currentValue = this._buffer.readUint8(position + i)
     let total = currentValue % 128
-    while (currentValue / 128 >= 1) {
+    // TODO: Broken for 4+ byte VarInts, do not wish to throw errors on it as it is only likely to impact capabilities, none of which are currently implemented either way.
+    while (currentValue >= 128 && i <= 3) {
       i += 1
-      currentValue = this._buffer.readInt8(position + i)
-      total += currentValue % 128
+      currentValue = this._buffer.readUint8(position + i)
+      total += (currentValue & 0x7f) << (7 * i)
     }
     return { length: i + 1, value: total }
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/combined-buf.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/combined-buf.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { newError } from '../../core/index.ts'
 import { BaseBuffer } from '../buf/index.js'
 import { alloc } from './channel-buf.js'
 
@@ -42,6 +43,7 @@ export default class CombinedBuffer extends BaseBuffer {
         return buffer.getUInt8(position)
       }
     }
+    throw newError('Read beyond end of CombinedBuffer')
   }
 
   getInt8 (position) {
@@ -55,6 +57,7 @@ export default class CombinedBuffer extends BaseBuffer {
         return buffer.getInt8(position)
       }
     }
+    throw newError('Read beyond end of CombinedBuffer')
   }
 
   getFloat64 (position) {


### PR DESCRIPTION
Part of: DRIVERS-543

Adds errors to reads beyond the end of the buffer, fixes the fact that `getUInt32` actually gets a signed int, Improves multi-byte VarInts (4 or more bytes still broken) and removes dead, broken code related to reading and writing int64s