### PR TITLE
Use isolated string decoder

### DIFF
--- a/packages/bolt-connection/src/channel/utf8.js
+++ b/packages/bolt-connection/src/channel/utf8.js
@@ -20,8 +20,6 @@ import { newError } from 'neo4j-driver-core'
 import buffer from 'buffer'
 import { StringDecoder } from 'string_decoder'
 
-const decoder = new StringDecoder('utf8')
-
 function encode (str) {
   return new ChannelBuffer(newBuffer(str))
 }
@@ -44,12 +42,17 @@ function decodeChannelBuffer (buffer, length) {
 }
 
 function decodeCombinedBuffer (buffer, length) {
-  return streamDecodeCombinedBuffer(
-    buffer,
-    length,
-    partBuffer => decoder.write(partBuffer._buffer),
-    () => decoder.end()
-  )
+  const decoder = new StringDecoder('utf8')
+  try {
+    return streamDecodeCombinedBuffer(
+      buffer,
+      length,
+      partBuffer => decoder.write(partBuffer._buffer),
+      () => decoder.end()
+    )
+  } finally {
+    decoder.end()
+  }
 }
 
 function streamDecodeCombinedBuffer (combinedBuffers, length, decodeFn, endFn) {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/utf8.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/utf8.js
@@ -20,8 +20,6 @@ import { newError } from '../../core/index.ts'
 import buffer from 'https://deno.land/std@0.119.0/node/buffer.ts'
 import { StringDecoder } from 'https://deno.land/std@0.119.0/node/string_decoder.ts'
 
-const decoder = new StringDecoder('utf8')
-
 function encode (str) {
   return new ChannelBuffer(newBuffer(str))
 }
@@ -44,12 +42,17 @@ function decodeChannelBuffer (buffer, length) {
 }
 
 function decodeCombinedBuffer (buffer, length) {
-  return streamDecodeCombinedBuffer(
-    buffer,
-    length,
-    partBuffer => decoder.write(partBuffer._buffer),
-    () => decoder.end()
-  )
+  const decoder = new StringDecoder('utf8')
+  try {
+    return streamDecodeCombinedBuffer(
+      buffer,
+      length,
+      partBuffer => decoder.write(partBuffer._buffer),
+      () => decoder.end()
+    )
+  } finally {
+    decoder.end()
+  }
 }
 
 function streamDecodeCombinedBuffer (combinedBuffers, length, decodeFn, endFn) {


### PR DESCRIPTION
Part of: DRIVERS-546

The driver currently uses the same string decoder for every time multiple buffers need to be concatenated. This currently has no known consequences, but if an error were to occur during this handling, there could be remaining data in the decoder that could cause an error the next time the decoder is used.