### PR TITLE
Do not silently coerce schemeless tokens into none

### DIFF
--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -282,7 +282,7 @@ function driver (
           routingContext: parsedUrl.query
         })
     } else {
-      if (isEmptyObjectOrNull(parsedUrl.query) !== true) {
+      if (!isEmptyObjectOrNull(parsedUrl.query)) {
         throw new Error(
           `Parameters are not supported with none routed scheme. Given URL: '${url}'`
         )

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -57,6 +57,7 @@ import {
   LocalTime,
   ManagedTransaction,
   Neo4jError,
+  newError,
   Node,
   Notification,
   GqlStatusObject,
@@ -166,10 +167,17 @@ function createAuthManager (authTokenOrProvider: AuthToken | AuthTokenManager): 
     return authTokenOrProvider
   }
 
-  let authToken: AuthToken = authTokenOrProvider
+  const authToken: AuthToken = { ...authTokenOrProvider }
   // Sanitize authority token. Nicer error from server when a scheme is set.
-  authToken = authToken ?? {}
-  authToken.scheme = authToken.scheme ?? 'none'
+  if (authToken.scheme == null) {
+    if (authToken.principal != null || authToken.credentials != null || authToken.realm != null || authToken.parameters != null) {
+      throw newError(
+        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos/custom, " +
+        'or set scheme explicitly.'
+      )
+    }
+    authToken.scheme = 'none'
+  }
   return staticAuthTokenManager({ authToken })
 }
 

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -170,7 +170,7 @@ function createAuthManager (authTokenOrProvider: AuthToken | AuthTokenManager): 
   const authToken: AuthToken = { ...authTokenOrProvider }
   // Sanitize authority token. Nicer error from server when a scheme is set.
   if (authToken.scheme == null) {
-    if ( Object.entries(authToken).length !== 0 ) {
+    if (Object.entries(authToken).length !== 0) {
       throw newError(
         "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos, " +
         'or set scheme explicitly.'

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -170,9 +170,9 @@ function createAuthManager (authTokenOrProvider: AuthToken | AuthTokenManager): 
   const authToken: AuthToken = { ...authTokenOrProvider }
   // Sanitize authority token. Nicer error from server when a scheme is set.
   if (authToken.scheme == null) {
-    if (authToken.principal != null || authToken.credentials != null || authToken.realm != null || authToken.parameters != null) {
+    if ( Object.entries(authToken).length !== 0 ) {
       throw newError(
-        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos/custom, " +
+        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos, " +
         'or set scheme explicitly.'
       )
     }

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -57,6 +57,7 @@ import {
   LocalTime,
   ManagedTransaction,
   Neo4jError,
+  newError,
   Node,
   Notification,
   GqlStatusObject,
@@ -165,10 +166,17 @@ function createAuthManager (authTokenOrProvider: AuthToken | AuthTokenManager): 
     return authTokenOrProvider
   }
 
-  let authToken: AuthToken = authTokenOrProvider
+  const authToken: AuthToken = { ...authTokenOrProvider }
   // Sanitize authority token. Nicer error from server when a scheme is set.
-  authToken = authToken ?? {}
-  authToken.scheme = authToken.scheme ?? 'none'
+  if (authToken.scheme == null) {
+    if (authToken.principal != null || authToken.credentials != null || authToken.realm != null || authToken.parameters != null) {
+      throw newError(
+        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos/custom, " +
+        'or set scheme explicitly.'
+      )
+    }
+    authToken.scheme = 'none'
+  }
   return staticAuthTokenManager({ authToken })
 }
 
@@ -273,7 +281,7 @@ function driver (
           routingContext: parsedUrl.query
         })
     } else {
-      if (isEmptyObjectOrNull(parsedUrl.query) !== true) {
+      if (!isEmptyObjectOrNull(parsedUrl.query)) {
         throw new Error(
           `Parameters are not supported with none routed scheme. Given URL: '${url}'`
         )

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -169,9 +169,9 @@ function createAuthManager (authTokenOrProvider: AuthToken | AuthTokenManager): 
   const authToken: AuthToken = { ...authTokenOrProvider }
   // Sanitize authority token. Nicer error from server when a scheme is set.
   if (authToken.scheme == null) {
-    if (authToken.principal != null || authToken.credentials != null || authToken.realm != null || authToken.parameters != null) {
+    if (Object.entries(authToken).length !== 0) {
       throw newError(
-        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos/custom, " +
+        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos, " +
         'or set scheme explicitly.'
       )
     }

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -72,6 +72,7 @@ import {
   bookmarkManager,
   routing,
   resultTransformers,
+  newError,
   notificationCategory,
   notificationClassification,
   notificationSeverityLevel,
@@ -127,10 +128,17 @@ function createAuthManager (authTokenOrManager) {
     return authTokenOrManager
   }
 
-  let authToken = authTokenOrManager
+  const authToken = { ...authTokenOrManager }
   // Sanitize authority token. Nicer error from server when a scheme is set.
-  authToken = authToken || {}
-  authToken.scheme = authToken.scheme || 'none'
+  if (authToken.scheme == null) {
+    if (authToken.principal != null || authToken.credentials != null || authToken.realm != null || authToken.parameters != null) {
+      throw newError(
+        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos/custom, " +
+        'or set scheme explicitly.'
+      )
+    }
+    authToken.scheme = 'none'
+  }
   return staticAuthTokenManager({ authToken })
 }
 

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -131,9 +131,9 @@ function createAuthManager (authTokenOrManager) {
   const authToken = { ...authTokenOrManager }
   // Sanitize authority token. Nicer error from server when a scheme is set.
   if (authToken.scheme == null) {
-    if (authToken.principal != null || authToken.credentials != null || authToken.realm != null || authToken.parameters != null) {
+    if (Object.entries(authToken).length !== 0) {
       throw newError(
-        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos/custom, " +
+        "Auth token is missing 'scheme'. Use neo4j.auth.basic/bearer/kerberos, " +
         'or set scheme explicitly.'
       )
     }


### PR DESCRIPTION
Part of: DRIVERS-547 

The driver will currently interpret any token without a set scheme as none auth silently.